### PR TITLE
Introducing: exhash

### DIFF
--- a/pysrc/bytewax/exhash.py
+++ b/pysrc/bytewax/exhash.py
@@ -1,0 +1,84 @@
+"""Implementation of a consistent hash for "exchanging" data. Hence
+"exhash".
+
+Bytewax uses this to ensure that items are routed to workers correctly
+and consistently. We cannot use Python's `__hash__` because is not
+consistent across processes by default.
+
+Bytewax calls `exhash` internally to do routing.
+
+If you need to route on a new key type, register a new version as is
+done below in your own code. You _must_ make sure that if two objects
+are `exhash(x) == exhash(y)` they also are `x == y`.
+
+"""
+from functools import singledispatch
+from hashlib import blake2b
+
+
+@singledispatch
+def exhash(key, h=None):
+    """A consistent hash of a value."""
+    raise NotImplementedError(f"{type(key)} isn't exhash-able")
+
+
+def new_hasher():
+    return blake2b(digest_size=8)
+
+
+@exhash.register
+def _(key: list, h=None):
+    raise NotImplementedError("can't exhash mutable list")
+
+
+@exhash.register
+def _(key: set, h=None):
+    raise NotImplementedError("can't exhash mutable set")
+
+
+@exhash.register
+def _(key: dict, h=None):
+    raise NotImplementedError("can't exhash mutable dict")
+
+
+@exhash.register
+def _(key: int, h=None):
+    if h is None:
+        h = new_hasher()
+    # This will throw on gigantic arbitrary precision integers.
+    h.update(key.to_bytes(8, byteorder="little"))
+    return h
+
+
+@exhash.register
+def _(key: str, h=None):
+    if h is None:
+        h = new_hasher()
+    h.update(key.encode("utf8"))
+    return h
+
+
+@exhash.register
+def _(key: bytes, h=None):
+    if h is None:
+        h = new_hasher()
+    h.update(key)
+    return h
+
+
+@exhash.register
+def _(key: tuple, h=None):
+    if h is None:
+        h = new_hasher()
+    for x in key:
+        h = exhash(x, h)
+    return h
+
+
+@exhash.register
+def _(key: frozenset, h=None):
+    if h is None:
+        h = new_hasher()
+    for x in sorted(key):
+        h = exhash(x, h)
+    return h

--- a/pytests/test_exhash.py
+++ b/pytests/test_exhash.py
@@ -1,0 +1,46 @@
+from bytewax.exhash import exhash
+from pytest import raises
+
+
+def test_exhash_int():
+    assert exhash(5).digest() == exhash(5).digest()
+    assert exhash(5).digest() != exhash(4).digest()
+
+
+def test_exhash_str():
+    assert exhash("hello").digest() == exhash("hello").digest()
+    assert exhash("hello").digest() != exhash("world").digest()
+
+
+def test_exhash_bytes():
+    assert exhash(b"hello").digest() == exhash(b"hello").digest()
+    assert exhash(b"hello").digest() != exhash(b"world").digest()
+
+
+def test_exhash_tuple():
+    assert exhash((1, 2)).digest() == exhash((1, 2)).digest()
+    assert exhash((1, 2)).digest() != exhash((2, 1)).digest()
+
+
+def test_exhash_frozenset():
+    assert (
+        exhash(frozenset([1, 2, 3])).digest() == exhash(frozenset([3, 2, 1])).digest()
+    )
+    assert (
+        exhash(frozenset([1, 2, 3])).digest() != exhash(frozenset([4, 5, 6])).digest()
+    )
+
+
+def test_cant_exhash_list():
+    with raises(NotImplementedError):
+        exhash([1, 2, 3]).digest()
+
+
+def test_cant_exhash_set():
+    with raises(NotImplementedError):
+        exhash({1, 2, 3}).digest()
+
+
+def test_cant_exhash_dict():
+    with raises(NotImplementedError):
+        exhash({"a": 1, "b": 2}).digest()


### PR DESCRIPTION
Missed out on [this crucial little note for Python's
`__hash__`](https://docs.python.org/3.9/reference/datamodel.html#object.__hash__):

> By default, the `__hash__()` values of str and bytes objects are
> "salted" with an unpredictable random value. Although they remain
> constant within an individual Python process, they are not
> predictable between repeated invocations of Python.

This means that having Timely route using Python's `hash` is fine
within one process, but breaks between multiple processes. Running the
wordcount demo with multiple procs, I occasionally get duplicate
counts because as it's doing `reduce_epoch` it thinks two instances of
`("the", 1)` are not the same key.

The "easier" way to fix this is to set the env var
[`PYTHONHASHSEED`](https://docs.python.org/3.9/using/cmdline.html#envvar-PYTHONHASHSEED). But
I don't think that's the best idea for a few reasons:

1. It's another gotcha for running multiple procs.

2. It's another source of coordination between cluster processes.

3. It feels weird to explain in one of our first tutorials that you
   need to use this obscure Python interpreter env var to make things
   work, and if you forget, there aren't errors, just wrong answers.

So my thought was to create an analagous `exhash` which explicitly is
meant to capture a consistent hash.

I did this using `functools.singledispatch` so you can write a version
for each type, and it'll call the right version. This will let users
add their own custom types later if they want. It returns a
[`hashlib`](https://docs.python.org/3/library/hashlib.html) algorithm
object (which doesn't actually have a formal type...). Which bytewax
will ask for the digest from and pass onto the Rust hashing machinery.

You can optionally pass in an algorithm object to support easy hashing
of nested types as you'll see in the `tuple` and `frozenset`
implementations.

Worries:

- This is also a little bit magic and another bit of conceptual
  overhead, although I'm hoping that if you stick to pretty common
  Python types you won't even need to touch this.

- Should we allow implementations for mutable objects like `list` and
  `set`? I haven't thought through what situations might cause a
  mutable list to "change" while sitting in a Rust `HashMap` and mean
  that all hell could break loose. I think this could happen if you
  use things like `stateful_map` and store and mutate values while
  also passing them on. I define some exception raising
  implementations for mutable types, but people could still override
  this if they want.
