### PR TITLE
Fixes `sorted_window()` to support items with identical times

### DIFF
--- a/pytests/test_inputs.py
+++ b/pytests/test_inputs.py
@@ -50,6 +50,7 @@ def test_sorted_window():
     items = [
         {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 4), "value": "b"},
         {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 5), "value": "c"},
+        {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 6), "value": "d"},
         {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 3), "value": "a"},
         {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 6), "value": "d"},
         {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 8), "value": "f"},
@@ -67,6 +68,7 @@ def test_sorted_window():
     assert list(out) == [
         {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 4), "value": "b"},
         {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 5), "value": "c"},
+        {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 6), "value": "d"},
         {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 6), "value": "d"},
         {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 7), "value": "e"},
         {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 8), "value": "f"},


### PR DESCRIPTION
In the implementation of `sorted_window()` we were storing 2-tuples of
`(time, item)` in a heap to keep them in sorted order. When all the
times were different, this worked fine because tuples ordering is
element-wise first, so just the times (which have to have a defined
ordering) are compared.

E.g. `(2, "dog")` vs `(3, "cat")`, just the `2` is compared to the `3`
in the heap operations.

But if the times are the same, then tuples would go to the next item.

E.g. `(2, "dog")` vs `(2, "cat")`, since the `2`s are equal, then it
compares `"dog"` vs `"cat"`. This has a defined result if the items
are comparable, but if you do something like `(2, {"animal": "dog"})`
vs `(2, {"animal": "cat"})` we get an exception because dictionaries
are not comparable.

We want to support whatever kind of input items and instead rely on
the timestamp for ordering. So to do this make a small wrapper class
`HeapItem` which has a custom `__lt__` which will only use the time
for ordering.

Modify our test to test for duplicated times.
