### PR TITLE
`stateful_map` should pass a tuple of (key, value) to the builder

### DIFF
--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -433,8 +433,8 @@ where
                     let mapper = mapper.clone_ref(py);
                     stream = stream.map(lift_2tuple).state_machine(
                         move |key, value, maybe_uninit_state: &mut Option<TdPyAny>| {
-                            let state =
-                                maybe_uninit_state.get_or_insert_with(|| build(&builder, key));
+                            let state = maybe_uninit_state
+                                .get_or_insert_with(|| build(&builder, &value));
                             stateful_map(&mapper, state, key, value)
                         },
                         hash,

--- a/src/pyo3_extensions/mod.rs
+++ b/src/pyo3_extensions/mod.rs
@@ -285,10 +285,9 @@ impl TdPyCallable {
     }
 }
 
-pub(crate) fn build(builder: &TdPyCallable, key: &TdPyAny) -> TdPyAny {
+pub(crate) fn build(builder: &TdPyCallable, value: &TdPyAny) -> TdPyAny {
     Python::with_gil(|py| {
-        let key = key.clone_ref(py);
-        with_traceback!(py, builder.call1(py, (key,))).into()
+        with_traceback!(py, builder.call1(py, (value,))).into()
     })
 }
 


### PR DESCRIPTION
When working on an example, I found it useful to have access to the full value that will be passed to the mapper function to build the initial value for `stateful_map`.

In the example I was working on, I was joining two streams of data. The first time I got a new value for a key, I wanted to use it as the initial value.

This PR changes the API of `stateful_map` to pass the `value` instead of the `key`. One could argue that you should pass the builder function both, but `value` in this case is always a tuple of (key, value). I considered destructuring it in rust to make the API for the `builder` function take two params of `key` and `value`, but left it this way for the moment.