### PR TITLE
Parse arguments in `build_and_run`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "bytewax"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "axum",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ harness = false
 [features]
 extension-module = ["pyo3/extension-module"]
 default = ["extension-module"]
+
+[profile.release]
+debug = 1

--- a/benches/benchmarks/wordcount_bytewax.py
+++ b/benches/benchmarks/wordcount_bytewax.py
@@ -18,8 +18,6 @@ def tokenize(x):
 
 def acc(word_to_count, words):
     for word in words:
-        if word not in word_to_count:
-            word_to_count[word] = 0
         word_to_count[word] += 1
     return word_to_count
 
@@ -30,4 +28,4 @@ flow.flat_map(tokenize)
 flow.accumulate(lambda: defaultdict(int), acc)
 
 if __name__ == "__main__":
-    exec.execute_directly(1)
+    exec.build_and_run(ctrlc=False)

--- a/benches/benchmarks/wordcount_bytewax.py
+++ b/benches/benchmarks/wordcount_bytewax.py
@@ -1,7 +1,7 @@
 import re
 import operator
 
-from bytewax import Executor, inp, workers
+from bytewax import Executor, inp, processes
 
 
 def tokenize(x):
@@ -20,4 +20,4 @@ flow.map(initial_count)
 flow.reduce_epoch(operator.add)
 
 if __name__ == "__main__":
-    workers.start_local_processes(ec, number_of_processes=3)
+    processes.start_local(ec, number_of_processes=6)

--- a/benches/benchmarks/wordcount_python.py
+++ b/benches/benchmarks/wordcount_python.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 if __name__ == "__main__":
     counts = defaultdict(int)
-    for line in open("pyexamples/sample_data/wordcount.txt", "r").readlines():
+    for line in open("benches/benchmarks/collected-works.txt", "r").readlines():
         line = line.lower()
         words = re.findall(r'[^\s!,.?":;0-9]+', line)
         for word in words:

--- a/pyexamples/wordcount.py
+++ b/pyexamples/wordcount.py
@@ -1,11 +1,13 @@
-import re
+import collections
 import operator
+import re
 
-from bytewax import Executor, inp, workers
+from bytewax import Executor
+from bytewax import inp
+from bytewax import workers
 
 
 def tokenize(x):
-    x = x.lower()
     return re.findall(r'[^\s!,.?":;0-9]+', x)
 
 
@@ -15,9 +17,19 @@ def initial_count(word):
 
 ec = Executor()
 flow = ec.Dataflow(inp.single_batch(open("benches/benchmarks/collected-works.txt")))
+# "Here we have full sentences"
 flow.flat_map(tokenize)
+# "Words"
+flow.map(str.lower)
+# "word"
+flow.filter(lambda x: x != "and")
+# "word_no_and"
 flow.map(initial_count)
+# ("word", 1)
 flow.reduce_epoch(operator.add)
+# ("word", count)
+flow.inspect(print)
+
 
 if __name__ == "__main__":
-    workers.start_local_processes(ec, number_of_processes=3)
+    workers.start_local_workers(ec, 4)

--- a/pysrc/bytewax/processes.py
+++ b/pysrc/bytewax/processes.py
@@ -1,0 +1,32 @@
+"""Helpers to facilitate running on multiple workers.
+
+Use these functions to start multiple processes.
+"""
+import multiprocessing as mp
+
+from bytewax import Executor
+
+
+def start_local_processes(
+    executor: Executor,
+    number_of_processes: int = 1,
+    threads_per_process: int = 1,
+    ctrlc=True,
+):
+    """Start a number of local workers
+
+    Convenience method for starting a number of local worker processes
+    using Python's multiprocessing package.
+
+    Args:
+        executor(:obj:`Executor`): The bytewax executor
+        number_of_workers(int): Number of local process workers to start
+        threads_per_worker(int): Number of threads per worker process
+        ctrlc(bool): Configure a ctrlc handler for this worker
+    """
+    for i in range(number_of_processes):
+        p = mp.Process(
+            target=executor.build_and_run,
+            args=(threads_per_process, i, number_of_processes, ctrlc),
+        )
+        p.start()

--- a/pysrc/bytewax/processes.py
+++ b/pysrc/bytewax/processes.py
@@ -7,7 +7,7 @@ import multiprocessing as mp
 from bytewax import Executor
 
 
-def start_local_processes(
+def start_local(
     executor: Executor,
     number_of_processes: int = 1,
     threads_per_process: int = 1,


### PR DESCRIPTION
## Overview

This PR refactors the `build_and_run` function to accept parameters that we were previously capturing from the command line.

## Rationale

Instead of accepting parameters from the command line, users of the library can decide how and where they would like to configure the number of workers and threads.

- Accepts configuration arguments for running/clustering.
- Optionally set the ctrl-c handler.