### PR TITLE
Add a key param to the `stateful_map` operator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/anomaly_detector.py
+++ b/examples/anomaly_detector.py
@@ -55,7 +55,7 @@ def inspector(epoch, metric__value_mu_sigma_anomalous):
 
 flow = Dataflow()
 # ("metric", value)
-flow.stateful_map(lambda: ZTestDetector(2.0), ZTestDetector.push)
+flow.stateful_map(lambda key: ZTestDetector(2.0), ZTestDetector.push)
 # ("metric", (value, mu, sigma, is_anomalous))
 flow.capture()
 

--- a/pytests/test_operators.py
+++ b/pytests/test_operators.py
@@ -217,7 +217,7 @@ def test_reduce_epoch_local():
 
 
 def test_stateful_map():
-    def build_seen():
+    def build_seen(key):
         return set()
 
     def add_key(item):

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -174,8 +174,9 @@ impl Dataflow {
     ///
     /// It calls two functions:
     ///
-    /// - A `builder() => new_state: Any` which returns a new state
-    /// and will be called whenever a new key is encountered.
+    /// - A `builder(key: Any) => new_state: Any` which returns a
+    /// new state and will be called whenever a new key is encountered
+    /// with the key as a parameter.
     ///
     /// - A `mapper(state: Any, value: Any) => (updated_state: Any,
     /// updated_value: Any)` which transforms values. Values will be

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -418,7 +418,8 @@ where
                     let mapper = mapper.clone_ref(py);
                     stream = stream.map(lift_2tuple).state_machine(
                         move |key, value, maybe_uninit_state: &mut Option<TdPyAny>| {
-                            let state = maybe_uninit_state.get_or_insert_with(|| build(&builder));
+                            let state =
+                                maybe_uninit_state.get_or_insert_with(|| build(&builder, key));
                             stateful_map(&mapper, state, key, value)
                         },
                         hash,

--- a/src/pyo3_extensions/mod.rs
+++ b/src/pyo3_extensions/mod.rs
@@ -280,17 +280,16 @@ impl TdPyCallable {
         Self(self.0.clone_ref(py))
     }
 
-    pub(crate) fn call0(&self, py: Python) -> PyResult<Py<PyAny>> {
-        self.0.call0(py)
-    }
-
     pub(crate) fn call1(&self, py: Python, args: impl IntoPy<Py<PyTuple>>) -> PyResult<Py<PyAny>> {
         self.0.call1(py, args)
     }
 }
 
-pub(crate) fn build(builder: &TdPyCallable) -> TdPyAny {
-    Python::with_gil(|py| with_traceback!(py, builder.call0(py)).into())
+pub(crate) fn build(builder: &TdPyCallable, key: &TdPyAny) -> TdPyAny {
+    Python::with_gil(|py| {
+        let key = key.clone_ref(py);
+        with_traceback!(py, builder.call1(py, (key,))).into()
+    })
 }
 
 /// Turn a Python 2-tuple into a Rust 2-tuple.


### PR DESCRIPTION
## Overview

When exploring some examples integrating with feature stores, I found myself wanting to be able to load previous state from an external source, and needing the key passed to the builder function of `stateful_map`.