### PR TITLE
Container and Kubernetes related improvements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,3 +103,40 @@ jobs:
         run: |
           pip install --upgrade twine
           twine upload --skip-existing *
+
+  publish-docker-hub:
+    name: Publish to Docker Hub
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [ release ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: bytewax/bytewax
+        tags: |
+          type=ref,event=tag
+  
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: Set RELEASE_VERSION Environment Variable
+      run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF:11})" >> $GITHUB_ENV
+      
+    - name: Build and push to Docker Hub
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        build-args: BYTEWAX_VERSION=${{ env.RELEASE_VERSION }}
+        file: Dockerfile.release

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get update && \
     python3 -m venv /venv && \
     /venv/bin/pip install --upgrade pip setuptools wheel
 
-COPY --from=maturin-builder /bytewax/target/wheels/bytewax-0.6.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl /bytewax/target/wheels/bytewax-0.6.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
-RUN /venv/bin/pip3 install /bytewax/target/wheels/bytewax-0.6.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+COPY --from=maturin-builder /bytewax/target/wheels/bytewax-0.7.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl /bytewax/target/wheels/bytewax-0.7.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+RUN /venv/bin/pip3 install /bytewax/target/wheels/bytewax-0.7.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
 
 FROM gcr.io/distroless/python3-debian11:debug
 COPY --from=build /venv /venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,16 @@ RUN rustc --version
 RUN maturin build --interpreter python3.9
 
 FROM debian:11-slim AS build
+
+ARG BYTEWAX_VERSION
+
 RUN apt-get update && \
     apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
     python3 -m venv /venv && \
     /venv/bin/pip install --upgrade pip setuptools wheel
 
-COPY --from=maturin-builder /bytewax/target/wheels/bytewax-0.7.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl /bytewax/target/wheels/bytewax-0.7.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
-RUN /venv/bin/pip3 install /bytewax/target/wheels/bytewax-0.7.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+COPY --from=maturin-builder /bytewax/target/wheels/bytewax-$BYTEWAX_VERSION-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl /bytewax/target/wheels/bytewax-$BYTEWAX_VERSION-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+RUN /venv/bin/pip3 install /bytewax/target/wheels/bytewax-$BYTEWAX_VERSION-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
 
 FROM gcr.io/distroless/python3-debian11:debug
 COPY --from=build /venv /venv

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,15 @@
+FROM debian:11-slim AS build
+
+ARG BYTEWAX_VERSION
+
+RUN apt-get update && \
+    apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
+    python3 -m venv /venv && \
+    /venv/bin/pip install --upgrade pip setuptools wheel
+
+RUN /venv/bin/pip3 install bytewax==$BYTEWAX_VERSION
+
+FROM gcr.io/distroless/python3-debian11:debug
+COPY --from=build /venv /venv
+WORKDIR /bytewax
+COPY ./entrypoint.sh .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,5 +3,10 @@
 cd $BYTEWAX_WORKDIR
 /venv/bin/python $BYTEWAX_PYTHON_FILE_PATH -w $BYTEWAX_WORKERS_PER_PROCESS -h $BYTEWAX_HOSTFILE_PATH -n $BYTEWAX_REPLICAS -p $(echo $BYTEWAX_POD_NAME | sed "s/$BYTEWAX_STATEFULSET_NAME-//g")
 
-echo 'Process ended. Keeping container alive...';
-while :; do sleep 1; done
+echo 'Process ended.'
+
+if [ "$BYTEWAX_KEEP_CONTAINER_ALIVE" = true ]
+then
+    echo 'Keeping container alive...';
+    while :; do sleep 1; done
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 cd $BYTEWAX_WORKDIR
-/venv/bin/python $BYTEWAX_PYTHON_FILE_PATH -w $BYTEWAX_WORKERS_PER_PROCESS -h $BYTEWAX_HOSTFILE_PATH -n $BYTEWAX_REPLICAS -p $(echo $BYTEWAX_POD_NAME | sed "s/$BYTEWAX_STATEFULSET_NAME-//g")
+/venv/bin/python $BYTEWAX_PYTHON_FILE_PATH
 
 echo 'Process ended.'
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,3 +2,6 @@
 
 cd $BYTEWAX_WORKDIR
 /venv/bin/python $BYTEWAX_PYTHON_FILE_PATH -w $BYTEWAX_WORKERS_PER_PROCESS -h $BYTEWAX_HOSTFILE_PATH -n $BYTEWAX_REPLICAS -p $(echo $BYTEWAX_POD_NAME | sed "s/$BYTEWAX_STATEFULSET_NAME-//g")
+
+echo 'Process ended. Keeping container alive...';
+while :; do sleep 1; done

--- a/pysrc/bytewax/processes.py
+++ b/pysrc/bytewax/processes.py
@@ -4,6 +4,8 @@ Use these functions to start multiple processes.
 """
 import multiprocessing as mp
 
+import os
+
 from bytewax import Executor
 
 
@@ -30,3 +32,37 @@ def start_local(
             args=(threads_per_process, i, number_of_processes, ctrlc),
         )
         p.start()
+
+
+def start_kubernetes(
+    executor: Executor,
+    ctrlc=True,
+):
+    """Start a number of workers in a kubernetes cluster
+
+    Convenience method for starting a number worker processes in Kubernetes
+    using Python's multiprocessing package.
+
+    Args:
+        executor(:obj:`Executor`): The bytewax executor
+        ctrlc(bool): Configure a ctrlc handler for this worker
+    """
+
+    threads_per_process = int(os.getenv("BYTEWAX_WORKERS_PER_PROCESS"))
+    
+    BYTEWAX_STATEFULSET_NAME = os.getenv("BYTEWAX_STATEFULSET_NAME")
+    BYTEWAX_POD_NAME = os.getenv("BYTEWAX_POD_NAME")
+    process = int(BYTEWAX_POD_NAME.replace(BYTEWAX_STATEFULSET_NAME + "-", ""))
+    
+    number_of_processes = int(os.getenv("BYTEWAX_REPLICAS"))
+
+    BYTEWAX_HOSTFILE_PATH = os.getenv("BYTEWAX_HOSTFILE_PATH")
+    hostfile = open(BYTEWAX_HOSTFILE_PATH, "r")
+    addresses = hostfile.read().splitlines()
+    hostfile.close()    
+
+    p = mp.Process(
+        target=executor.build_and_run,
+        args=(threads_per_process, process, number_of_processes, ctrlc, addresses),
+    )
+    p.start()

--- a/pysrc/bytewax/processes.py
+++ b/pysrc/bytewax/processes.py
@@ -33,8 +33,7 @@ def start_local(
 
 
 def start_kubernetes(
-    executor: Executor,
-    ctrlc=True,
+    executor: Executor
 ):
     """Start a number of workers in a kubernetes cluster
 
@@ -43,7 +42,6 @@ def start_kubernetes(
 
     Args:
         executor(:obj:`Executor`): The bytewax executor
-        ctrlc(bool): Configure a ctrlc handler for this worker
     """
 
     threads_per_process = int(os.getenv("BYTEWAX_WORKERS_PER_PROCESS"))
@@ -55,12 +53,11 @@ def start_kubernetes(
     number_of_processes = int(os.getenv("BYTEWAX_REPLICAS"))
 
     BYTEWAX_HOSTFILE_PATH = os.getenv("BYTEWAX_HOSTFILE_PATH")
-    hostfile = open(BYTEWAX_HOSTFILE_PATH, "r")
-    addresses = hostfile.read().splitlines()
-    hostfile.close()    
+    with open(BYTEWAX_HOSTFILE_PATH, "r") as hostfile:
+        addresses = hostfile.read().splitlines()
 
     p = mp.Process(
         target=executor.build_and_run,
-        args=(threads_per_process, process, number_of_processes, ctrlc, addresses),
+        args=(threads_per_process, process, number_of_processes, addresses),
     )
     p.start()


### PR DESCRIPTION
This PR includes this changes related to Bytewax in a container:

- Adds `start_kubernetes` to start a set of Bytewax workers in k8s.
- Adds an infinite loop in `entrypoint.sh` to keep the container alive after finish the workload.
- Manages Bytewax package version in Dockerfile using `ARG`.
- Adds GA Workflow to push a new image to Docker Hub after a PyPI release.

Note: `start_kubernetes` does not deal with wrong env var values yet. I think we could enhance that when we have an end-to-end k8s ecosystem working (CD pushing to docker hub, public helm chart and documentation).