### PR TITLE
Testable examples

### DIFF
--- a/build.requirements.txt
+++ b/build.requirements.txt
@@ -1,1 +1,2 @@
-pytest==7.0.0
+pytest==7.1.0
+myst-docutils==0.17.0

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,262 @@
+"""Hooks and code to tell pytest how to run our Markdown documentation
+as a kind of doctest.
+
+Each file is a separate "script". Each Python code block within each
+file will be run in sequence. If there's a code block tagged
+`{testoutput}`, it will be compared to the stdout of the previous
+Python code block. Errors will be reported.
+
+"""
+from contextlib import redirect_stdout
+from dataclasses import dataclass
+from doctest import Example, OutputChecker
+from io import StringIO
+from pathlib import Path
+from traceback import print_exc
+from typing import Iterator
+
+import myst_parser.main
+from _pytest._code.code import ReprFileLocation, TerminalRepr
+from _pytest._io import TerminalWriter
+from pytest import File, Item
+
+
+@dataclass
+class Block:
+    """Represents a code block in a Markdown file so we can reference it
+    later.
+
+    """
+
+    path: Path
+    content: str
+    content_first_line: int
+    content_last_line: int
+
+
+class MdTestFailure(Exception):
+    """Exception thrown when the expected output doesn't match the found
+    output.
+
+    """
+
+    def __init__(self, found: str):
+        self.found = found
+
+
+class MdTestFailureRepr(TerminalRepr):
+    """pytest class for pretty printing test results. Returned by
+    `MdTestItem.repr_failure` to print nice things.
+
+    """
+
+    def __init__(
+        self, checker: OutputChecker, source: Block, expected: Block, found: str
+    ):
+        super().__init__()
+        self.checker = checker
+        self.source = source
+        self.expected = expected
+        self.found = found
+
+    # Formatting ideas taken from
+    # https://github.com/pytest-dev/pytest/blob/63126643b9b02bce4bbccc94ea00bebdb8137975/src/_pytest/doctest.py
+    def toterminal(self, tw: TerminalWriter) -> None:
+        """Copy what pytest's built in doctest code does to print output
+        mismatches.
+
+        """
+        # Pick the biggest lenght line numbers so the code is always
+        # aligned on a 99, 100 rollover.
+        digits = len(str(abs(self.source.content_last_line)))
+        lines = self.source.content.splitlines()
+        # Print the source that produced bad output.
+        for offset, line in enumerate(lines):
+            lineno = self.source.content_first_line + offset
+            tw.line(f"{lineno:0>{digits}}    {line}")
+
+        # Use the builtin doctest diff printer.
+        example = Example(self.source.content, self.expected.content)
+        tw.write(self.checker.output_difference(example, self.found, 0))
+
+        # Write out the location of the expected output.
+        expected_loc = ReprFileLocation(
+            self.expected.path, self.expected.content_first_line, MdTestFailure.__name__
+        )
+        expected_loc.toterminal(tw)
+
+
+class MdTestItem(Item):
+    """Represents a single test for pytest to run.
+
+    There's one of these for every code block in the Markdown input
+    (paired with an optional output block).
+
+    """
+
+    def __init__(self, *, globs, source: Block, expected: Block, **kwargs):
+        name = f"{expected.content_first_line}"
+        super().__init__(name=name, **kwargs)
+
+        self.globs = globs
+
+        self.source = source
+        self.expected = expected
+
+        self.checker = OutputChecker()
+
+    def runtest(self):
+        """Called by pytest to actually run the test!
+
+        `compile()` the source string, and `exec()` it, capturing all
+        output for later comparison.
+
+        """
+        # We only want to run the source content of this code block,
+        # so we have to have it in isolation. But we also want
+        # exceptions thrown here to show the line numbers in the
+        # original Markdown file to help with debugging. Hack to do
+        # that. Idea taken from
+        # https://github.com/simplistix/sybil/blob/11494c65deb0dfd34e225d3f0b38a6824406d94c/sybil/parsers/codeblock.py#L44
+        lineno_adjusted_source = (
+            "\n" * (self.source.content_first_line - 1) + self.source.content
+        )
+        code = compile(lineno_adjusted_source, self.source.path, "exec")
+
+        capture = StringIO()
+        with redirect_stdout(capture):
+            # For some reason, if we're running something
+            # representing a module, there's only a
+            # globals dictionary. See
+            # https://docs.python.org/3/library/functions.html#exec
+            try:
+                exec(code, self.globs, self.globs)
+            except:
+                print_exc(file=capture)
+
+        found = capture.getvalue()
+        if not self.checker.check_output(self.expected.content, found, 0):
+            raise MdTestFailure(found)
+
+    def reportinfo(self):
+        """Called by pytest before pretty printing out failures.
+
+        Use this to show which code block failed.
+
+        """
+        return (
+            self.expected.path,
+            self.expected.content_first_line,
+            f"[mdtest] {self.expected.path.name}:{self.name}",
+        )
+
+    def repr_failure(self, excinfo):
+        """Called by pytest to convert exceptions thrown in `runtest()` into
+        pretty printer objects.
+
+        """
+        ex = excinfo.value
+        assert isinstance(ex, MdTestFailure)
+        return MdTestFailureRepr(self.checker, self.source, self.expected, ex.found)
+
+
+def _empty_block(path: Path, source_last_line: int) -> Block:
+    """If your code block doesn't have any output, we let you optionally
+    omit the {testoutput} block after it.
+
+    This function builds a fake, empty block that contains the
+    expected empty output but with line numbers pointing at the end of
+    the source block.
+
+    """
+    end_fence_line = source_last_line + 1
+    return Block(path, "", end_fence_line, end_fence_line)
+
+
+class MdTestFile(File):
+    """pytest class used to discover all tests in a file."""
+
+    def collect(self) -> Iterator[MdTestItem]:
+        """Called by pytest to find all tests in this file.
+
+        Read the Markdown file, then for each code block see if it's a
+        Python block. If so, cache it to see if we find an output
+        block. If we do, yield out a single test joining the source to
+        the expected output in a `Block`. If we don't find an output
+        block before the next code block, yield out a test expecting
+        no output via `_empty_block`.
+
+        """
+        # Run all code blocks in this file in the same global
+        # interpreter context. Pass this around to the inner calls to
+        # `exec()` when actually running the code blocks.
+        globs = {}
+
+        tokens = myst_parser.main.to_tokens(self.fspath.read_text(encoding="UTF-8"))
+        fences = (token for token in tokens if token.type == "fence")
+
+        last_source = None
+
+        def flush(source, expected):
+            """Call this when we've paired up a bit of source Python with some
+            expected output.
+
+            That might happen when we find pairs of code-output or two
+            code blocks in a row and we assume the optional output was
+            missing.
+
+            """
+            assert (
+                source
+            ), f"Test output at {expected.path}:{expected.content_first_line} needs a proceeding code block"
+            yield MdTestItem.from_parent(
+                parent=self,
+                globs=globs,
+                source=source,
+                expected=expected,
+            )
+
+        for token in fences:
+            content_first_line, content_last_line = token.map
+            # MyST puts the start as the line just before the opening
+            # fence so bump that to the first line in the fence.
+            content_first_line += 2
+            # MyST puts the end as the line with the fence, so bump
+            # back to the last line inside the fence.
+            content_last_line -= 1
+            if token.info.startswith("py"):
+                # {testoutput} is optional. If there's no output
+                # block, yield a test with empty output.
+                if last_source is not None:
+                    yield from flush(
+                        last_source,
+                        _empty_block(self.path, last_source.content_last_line),
+                    )
+                    last_source = None
+                last_source = Block(
+                    self.path, token.content, content_first_line, content_last_line
+                )
+            elif token.info.startswith("{testoutput}"):
+                expected = Block(
+                    self.path, token.content, content_first_line, content_last_line
+                )
+                yield from flush(last_source, expected)
+                last_source = None
+
+        # Emit that last test if there's no output block.
+        if last_source is not None:
+            yield from flush(
+                last_source, _empty_block(self.path, last_source.content_last_line)
+            )
+            last_source = None
+
+
+def pytest_collect_file(file_path, path: Path, parent) -> MdTestFile:
+    """Hook function that pytest will call with each file found in this
+    subdirectory.
+
+    If we find a Markdown file, build a set of tests for it.
+
+    """
+    if file_path.suffix == ".md":
+        return MdTestFile.from_parent(parent, path=file_path)

--- a/docs/examples/search_session.md
+++ b/docs/examples/search_session.md
@@ -1,0 +1,309 @@
+Building Sessions from Search Logs
+==================================
+
+Here is a basic example of using Bytewax to turn an incoming stream of
+event logs from a hypothetical search engine into metrics over search
+sessions. In this example, we're going to focus on the dataflow itself
+and aggregating state, and gloss over details of building this
+processing into a larger system.
+
+Schema
+------
+
+Let's start by defining a data model / schema for our incoming
+events. We'll make a little model class for all the relevant events
+we'd want to monitor.
+
+```python
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class AppOpen:
+    user: int
+
+
+@dataclass
+class Search:
+    user: int
+    query: str
+
+
+@dataclass
+class Results:
+    user: int
+    items: List[str]
+
+
+@dataclass
+class ClickResult:
+    user: int
+    item: str
+
+
+@dataclass
+class AppClose:
+    user: int
+
+
+@dataclass
+class Timeout:
+    user: int
+```
+
+In a more mature system, these might come from external schema or be
+auto generated.
+
+Epochs
+------
+
+Now that we've got those, here's a small dump of some example data you
+could imagine comming from your app's events infrastructure.
+
+```python
+IMAGINE_THESE_EVENTS_STREAM_FROM_CLIENTS = [
+    # epoch, event
+    (0, AppOpen(user=1)),
+    (1, Search(user=1, query="dogs")),
+    # Eliding named args...
+    (2, Results(1, ["fido", "rover", "buddy"])),
+    (3, ClickResult(1, "rover")),
+    (4, Search(1, "cats")),
+    (5, Results(1, ["fluffy", "burrito", "kathy"])),
+    (6, ClickResult(1, "fluffy")),
+    (7, AppOpen(2)),
+    (8, ClickResult(1, "kathy")),
+    (9, Search(2, "fruit")),
+    (10, AppClose(1)),
+    (11, AppClose(2)),
+]
+```
+
+Let's breakdown some of the details here.
+
+One of Bytewax's cool powers is givving you a high level control over
+the concept of time in your execution via attaching a kind of
+timestamp called an **epoch** to each **item** of input data.
+
+[You can read more about the details of epochs in our
+documentation](epochs), but the most important facet of them for this
+example is that they are the _only_ way you can set up a sense of
+order in your data.
+
+Since we are going to use the order in which events happen to divvy
+them up into user sessions, we need to take advantage of epochs at
+some level. In this basic example, we're going to label each input
+event with a monotonically increasing epoch. [There are some some
+scaling downsides to this approach](epochs/scaling), but we will be
+using it here anyway to demonstrate the basics of epochs.
+
+You tell Bytewax what epoch each input item has by having your input
+iterator yield `(epoch, item)` tuples. In this example, we're
+explicitly making those tuples and putting them in a list.
+
+High-Level Plan
+---------------
+
+Let's talk about the tasks high-level plan for how to sessionize:
+
+- Searches are per-user, so we need to divvy up events by user.
+
+- Searches don't span user sessions, so we should calculate user
+  sessions first.
+
+- Sessions without a search shouldn't contribute.
+
+- Let's calculate one metric: **click through rate** (or **CTR**), if
+  a user clicked on any result in a search.
+
+The Dataflow
+------------
+
+Now that we have some input data, let's start defining the
+computational steps of our dataflow based on our plan.
+
+To start, make an empty `Dataflow` object from Bytewax.
+
+```python
+from bytewax import Dataflow
+
+flow = Dataflow()
+```
+
+You can then add a series of **steps** to the dataflow. Steps are made
+up of **operators**, that provide a "kind" of transformation", and
+**logic functions**, that you supply to do your specific
+transformation. [You can read more about all the operators in our
+documentation.](operators)
+
+Our first task is to make sure to group incoming events by user since
+no session deals with multiple users.
+
+Any Bytewax operators that perform grouping do so by requiring the
+input to be a `(key, value)` two tuple and grouping off the key.
+
+The operator which modifies all data flowing through it is
+[map](operators/map). Let's use that and pull each event's user into
+that key position.
+
+```python
+def initial_session(event):
+    return event.user, [event]
+
+flow.map(initial_session)
+```
+
+For the value, we're planning ahead a little bit to our next task:
+sessionization. The operator best shaped for this is
+[reduce operator](operators/reduce) which groups items by key, then combines
+them together into an **aggregator** in order. We can think about our
+reduce step as "combine together sessions if they should be
+joined". We'll be modeling a session as a list of events, so have the
+values be a list of a single event `[event]` that we will combine now.
+
+Reduce requires two bits of logic:
+
+- How do I combine sessions? Since session are just Python lists, we
+  can use the `+` operator to add them (via the built-in
+  `operator.add` function).
+
+- When is a session complete? In this case, a session is complete when
+  the last item in the session is the app closing. We'll write a
+  `session_has_closed` function to answer that.
+
+```python
+import operator
+
+
+def session_has_closed(session):
+    # isinstance does not work on objects sent through pickling, which
+    # Bytewax does when there are multiple workers.
+    return type(session[-1]).__name__ == "AppClose"
+
+
+flow.reduce(operator.add, session_has_closed)
+```
+
+We had to group by user because sessions were per-user, but now that
+we have sessions, the grouping key is no longer necessary for
+metrics. Let's remove it with another map.
+
+```python
+def remove_key(user_event):
+    user, event = user_event
+    return event
+
+
+flow.map(remove_key)
+```
+
+Our next task is to split user sessions into search sessions. To do
+that, we'll use the [flat map operator](operators/flat-map), which
+allows you to emit multiple items downstream (search sessions) for
+each input item (user session).
+
+We walk through each user session's events, then whenever we encounter
+a search, emit downstream the previous events. This works just like
+`str.split` but with objects.
+
+```python
+def is_search(event):
+    return type(event).__name__ == "Search"
+
+
+def split_into_searches(user_session):
+    search_session = []
+    for event in user_session:
+        if is_search(event):
+            yield search_session
+            search_session = []
+        search_session.append(event)
+    yield search_session
+
+
+flow.flat_map(split_into_searches)
+```
+
+The last little bit to get search sessions we need to filter out edge
+cases produced by the above splitting code: no searches, events before
+searches, etc. We can use the [filter operator](operators/filter) to
+get rid of all search sessions that don't contain searches and
+shouldn't contribute to metrics.
+
+```python
+def has_search(search_session):
+    return any(is_search(event) for event in search_session)
+
+
+flow.filter(has_search)
+```
+
+We can now move on to our final task: generating metric observations
+per search session. If there's a click during a search, the CTR is 1.0
+for that search, 0.0 otherwise. Given those two extreme values, we can
+do further statistics to get things like CTR per day, etc
+
+```python
+def has_click(search_session):
+    return any(type(event).__name__ == "ClickResult" for event in search_session)
+
+
+def calc_ctr(search_session):
+    if has_click(search_session):
+        return 1.0
+    else:
+        return 0.0
+
+
+flow.map(calc_ctr)
+```
+
+Bytewax requires you to mark what parts of the dataflow should be
+captured for output.
+
+```python
+flow.capture()
+```
+
+Now we're done with defining the dataflow. Let's run it!
+
+Execution
+---------
+
+[Bytewax provides a few different entry points for executing your
+dataflow](execution), but because we're focusing on the dataflow in
+this example, we're going to use `bytewax.run` which is the most basic
+one that pushes items in an iterator through the dataflow in-thread.
+
+Let's take our example list of events and pipe it in:
+
+```python
+from bytewax import run
+
+
+for epoch, item in run(flow, IMAGINE_THESE_EVENTS_STREAM_FROM_CLIENTS):
+    print(epoch, item)
+```
+
+Let's inspect the output and see if it makes sense.
+
+```{testoutput}
+10 1.0
+10 1.0
+11 0.0
+```
+
+Since the [capture](operators/capture) step is immediately after calculating CTR,
+we should see one output item for each search session. That checks
+out! There were three searches in the input: "dogs", "cats", and
+"fruit". Only the first two resulted in a click, so they contributed
+`1.0` to the CTR, while the no-click search contributed `0.0`.
+
+Now let's talk about the output epochs briefly. In general, operators
+do not modify the epoch unless they explicitly say so. The only
+operator that deals with the epoch here is [reduce](operators/reduce)
+which emits output at the timestamp of the past-processed input. Since
+we were generating user sessions via reduce, this will correspond to
+the `AppClose` events which have an epoch originally asigned of `10`
+and `11`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,4 +37,5 @@ doctest_optionflags = "NORMALIZE_WHITESPACE"
 testpaths = [
     "pytests",
     "pysrc",
+    "docs",
 ]


### PR DESCRIPTION
Adds some pytest hook code to "run" our Markdown example
documentation.
    
This will take each Markdown file in the `docs/` directory, parse it,
and run all code blocks in each file in order. The stdout of each code
block is then compared to an expected value in an optional following
`{testoutput}` block. If the output is missing, the output is assumed
to be nothing.

Eventually, I'd like to start porting our blog posts over to this format.
This post also will need some fixups to interface with Konrad's work
so links are translated properly and we can link to other
documentation. The big thing I wanted to do here was get these tests
working.