### PR TITLE
Adds run_main()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Adds `run_main()` as a way to test input and output builders without
+  starting a cluster.
+
 ## 0.8.0
 
 - Capture operator no longer takes arguments. Items that flow through

--- a/pysrc/bytewax/__init__.py
+++ b/pysrc/bytewax/__init__.py
@@ -5,11 +5,12 @@ scalable dataflows in a streaming or batch context.
 documentation.](https://github.com/bytewax/bytewax)
 
 """
-from .bytewax import cluster_main, Dataflow
+from .bytewax import cluster_main, Dataflow, run_main
 from .execution import run, run_cluster, spawn_cluster
 
 __all__ = [
     "Dataflow",
+    "run_main",
     "run",
     "run_cluster",
     "spawn_cluster",

--- a/pysrc/bytewax/execution.py
+++ b/pysrc/bytewax/execution.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 from multiprocess import Manager, Pool
 
-from .bytewax import _run, cluster_main, Dataflow
+from .bytewax import cluster_main, Dataflow, run_main
 
 
 def __skip_doctest_on_win_gha():
@@ -61,7 +61,7 @@ def run(flow: Dataflow, inp: Iterable[Tuple[int, Any]]) -> List[Tuple[int, Any]]
         assert worker_index == 0
         return out.append
 
-    _run(flow, input_builder, output_builder)
+    run_main(flow, input_builder, output_builder)
 
     return out
 
@@ -86,12 +86,6 @@ def spawn_cluster(
     parallelism and higher throughput, or simple stand-alone demo
     programs.
 
-    See `bytewax.run_cluster()` for a convenience method to pass data
-    through a dataflow for notebook development.
-
-    See `bytewax.cluster_main()` for starting one process in a cluster
-    in a distributed situation.
-
     >>> __skip_doctest_on_win_gha()
     >>> __fix_pickling_in_doctest()
     >>> flow = Dataflow()
@@ -101,6 +95,15 @@ def spawn_cluster(
     >>> def output_builder(worker_index, worker_count):
     ...     return print
     >>> spawn_cluster(flow, input_builder, output_builder, proc_count=2)
+
+    See `bytewax.run_main()` for a way to test input and output
+    builders without the complexity of starting a cluster.
+
+    See `bytewax.run_cluster()` for a convenience method to pass data
+    through a dataflow for notebook development.
+
+    See `bytewax.cluster_main()` for starting one process in a cluster
+    in a distributed situation.
 
     Args:
 
@@ -164,12 +167,6 @@ def run_cluster(
     distribution to cluster and otherwise collected output will grow
     unbounded.
 
-    See `bytewax.spawn_cluster()` for starting a cluster on this
-    machine with full control over inputs and outputs.
-
-    See `bytewax.cluster_main()` for starting one process in a cluster
-    in a distributed situation.
-
     >>> __skip_doctest_on_win_gha()
     >>> flow = Dataflow()
     >>> flow.map(str.upper)
@@ -177,6 +174,12 @@ def run_cluster(
     >>> out = run_cluster(flow, [(0, "a"), (1, "b"), (2, "c")], proc_count=2)
     >>> sorted(out)
     [(0, 'A'), (1, 'B'), (2, 'C')]
+
+    See `bytewax.spawn_cluster()` for starting a cluster on this
+    machine with full control over inputs and outputs.
+
+    See `bytewax.cluster_main()` for starting one process in a cluster
+    in a distributed situation.
 
     Args:
         flow: Dataflow to run.

--- a/pytests/test_operators.py
+++ b/pytests/test_operators.py
@@ -82,8 +82,14 @@ def test_inspect():
     flow.inspect(seen.append)
     flow.capture()
 
-    run(flow, inp)
+    out = run(flow, inp)
 
+    assert sorted(out) == sorted(
+        [
+            (1, "a"),
+        ]
+    )
+    # Check side-effects after execution is complete.
     assert seen == ["a"]
 
 
@@ -97,8 +103,14 @@ def test_inspect_epoch():
     flow.inspect_epoch(lambda epoch, item: seen.append((epoch, item)))
     flow.capture()
 
-    run(flow, inp)
+    out = run(flow, inp)
 
+    assert sorted(out) == sorted(
+        [
+            (1, "a"),
+        ]
+    )
+    # Check side-effects after execution is complete.
     assert seen == [(1, "a")]
 
 

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -110,6 +110,7 @@ where
     }
 }
 
+// TODO: pytest --doctest-modules does not find doctests in PyO3 code.
 /// Execute a dataflow in the current thread.
 ///
 /// Blocks until execution is complete.
@@ -118,15 +119,13 @@ where
 /// builders with a single worker before using them in a cluster
 /// setting.
 ///
-/// >>> import asyncio
 /// >>> flow = Dataflow()
 /// >>> flow.capture()
 /// >>> def input_builder(worker_index, worker_count):
 /// ...     return enumerate(range(3))
-/// >>> async def output_builder(worker_index, worker_count, epoch_items):
-/// ...     async for epoch, item in epoch_items:
-/// ...         print(epoch, item)
-/// >>> asyncio.run(run_main(flow, input_builder, output_builder))  # doctest: +ELLIPSIS
+/// >>> def output_builder(worker_index, worker_count):
+/// ...     return print
+/// >>> run_main(flow, input_builder, output_builder)  # doctest: +ELLIPSIS
 /// (...)
 ///
 /// See `bytewax.run()` for a convenience method to not need to worry


### PR DESCRIPTION
"Backporting" some of the useful things from my async branch.

One is renaming `_run()` to `run_main()` and making it public. It runs
the dataflow in-thread but uses input and output builders so you can
test them before dealing with a cluster.

Since it's used by `run()` the tests excercise it.

Also added two little extra asserts in the `inspect{,_epoch}` tests.
