### PR TITLE
Update to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Bytewax Changelog
 
+## Latest
+
+__Add any extra change notes here and we'll put them in the release
+notes on GitHub when we make a new release.__
+
 ## 0.8.0
 
 - Capture operator no longer takes arguments. Items that flow through
@@ -30,6 +35,4 @@
 - Adds `bytewax.parse` module to help with reading command line
   arguments and environment variables for the above entrypoints.
   
-- Adds `manual_cluster` example.
-
 - Renames `bytewax.inp` to `bytewax.inputs`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "bytewax"
-version = "0.8.0-beta.3"
+version = "0.8.0"
 dependencies = [
  "axum",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytewax"
-version = "0.8.0-beta.3"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,92 @@
+# Steps to Release Bytewax
+
+## 1. One Final PR
+
+Make a PR which commits the following:
+
+1. Bumps version number in `Cargo.toml`
+
+   ```diff
+   *** Cargo.toml
+    [package]
+   -version = "0.1.0"
+   +version = "1.2.3"
+   ```
+   
+2. Commits updated API docs
+
+   ```sh
+   (.venv) bytewax/apidocs $ pip install -r requirements.txt
+   (.venv) bytewax/apidocs $ rm -rf html/
+   (.venv) bytewax/apidocs $ ./build.sh
+   ```
+   
+   You'll get a warning about `Couldn't read PEP-224 variable
+   docstrings`, but ignore that as our PyO3 Rust pyclasses don't have
+   Python source `pdoc` can read.
+   
+   If we've been committing these as we go, there might not be any
+   changes to commit here. That's fine.
+   
+3. Labels the latest changelog entries with the version number
+
+   Look in `CHANGELOG.md` for the latest batch of hand-written
+   changelog notes and add a new headings with the version number.
+   
+   ```diff
+   *** CHANGELOG.md
+    ## Latest
+    
+    __Add any extra change notes here and we'll put them in the release
+    notes on GitHub when we make a new release.__
+   
+   +## 1.2.3
+   +
+    * Example note here. Describe any super important changes that you
+      wouldn't glean from PR names which will be added by GitHub
+      automatically.
+   ```
+   
+Approve and merge that PR.
+
+## 2. Create Release on GitHub
+
+Go to the [create a new GitHub release page for our
+repo](https://github.com/bytewax/bytewax/releases/new).
+
+1. Choose a tag and enter a tag with the new version number `v1.2.3`.
+
+2. Click "Auto-generate release notes".
+
+   This will pre-populate the GitHub release notes with a list of
+   changes via PRs.
+   
+3. Copy and paste any hand-written notes from the section of
+   [`CHANGELOG.md`](https://raw.githubusercontent.com/bytewax/bytewax/main/CHANGELOG.md)
+   with this version into a new section of the GitHub release
+   description at the top.
+   
+   ```diff
+   +## Overview
+   +* Paste in the stuff in `CHANGELOG.md` here.
+   +
+    ## What's Changed
+    * List of PRs that were merged, but sometimes the names aren't helpful.
+   ```
+
+4. *Press "Publish release"!*
+
+   This should create a tag in our repo named `v1.2.3` and CI will
+   kick off building, running tests, and pushing the final package to
+   PyPI.
+   
+   Check that the CI run completed on [our CI actions
+   page](https://github.com/bytewax/bytewax/actions/workflows/CI.yml).
+
+## 3. Double check PyPI
+
+Double check our [Bytewax PyPI
+page](https://pypi.org/project/bytewax/) to make sure that the new
+version of the package is there.
+
+I think we're done! Update this if we're not!

--- a/apidocs/html/bytewax/inputs.html
+++ b/apidocs/html/bytewax/inputs.html
@@ -17,6 +17,7 @@ Use these to wrap an existing iterator which yields items.
 &#34;&#34;&#34;
 import datetime
 import heapq
+from dataclasses import dataclass
 from typing import Any, Callable, Iterable, Tuple
 
 
@@ -109,7 +110,7 @@ def tumbling_epoch(
         epoch_start_time: The timestamp that should correspond to
             the start of the 0th epoch. Otherwise defaults to the time
             found on the first item.
-        
+
         epoch_start: The integer value to start counting epochs from.
             This can be used for continuity during processing.
 
@@ -156,6 +157,23 @@ def fully_ordered(wrap_iter: Iterable) -&gt; Iterable[Tuple[int, Any]]:
     for item in wrap_iter:
         yield (epoch, item)
         epoch += 1
+
+
+@dataclass
+class _HeapItem:
+    &#34;&#34;&#34;Wrapper class which holds pairs of time and item for implementing
+    `sorted_window()`.
+
+    We need some class that has an ordering only based on the time.
+
+    &#34;&#34;&#34;
+
+    time: Any
+    item: Any
+
+    def __lt__(self, other):
+        &#34;&#34;&#34;Compare just by timestamp. Ignore the item.&#34;&#34;&#34;
+        return self.time &lt; other.time
 
 
 def sorted_window(
@@ -251,9 +269,9 @@ def sorted_window(
         return newest_time is None or time &gt; newest_time
 
     def emit_all(emit_older_than):
-        while len(sorted_buffer) &gt; 0 and sorted_buffer[0][0] &lt;= emit_older_than:
-            time, item = heapq.heappop(sorted_buffer)
-            yield item
+        while len(sorted_buffer) &gt; 0 and sorted_buffer[0].time &lt;= emit_older_than:
+            sort_item = heapq.heappop(sorted_buffer)
+            yield sort_item.item
 
     for item in wrap_iter:
         time = time_getter(item)
@@ -262,7 +280,7 @@ def sorted_window(
             if on_drop:
                 on_drop(item)
         else:
-            heapq.heappush(sorted_buffer, (time, item))
+            heapq.heappush(sorted_buffer, _HeapItem(time, item))
 
             if is_newest_item(time):
                 newest_time = time
@@ -552,9 +570,9 @@ length.</dd>
         return newest_time is None or time &gt; newest_time
 
     def emit_all(emit_older_than):
-        while len(sorted_buffer) &gt; 0 and sorted_buffer[0][0] &lt;= emit_older_than:
-            time, item = heapq.heappop(sorted_buffer)
-            yield item
+        while len(sorted_buffer) &gt; 0 and sorted_buffer[0].time &lt;= emit_older_than:
+            sort_item = heapq.heappop(sorted_buffer)
+            yield sort_item.item
 
     for item in wrap_iter:
         time = time_getter(item)
@@ -563,7 +581,7 @@ length.</dd>
             if on_drop:
                 on_drop(item)
         else:
-            heapq.heappush(sorted_buffer, (time, item))
+            heapq.heappush(sorted_buffer, _HeapItem(time, item))
 
             if is_newest_item(time):
                 newest_time = time
@@ -707,7 +725,7 @@ This can be used for continuity during processing.</dd>
         epoch_start_time: The timestamp that should correspond to
             the start of the 0th epoch. Otherwise defaults to the time
             found on the first item.
-        
+
         epoch_start: The integer value to start counting epochs from.
             This can be used for continuity during processing.
 

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -148,7 +148,7 @@ def fully_ordered(wrap_iter: Iterable) -> Iterable[Tuple[int, Any]]:
 
 
 @dataclass
-class HeapItem:
+class _HeapItem:
     """Wrapper class which holds pairs of time and item for implementing
     `sorted_window()`.
 
@@ -268,7 +268,7 @@ def sorted_window(
             if on_drop:
                 on_drop(item)
         else:
-            heapq.heappush(sorted_buffer, HeapItem(time, item))
+            heapq.heappush(sorted_buffer, _HeapItem(time, item))
 
             if is_newest_item(time):
                 newest_time = time


### PR DESCRIPTION
- Updates Cargo.lock
- Bumps version to 0.8.0
- Makes HeapItem private so it won't appear in API docs
- Rebuilds API docs
- Bumps version in changelog
- Adds release instructions
