### PR TITLE
Fix typing for inp.py

### DIFF
--- a/pysrc/bytewax/inp.py
+++ b/pysrc/bytewax/inp.py
@@ -3,11 +3,10 @@
 Use these to wrap an existing iterator which yields items.
 """
 import time
-from collections.abc import Iterable
-from typing import Any
+from typing import Any, Iterable, Tuple
 
 
-def single_batch(wrap_iter: Iterable, epoch: int = 0) -> Iterable[tuple[int, Any]]:
+def single_batch(wrap_iter: Iterable, epoch: int = 0) -> Iterable[Tuple[int, Any]]:
     """All input items are part of the same epoch.
 
     Use this for non-streaming-style batch processing.
@@ -27,7 +26,7 @@ def single_batch(wrap_iter: Iterable, epoch: int = 0) -> Iterable[tuple[int, Any
 
 def tumbling_epoch(
     epoch_length_sec: float, wrap_iter: Iterable
-) -> Iterable[tuple[int, Any]]:
+) -> Iterable[Tuple[int, Any]]:
     """All inputs within a tumbling window are part of the same epoch.
 
     >>> items = [
@@ -55,7 +54,7 @@ def tumbling_epoch(
             last_epoch_start_sec = now_sec
 
 
-def fully_ordered(wrap_iter: Iterable) -> Iterable[tuple[int, any]]:
+def fully_ordered(wrap_iter: Iterable) -> Iterable[Tuple[int, any]]:
     """Each input item increments the epoch.
 
     Be carful using this in high-volume streams with many workers, as


### PR DESCRIPTION
This PR:
- fixes imports for type hints

When doing `from bytewax import inp` I kept getting the error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'type' object is not subscriptable
```

After fiddling with the type hints in the file I was able to get it to work again 🎉