### PR TITLE
Exceptions and interrupts in multiple worker threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ version = "0.7.0"
 dependencies = [
  "axum",
  "criterion",
- "ctrlc",
  "pyo3",
  "rand",
+ "scopeguard",
  "serde",
  "timely",
  "tokio",
@@ -153,12 +153,6 @@ checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
  "rustc_version",
 ]
-
-[[package]]
-name = "cc"
-version = "1.0.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -277,16 +271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
-dependencies = [
- "nix",
- "winapi",
 ]
 
 [[package]]
@@ -606,19 +590,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ crate-type = ["cdylib"]
 python-source = "pysrc"
 
 [dependencies]
-pyo3 = { version = "0.15.1" }
-timely = { version = "0.12.0", features = ["bincode"] }
-serde = { version = "1.0.134" }
-ctrlc = { version = "3.2.1" }
 axum = { version = "0.4.3" }
-tokio = { version = "1.15.0", features = ["full"] }
+pyo3 = { version = "0.15.1" }
 rand = { version = "0.8.4" }
+scopeguard = { version = "1.1.0" }
+serde = { version = "1.0.134" }
+timely = { version = "0.12.0", features = ["bincode"] }
+tokio = { version = "1.15.0", features = ["full"] }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/pysrc/bytewax/processes.py
+++ b/pysrc/bytewax/processes.py
@@ -11,7 +11,6 @@ def start_local(
     executor: Executor,
     number_of_processes: int = 1,
     threads_per_process: int = 1,
-    ctrlc=True,
 ):
     """Start a number of local workers
 
@@ -22,11 +21,10 @@ def start_local(
         executor(:obj:`Executor`): The bytewax executor
         number_of_workers(int): Number of local process workers to start
         threads_per_worker(int): Number of threads per worker process
-        ctrlc(bool): Configure a ctrlc handler for this worker
     """
     for i in range(number_of_processes):
         p = mp.Process(
             target=executor.build_and_run,
-            args=(threads_per_process, i, number_of_processes, ctrlc),
+            args=(threads_per_process, i, number_of_processes),
         )
         p.start()

--- a/pytests/test_exceptions.py
+++ b/pytests/test_exceptions.py
@@ -1,0 +1,51 @@
+import bytewax
+from pytest import raises
+
+
+def test_threads_exception_in_all_workers():
+    out = []
+
+    def boom(item):
+        raise RuntimeError()
+
+    ec = bytewax.Executor()
+    flow = ec.Dataflow(
+        [
+            (0, 0),
+            (0, 1),
+            (0, 2),
+        ]
+    )
+    flow.map(boom)
+    flow.capture(out.append)
+
+    with raises(RuntimeError):
+        ec.build_and_run(threads=2)
+
+    assert out == []
+
+
+def test_threads_exception_in_one_worker_shuts_down_all():
+    out = []
+
+    def boom(item):
+        if item == 0:
+            raise RuntimeError()
+        else:
+            return item
+
+    ec = bytewax.Executor()
+    flow = ec.Dataflow(
+        [
+            (0, 0),
+            (0, 1),
+            (0, 2),
+        ]
+    )
+    flow.map(boom)
+    flow.capture(out.append)
+
+    with raises(RuntimeError):
+        ec.build_and_run(threads=2)
+
+    assert len(out) < 3

--- a/pytests/test_operators.py
+++ b/pytests/test_operators.py
@@ -19,7 +19,7 @@ def test_map():
     flow.map(add_one)
     flow.capture(out.append)
 
-    ec.build_and_run(ctrlc=False)
+    ec.build_and_run()
 
     assert sorted(out) == sorted(
         [
@@ -45,7 +45,7 @@ def test_flat_map():
     flow.flat_map(split_into_words)
     flow.capture(out.append)
 
-    ec.build_and_run(ctrlc=False)
+    ec.build_and_run()
 
     assert sorted(out) == sorted(
         [
@@ -72,7 +72,7 @@ def test_filter():
     flow.filter(is_odd)
     flow.capture(out.append)
 
-    ec.build_and_run(ctrlc=False)
+    ec.build_and_run()
 
     assert sorted(out) == sorted([(0, 1), (0, 3)])
 
@@ -104,7 +104,7 @@ def test_inspect_epoch():
     )
     flow.inspect_epoch(lambda epoch, item: out.append((epoch, item)))
 
-    ec.build_and_run(ctrlc=False)
+    ec.build_and_run()
 
     assert out == [(1, "a")]
 
@@ -135,7 +135,7 @@ def test_reduce():
     flow.reduce(extend_session, session_complete)
     flow.capture(out.append)
 
-    ec.build_and_run(ctrlc=False)
+    ec.build_and_run()
 
     assert sorted(out) == sorted(
         [
@@ -186,7 +186,7 @@ def test_reduce_epoch():
     flow.reduce_epoch(count)
     flow.capture(out.append)
 
-    ec.build_and_run(ctrlc=False)
+    ec.build_and_run()
 
     assert sorted(out) == sorted(
         [
@@ -239,7 +239,7 @@ def test_stateful_map():
     flow.flat_map(remove_seen)
     flow.capture(out.append)
 
-    ec.build_and_run(ctrlc=False)
+    ec.build_and_run()
 
     assert sorted(out) == sorted(
         [
@@ -260,6 +260,6 @@ def test_capture():
     flow = ec.Dataflow(inp)
     flow.capture(out.append)
 
-    ec.build_and_run(ctrlc=False)
+    ec.build_and_run()
 
     assert sorted(out) == sorted(inp)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -7,18 +7,7 @@ macro_rules! with_traceback {
         // feature.
         match (|| $pyfunc)() {
             Ok(r) => r,
-            Err(err) => {
-                let traceback_msg = match err.ptraceback($py) {
-                    // Not all Python function calls have a traceback
-                    Some(t) => t.format().unwrap_or("no traceback available".to_string()),
-                    None => "no traceback available".to_string(),
-                };
-                // TODO: We may not actually want to panic/abort here
-                // But we'll need the ability to decide what to do on error
-                // because of the way we are calling operations in
-                // timely dataflow
-                panic!("{}, {}", err, traceback_msg)
-            }
+            Err(err) => std::panic::panic_any(err),
         }
     };
 }


### PR DESCRIPTION
Ctrlc works a lot better
------------------------

Stops registering a custom ctrlc handler. Instead do what CPython
does during `Thread.join()` which is sleep for a bit then check
interrupts then check if workers are done.

If we got an interrupt, set the "graceful shutdown" flag. All the
worker threads will see this and stop.

Something I didn't realize is that Timely _keeps spinning_ after the
worker main finishes until the dataflows are dropped. So does that.

To communicate when workers are done, increment an atomic counter that
the main thread checks. There's a nightly method
`JoinHandle::is_running` we could maybe use one day.

Shutdown all worker threads when one has error
----------------------------------------------

Use a panic hook to see if a worker thread had a panic. If so, tell
all other workers to gracefully shutdown. Panic hooks are a weird
per-process global thing, so use a lib's `defer!` macro to somewhat
gracefully unregister them. This isn't great but unlike the global
ctrlc handler I think will work ok because hopefully there's no other
Rust code running in some other Python lib that needs this!

`guards.join()` will return if any of the worker threads panic'd so
raise a generic exception in the main Python thread.

Print nice Python tracebacks
----------------------------

My "holy grail" would be to re-raise Python exceptions from a worker
thread in the main thread. Towards this end, modify `with_traceback!`
to instead of sending a string with the exception, try straight
attaching the entire `PyErr` exception. Usually, we can access
whatever object this is from `handle.join()` and then we could
re-raise it, but Timely unceremonially turns that into a debug string,
so we can't recreate it.

Instead, nicely print the traceback in the panic hook. Good enough for
now.

Future work
-----------

I'd eventually like to replicate this behavior for the multi-process
case, not just the multi-threaded case as here. We'll have to see what
our options for a "control plane" IPC is and if we can piggy-back on
what Timely uses.
