### PR TITLE
Container and Kubernetes related improvements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,3 +107,40 @@ jobs:
         run: |
           pip install --upgrade twine
           twine upload --skip-existing *
+
+  publish-docker-hub:
+    name: Publish to Docker Hub
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [ release ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: bytewax/bytewax
+        tags: |
+          type=ref,event=tag
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: Set RELEASE_VERSION Environment Variable
+      run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF:11})" >> $GITHUB_ENV
+
+    - name: Build and push to Docker Hub
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        build-args: BYTEWAX_VERSION=${{ env.RELEASE_VERSION }}
+        file: Dockerfile.release

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,16 @@ RUN rustc --version
 RUN maturin build --interpreter python3.9
 
 FROM debian:11-slim AS build
+
+ARG BYTEWAX_VERSION
+
 RUN apt-get update && \
     apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
     python3 -m venv /venv && \
     /venv/bin/pip install --upgrade pip setuptools wheel
 
-COPY --from=maturin-builder /bytewax/target/wheels/bytewax-0.6.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl /bytewax/target/wheels/bytewax-0.6.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
-RUN /venv/bin/pip3 install /bytewax/target/wheels/bytewax-0.6.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+COPY --from=maturin-builder /bytewax/target/wheels/bytewax-$BYTEWAX_VERSION-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl /bytewax/target/wheels/bytewax-$BYTEWAX_VERSION-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+RUN /venv/bin/pip3 install /bytewax/target/wheels/bytewax-$BYTEWAX_VERSION-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
 
 FROM gcr.io/distroless/python3-debian11:debug
 COPY --from=build /venv /venv

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,15 @@
+FROM debian:11-slim AS build
+
+ARG BYTEWAX_VERSION
+
+RUN apt-get update && \
+    apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
+    python3 -m venv /venv && \
+    /venv/bin/pip install --upgrade pip setuptools wheel
+
+RUN /venv/bin/pip3 install bytewax==$BYTEWAX_VERSION
+
+FROM gcr.io/distroless/python3-debian11:debug
+COPY --from=build /venv /venv
+WORKDIR /bytewax
+COPY ./entrypoint.sh .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 
 cd $BYTEWAX_WORKDIR
-/venv/bin/python $BYTEWAX_PYTHON_FILE_PATH -w $BYTEWAX_WORKERS_PER_PROCESS -h $BYTEWAX_HOSTFILE_PATH -n $BYTEWAX_REPLICAS -p $(echo $BYTEWAX_POD_NAME | sed "s/$BYTEWAX_STATEFULSET_NAME-//g")
+/venv/bin/python $BYTEWAX_PYTHON_FILE_PATH
+
+echo 'Process ended.'
+
+if [ "$BYTEWAX_KEEP_CONTAINER_ALIVE" = true ]
+then
+    echo 'Keeping container alive...';
+    while :; do sleep 1; done
+fi


### PR DESCRIPTION
This PR includes these changes related to Bytewax in a container:

- Adds an infinite loop in `entrypoint.sh` to keep the container alive after finishing the workload.
- Manages Bytewax package version in Dockerfile using `ARG`.
- Adds GA Workflow to push a new image to Docker Hub after a PyPI release.