### PR TITLE
Examples metadata

### DIFF
--- a/docs/examples/metadata.json
+++ b/docs/examples/metadata.json
@@ -1,0 +1,7 @@
+[
+  {
+    "title": "Building Sessions from Search Logs",
+    "description": "A basic example of using Bytewax to turn an incoming stream of event logs from a hypothetical search engine into metrics over search sessions.",
+    "filename": "search_session.md"
+  }
+]


### PR DESCRIPTION
The idea is to store the basic metadata of each example in one JSON file. We'll be able to use them while rendering examples list without fetching all files from the API