### PR TITLE
Re-enable documentation tests and upgrade longform docs to 0.8.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,8 +32,7 @@ jobs:
         WHEEL_FILE=$(ls ./dist/*.whl)
         pip install $WHEEL_FILE -v
         pip install -r build.requirements.txt
-        # Set this env var to ignore the fact that we're running doctests from the source tree but importing code from the installed package. See https://github.com/pytest-dev/pytest/issues/2042
-        PY_IGNORE_IMPORTMISMATCH=1 pytest
+        pytest
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:
@@ -64,7 +63,6 @@ jobs:
         $WHEEL_FILE=Get-ChildItem ./dist | Select Name -ExpandProperty Name
         pip install ./dist/$WHEEL_FILE -v
         pip install -r build.requirements.txt
-        $env:PY_IGNORE_IMPORTMISMATCH=1
         pytest
     - name: Upload wheels
       uses: actions/upload-artifact@v2
@@ -93,7 +91,7 @@ jobs:
         WHEEL_FILE=$(ls ./dist/*.whl)
         pip install $WHEEL_FILE -v
         pip install -r build.requirements.txt
-        PY_IGNORE_IMPORTMISMATCH=1 pytest
+        pytest
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
-- Adds `run_main()` as a way to test input and output builders without
-  starting a cluster.
+- Adds `bytewax.run_main()` as a way to test input and output builders
+  without starting a cluster.
+  
+- Adds a `bytewax.testing` module with helpers for testing.
+
+- `bytewax.run_cluster()` and `bytewax.spawn_cluster()` now take a
+  `mp_ctx` argument to allow you to change the multiprocessing
+  behavior. E.g. from "fork" to "spawn". Defaults now to "spawn".
 
 ## 0.8.0
 

--- a/apidocs/html/bytewax/index.html
+++ b/apidocs/html/bytewax/index.html
@@ -19,11 +19,12 @@ scalable dataflows in a streaming or batch context.
 documentation.](https://github.com/bytewax/bytewax)
 
 &#34;&#34;&#34;
-from .bytewax import cluster_main, Dataflow
+from .bytewax import cluster_main, Dataflow, run_main
 from .execution import run, run_cluster, spawn_cluster
 
 __all__ = [
     &#34;Dataflow&#34;,
+    &#34;run_main&#34;,
     &#34;run&#34;,
     &#34;run_cluster&#34;,
     &#34;spawn_cluster&#34;,
@@ -62,6 +63,12 @@ route data to workers …</p></div>
 line.</p></div>
 </p>
 </div>
+<div class="api__article-submodules-item">
+<h4><a class="api-submodule" href="bytewax.testing">bytewax.testing</a></h4>
+<p>
+<div class="desc"><p>Helper tools for testing dataflows.</p></div>
+</p>
+</div>
 </div>
 </section>
 <section>
@@ -79,17 +86,20 @@ cluster and ensuring they each are assigned a unique ID and know
 the addresses of other processes. You'd commonly use this for
 starting processes as part of a Kubernetes cluster.</p>
 <p>Blocks until execution is complete.</p>
-<p>See <code><a title="bytewax.run_cluster" href="#bytewax.run_cluster">run_cluster()</a></code> for a convenience method to pass data
-through a dataflow for notebook development.</p>
-<p>See <code><a title="bytewax.spawn_cluster" href="#bytewax.spawn_cluster">spawn_cluster()</a></code> for starting a simple cluster
-locally on one machine.</p>
 <pre><code class="language-python-repl">&gt;&gt;&gt; flow = Dataflow()
 &gt;&gt;&gt; def input_builder(worker_index, worker_count):
 ...     return enumerate(range(3))
 &gt;&gt;&gt; def output_builder(worker_index, worker_count):
 ...     return print
-&gt;&gt;&gt; cluster_main(flow, input_builder, output_builder)
+&gt;&gt;&gt; cluster_main(flow, input_builder, output_builder)  # doctest: +ELLIPSIS
+(...)
 </code></pre>
+<p>See <code><a title="bytewax.run_main" href="#bytewax.run_main">run_main()</a></code> for a way to test input and output
+builders without the complexity of starting a cluster.</p>
+<p>See <code><a title="bytewax.run_cluster" href="#bytewax.run_cluster">run_cluster()</a></code> for a convenience method to pass data
+through a dataflow for notebook development.</p>
+<p>See <code><a title="bytewax.spawn_cluster" href="#bytewax.spawn_cluster">spawn_cluster()</a></code> for starting a simple cluster
+locally on one machine.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>flow</code></strong></dt>
@@ -181,13 +191,13 @@ unbounded.</p>
         assert worker_index == 0
         return out.append
 
-    _run(flow, input_builder, output_builder)
+    run_main(flow, input_builder, output_builder)
 
     return out</code></pre>
 </details>
 </dd>
 <dt id="bytewax.run_cluster"><code class="language-python name flex">
-<span>def <span class="ident">run_cluster</span></span>(<span>flow: <a title="bytewax.Dataflow" href="#bytewax.Dataflow">Dataflow</a>, inp: Iterable[Tuple[int, Any]], proc_count: int = 1, worker_count_per_proc: int = 1) ‑> List[Tuple[int, Any]]</span>
+<span>def <span class="ident">run_cluster</span></span>(<span>flow: <a title="bytewax.Dataflow" href="#bytewax.Dataflow">Dataflow</a>, inp: Iterable[Tuple[int, Any]], proc_count: int = 1, worker_count_per_proc: int = 1, mp_ctx=&lt;multiprocess.context.SpawnContext object&gt;) ‑> List[Tuple[int, Any]]</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Pass data through a dataflow running as a cluster of processes on
@@ -200,18 +210,23 @@ higher throughput, or simple stand-alone demo programs.</p>
 <p>Input must be finite because it is reified into a list before
 distribution to cluster and otherwise collected output will grow
 unbounded.</p>
+<pre><code class="language-python-repl">&gt;&gt;&gt; from bytewax.testing import doctest_ctx
+&gt;&gt;&gt; flow = Dataflow()
+&gt;&gt;&gt; flow.map(str.upper)
+&gt;&gt;&gt; flow.capture()
+&gt;&gt;&gt; out = run_cluster(
+...     flow,
+...     [(0, &quot;a&quot;), (1, &quot;b&quot;), (2, &quot;c&quot;)],
+...     proc_count=2,
+...     mp_ctx=doctest_ctx,  # Outside a doctest, you'd skip this.
+... )
+&gt;&gt;&gt; sorted(out)
+[(0, 'A'), (1, 'B'), (2, 'C')]
+</code></pre>
 <p>See <code><a title="bytewax.spawn_cluster" href="#bytewax.spawn_cluster">spawn_cluster()</a></code> for starting a cluster on this
 machine with full control over inputs and outputs.</p>
 <p>See <code><a title="bytewax.cluster_main" href="#bytewax.cluster_main">cluster_main()</a></code> for starting one process in a cluster
 in a distributed situation.</p>
-<pre><code class="language-python-repl">&gt;&gt;&gt; __skip_doctest_on_win_gha()
-&gt;&gt;&gt; flow = Dataflow()
-&gt;&gt;&gt; flow.map(str.upper)
-&gt;&gt;&gt; flow.capture()
-&gt;&gt;&gt; out = run_cluster(flow, [(0, &quot;a&quot;), (1, &quot;b&quot;), (2, &quot;c&quot;)], proc_count=2)
-&gt;&gt;&gt; sorted(out)
-[(0, 'A'), (1, 'B'), (2, 'C')]
-</code></pre>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>flow</code></strong></dt>
@@ -224,6 +239,10 @@ processes. Will be partitioned between workers for you.</dd>
 <dt><strong><code>worker_count_per_proc</code></strong></dt>
 <dd>Number of worker threads to start on
 each process.</dd>
+<dt><strong><code>mp_ctx</code></strong></dt>
+<dd><code>multiprocessing</code> context to use. Use this to
+configure starting up subprocesses via spawn or
+fork. Defaults to spawn.</dd>
 </dl>
 <h2 id="returns">Returns</h2>
 <p>List of <code>(epoch, item)</code> tuples seen by capture operators.</p></div>
@@ -236,6 +255,7 @@ each process.</dd>
     inp: Iterable[Tuple[int, Any]],
     proc_count: int = 1,
     worker_count_per_proc: int = 1,
+    mp_ctx=get_context(&#34;spawn&#34;),
 ) -&gt; List[Tuple[int, Any]]:
     &#34;&#34;&#34;Pass data through a dataflow running as a cluster of processes on
     this machine.
@@ -251,19 +271,24 @@ each process.</dd>
     distribution to cluster and otherwise collected output will grow
     unbounded.
 
+    &gt;&gt;&gt; from bytewax.testing import doctest_ctx
+    &gt;&gt;&gt; flow = Dataflow()
+    &gt;&gt;&gt; flow.map(str.upper)
+    &gt;&gt;&gt; flow.capture()
+    &gt;&gt;&gt; out = run_cluster(
+    ...     flow,
+    ...     [(0, &#34;a&#34;), (1, &#34;b&#34;), (2, &#34;c&#34;)],
+    ...     proc_count=2,
+    ...     mp_ctx=doctest_ctx,  # Outside a doctest, you&#39;d skip this.
+    ... )
+    &gt;&gt;&gt; sorted(out)
+    [(0, &#39;A&#39;), (1, &#39;B&#39;), (2, &#39;C&#39;)]
+
     See `bytewax.spawn_cluster()` for starting a cluster on this
     machine with full control over inputs and outputs.
 
     See `bytewax.cluster_main()` for starting one process in a cluster
     in a distributed situation.
-
-    &gt;&gt;&gt; __skip_doctest_on_win_gha()
-    &gt;&gt;&gt; flow = Dataflow()
-    &gt;&gt;&gt; flow.map(str.upper)
-    &gt;&gt;&gt; flow.capture()
-    &gt;&gt;&gt; out = run_cluster(flow, [(0, &#34;a&#34;), (1, &#34;b&#34;), (2, &#34;c&#34;)], proc_count=2)
-    &gt;&gt;&gt; sorted(out)
-    [(0, &#39;A&#39;), (1, &#39;B&#39;), (2, &#39;C&#39;)]
 
     Args:
         flow: Dataflow to run.
@@ -276,33 +301,80 @@ each process.</dd>
         worker_count_per_proc: Number of worker threads to start on
             each process.
 
+        mp_ctx: `multiprocessing` context to use. Use this to
+            configure starting up subprocesses via spawn or
+            fork. Defaults to spawn.
+
     Returns:
 
         List of `(epoch, item)` tuples seen by capture operators.
 
     &#34;&#34;&#34;
-    man = Manager()
-    inp = man.list(list(inp))
+    # A Manager starts up a background process to manage shared state.
+    with mp_ctx.Manager() as man:
+        inp = man.list(list(inp))
 
-    def input_builder(worker_index, worker_count):
-        for i, epoch_item in enumerate(inp):
-            if i % worker_count == worker_index:
-                yield epoch_item
+        def input_builder(worker_index, worker_count):
+            for i, epoch_item in enumerate(inp):
+                if i % worker_count == worker_index:
+                    yield epoch_item
 
-    out = man.list()
+        out = man.list()
 
-    def output_builder(worker_index, worker_count):
-        return out.append
+        def output_builder(worker_index, worker_count):
+            return out.append
 
-    spawn_cluster(
-        flow, input_builder, output_builder, proc_count, worker_count_per_proc
-    )
+        spawn_cluster(
+            flow,
+            input_builder,
+            output_builder,
+            proc_count,
+            worker_count_per_proc,
+            mp_ctx,
+        )
 
-    return out</code></pre>
+        # We have to copy out the shared state before process
+        # shutdown.
+        return list(out)</code></pre>
 </details>
 </dd>
+<dt id="bytewax.run_main"><code class="language-python name flex">
+<span>def <span class="ident">run_main</span></span>(<span>flow, input_builder, output_builder)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Execute a dataflow in the current thread.</p>
+<p>Blocks until execution is complete.</p>
+<p>You'd commonly use this for prototyping custom input and output
+builders with a single worker before using them in a cluster
+setting.</p>
+<pre><code class="language-python-repl">&gt;&gt;&gt; flow = Dataflow()
+&gt;&gt;&gt; flow.capture()
+&gt;&gt;&gt; def input_builder(worker_index, worker_count):
+...     return enumerate(range(3))
+&gt;&gt;&gt; def output_builder(worker_index, worker_count):
+...     return print
+&gt;&gt;&gt; run_main(flow, input_builder, output_builder)  # doctest: +ELLIPSIS
+(...)
+</code></pre>
+<p>See <code><a title="bytewax.run" href="#bytewax.run">run()</a></code> for a convenience method to not need to worry
+about input or output builders.</p>
+<p>See <code><a title="bytewax.spawn_cluster" href="#bytewax.spawn_cluster">spawn_cluster()</a></code> for starting a cluster on this
+machine with full control over inputs and outputs.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>flow</code></strong></dt>
+<dd>Dataflow to run.</dd>
+<dt><strong><code>input_builder</code></strong></dt>
+<dd>Returns input that each worker thread should
+process.</dd>
+<dt><strong><code>output_builder</code></strong></dt>
+<dd>Returns a callback function for each worker
+thread, called with <code>(epoch, item)</code> whenever and item
+passes by a capture operator on this process.</dd>
+</dl></div>
+</dd>
 <dt id="bytewax.spawn_cluster"><code class="language-python name flex">
-<span>def <span class="ident">spawn_cluster</span></span>(<span>flow: <a title="bytewax.Dataflow" href="#bytewax.Dataflow">Dataflow</a>, input_builder: Callable[[int, int], Iterable[Tuple[int, Any]]], output_builder: Callable[[int, int], Callable[[Tuple[int, Any]], None]], proc_count: int = 1, worker_count_per_proc: int = 1) ‑> List[Tuple[int, Any]]</span>
+<span>def <span class="ident">spawn_cluster</span></span>(<span>flow: <a title="bytewax.Dataflow" href="#bytewax.Dataflow">Dataflow</a>, input_builder: Callable[[int, int], Iterable[Tuple[int, Any]]], output_builder: Callable[[int, int], Callable[[Tuple[int, Any]], None]], proc_count: int = 1, worker_count_per_proc: int = 1, mp_ctx=&lt;multiprocess.context.SpawnContext object&gt;) ‑> List[Tuple[int, Any]]</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Execute a dataflow as a cluster of processes on this machine.</p>
@@ -311,20 +383,28 @@ each process.</dd>
 together. You'd commonly use this for notebook analysis that needs
 parallelism and higher throughput, or simple stand-alone demo
 programs.</p>
-<p>See <code><a title="bytewax.run_cluster" href="#bytewax.run_cluster">run_cluster()</a></code> for a convenience method to pass data
-through a dataflow for notebook development.</p>
-<p>See <code><a title="bytewax.cluster_main" href="#bytewax.cluster_main">cluster_main()</a></code> for starting one process in a cluster
-in a distributed situation.</p>
-<pre><code class="language-python-repl">&gt;&gt;&gt; __skip_doctest_on_win_gha()
-&gt;&gt;&gt; __fix_pickling_in_doctest()
+<pre><code class="language-python-repl">&gt;&gt;&gt; from bytewax.testing import doctest_ctx
 &gt;&gt;&gt; flow = Dataflow()
 &gt;&gt;&gt; flow.capture()
 &gt;&gt;&gt; def input_builder(worker_index, worker_count):
 ...     return enumerate(range(3))
 &gt;&gt;&gt; def output_builder(worker_index, worker_count):
 ...     return print
-&gt;&gt;&gt; spawn_cluster(flow, input_builder, output_builder, proc_count=2)
+&gt;&gt;&gt; spawn_cluster(
+...     flow,
+...     input_builder,
+...     output_builder,
+...     proc_count=2,
+...     mp_ctx=doctest_ctx,  # Outside a doctest, you'd skip this.
+... )  # doctest: +ELLIPSIS
+(...)
 </code></pre>
+<p>See <code><a title="bytewax.run_main" href="#bytewax.run_main">run_main()</a></code> for a way to test input and output
+builders without the complexity of starting a cluster.</p>
+<p>See <code><a title="bytewax.run_cluster" href="#bytewax.run_cluster">run_cluster()</a></code> for a convenience method to pass data
+through a dataflow for notebook development.</p>
+<p>See <code><a title="bytewax.cluster_main" href="#bytewax.cluster_main">cluster_main()</a></code> for starting one process in a cluster
+in a distributed situation.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>flow</code></strong></dt>
@@ -341,6 +421,10 @@ passes by a capture operator on this process.</dd>
 <dt><strong><code>worker_count_per_proc</code></strong></dt>
 <dd>Number of worker threads to start on
 each process.</dd>
+<dt><strong><code>mp_ctx</code></strong></dt>
+<dd><code>multiprocessing</code> context to use. Use this to
+configure starting up subprocesses via spawn or
+fork. Defaults to spawn.</dd>
 </dl></div>
 <details class="source">
 <summary>
@@ -352,6 +436,7 @@ each process.</dd>
     output_builder: Callable[[int, int], Callable[[Tuple[int, Any]], None]],
     proc_count: int = 1,
     worker_count_per_proc: int = 1,
+    mp_ctx=get_context(&#34;spawn&#34;),
 ) -&gt; List[Tuple[int, Any]]:
     &#34;&#34;&#34;Execute a dataflow as a cluster of processes on this machine.
 
@@ -362,21 +447,30 @@ each process.</dd>
     parallelism and higher throughput, or simple stand-alone demo
     programs.
 
-    See `bytewax.run_cluster()` for a convenience method to pass data
-    through a dataflow for notebook development.
-
-    See `bytewax.cluster_main()` for starting one process in a cluster
-    in a distributed situation.
-
-    &gt;&gt;&gt; __skip_doctest_on_win_gha()
-    &gt;&gt;&gt; __fix_pickling_in_doctest()
+    &gt;&gt;&gt; from bytewax.testing import doctest_ctx
     &gt;&gt;&gt; flow = Dataflow()
     &gt;&gt;&gt; flow.capture()
     &gt;&gt;&gt; def input_builder(worker_index, worker_count):
     ...     return enumerate(range(3))
     &gt;&gt;&gt; def output_builder(worker_index, worker_count):
     ...     return print
-    &gt;&gt;&gt; spawn_cluster(flow, input_builder, output_builder, proc_count=2)
+    &gt;&gt;&gt; spawn_cluster(
+    ...     flow,
+    ...     input_builder,
+    ...     output_builder,
+    ...     proc_count=2,
+    ...     mp_ctx=doctest_ctx,  # Outside a doctest, you&#39;d skip this.
+    ... )  # doctest: +ELLIPSIS
+    (...)
+
+    See `bytewax.run_main()` for a way to test input and output
+    builders without the complexity of starting a cluster.
+
+    See `bytewax.run_cluster()` for a convenience method to pass data
+    through a dataflow for notebook development.
+
+    See `bytewax.cluster_main()` for starting one process in a cluster
+    in a distributed situation.
 
     Args:
 
@@ -394,9 +488,13 @@ each process.</dd>
         worker_count_per_proc: Number of worker threads to start on
             each process.
 
+        mp_ctx: `multiprocessing` context to use. Use this to
+            configure starting up subprocesses via spawn or
+            fork. Defaults to spawn.
+
     &#34;&#34;&#34;
     addresses = _gen_addresses(proc_count)
-    with Pool(processes=proc_count) as pool:
+    with mp_ctx.Pool(processes=proc_count) as pool:
         futures = [
             pool.apply_async(
                 cluster_main,
@@ -616,6 +714,11 @@ bytewax.inputs
 bytewax.parse
 </a>
 </li>
+<li class="api__sidebar-nav-menu-item">
+<a class="api__sidebar-nav-menu-link api-submodule" href="bytewax.testing">
+bytewax.testing
+</a>
+</li>
 </ul>
 </li>
 <li class="api__sidebar-nav-item">
@@ -624,6 +727,7 @@ bytewax.parse
 <li class="api__sidebar-nav-menu-item"><a title="bytewax.cluster_main" href="#bytewax.cluster_main">cluster_main</a></li>
 <li class="api__sidebar-nav-menu-item"><a title="bytewax.run" href="#bytewax.run">run</a></li>
 <li class="api__sidebar-nav-menu-item"><a title="bytewax.run_cluster" href="#bytewax.run_cluster">run_cluster</a></li>
+<li class="api__sidebar-nav-menu-item"><a title="bytewax.run_main" href="#bytewax.run_main">run_main</a></li>
 <li class="api__sidebar-nav-menu-item"><a title="bytewax.spawn_cluster" href="#bytewax.spawn_cluster">spawn_cluster</a></li>
 </ul>
 </li>

--- a/apidocs/html/bytewax/parse.html
+++ b/apidocs/html/bytewax/parse.html
@@ -19,13 +19,6 @@ from argparse import ArgumentParser
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
-def __skip_doctest_on_win_gha():
-    import os, pytest
-
-    if os.name == &#34;nt&#34; and os.environ.get(&#34;GITHUB_ACTION&#34;):
-        pytest.skip(&#34;Hangs in Windows GitHub Actions&#34;)
-
-
 def cluster_args(args: Iterable[str] = None) -&gt; Dict[str, Any]:
     &#34;&#34;&#34;Parse command line arguments to generate arguments for
     `bytewax.run_cluster()`.
@@ -33,12 +26,17 @@ def cluster_args(args: Iterable[str] = None) -&gt; Dict[str, Any]:
     See documentation for `bytewax.run_cluster()` for semantics of
     these variables.
 
-    &gt;&gt;&gt; __skip_doctest_on_win_gha()
     &gt;&gt;&gt; from bytewax import Dataflow, run_cluster
+    &gt;&gt;&gt; from bytewax.testing import doctest_ctx
     &gt;&gt;&gt; flow = Dataflow()
     &gt;&gt;&gt; flow.capture()
     &gt;&gt;&gt; args = &#34;-w2 -n2&#34;.split()
-    &gt;&gt;&gt; out = run_cluster(flow, enumerate(range(3)), **cluster_args(args))
+    &gt;&gt;&gt; out = run_cluster(
+    ...     flow,
+    ...     enumerate(range(3)),
+    ...     mp_ctx=doctest_ctx,
+    ...     **cluster_args(args),
+    ... )
     &gt;&gt;&gt; sorted(out)
     [(0, 0), (1, 1), (2, 2)]
 
@@ -105,7 +103,6 @@ def proc_env(env: Dict[str, str] = os.environ) -&gt; Dict[str, Any]:
       E.g. `cluster_name-0` and `cluster_name` and we will calculate
       the process ID from that.
 
-    &gt;&gt;&gt; __skip_doctest_on_win_gha()
     &gt;&gt;&gt; from bytewax import Dataflow, cluster_main
     &gt;&gt;&gt; flow = Dataflow()
     &gt;&gt;&gt; flow.capture()
@@ -117,9 +114,7 @@ def proc_env(env: Dict[str, str] = os.environ) -&gt; Dict[str, Any]:
     ...     &#34;BYTEWAX_WORKERS_PER_PROCESS&#34;: &#34;2&#34;,
     ... }
     &gt;&gt;&gt; cluster_main(flow, ib, ob, **proc_env(env))  # doctest: +ELLIPSIS
-    (0, 0)
-    ...
-    (2, 2)
+    (...)
 
     Args:
 
@@ -161,7 +156,6 @@ def proc_args(args: Iterable[str] = None) -&gt; Dict[str, Any]:
     See documentation for `bytewax.cluster_main()` for semantics of
     these variables.
 
-    &gt;&gt;&gt; __skip_doctest_on_win_gha()
     &gt;&gt;&gt; from bytewax import Dataflow, cluster_main
     &gt;&gt;&gt; flow = Dataflow()
     &gt;&gt;&gt; flow.capture()
@@ -169,9 +163,7 @@ def proc_args(args: Iterable[str] = None) -&gt; Dict[str, Any]:
     &gt;&gt;&gt; ob = lambda i, n: print
     &gt;&gt;&gt; args = &#34;-w2 -p0 -a localhost:2101&#34;.split()
     &gt;&gt;&gt; cluster_main(flow, ib, ob, **proc_args(args))  # doctest: +ELLIPSIS
-    (0, 0)
-    ...
-    (2, 2)
+    (...)
 
     Args:
 
@@ -229,12 +221,17 @@ def proc_args(args: Iterable[str] = None) -&gt; Dict[str, Any]:
 <code><a title="bytewax.run_cluster" href="index.html#bytewax.run_cluster">run_cluster()</a></code>.</p>
 <p>See documentation for <code><a title="bytewax.run_cluster" href="index.html#bytewax.run_cluster">run_cluster()</a></code> for semantics of
 these variables.</p>
-<pre><code class="language-python-repl">&gt;&gt;&gt; __skip_doctest_on_win_gha()
-&gt;&gt;&gt; from bytewax import Dataflow, run_cluster
+<pre><code class="language-python-repl">&gt;&gt;&gt; from bytewax import Dataflow, run_cluster
+&gt;&gt;&gt; from bytewax.testing import doctest_ctx
 &gt;&gt;&gt; flow = Dataflow()
 &gt;&gt;&gt; flow.capture()
 &gt;&gt;&gt; args = &quot;-w2 -n2&quot;.split()
-&gt;&gt;&gt; out = run_cluster(flow, enumerate(range(3)), **cluster_args(args))
+&gt;&gt;&gt; out = run_cluster(
+...     flow,
+...     enumerate(range(3)),
+...     mp_ctx=doctest_ctx,
+...     **cluster_args(args),
+... )
 &gt;&gt;&gt; sorted(out)
 [(0, 0), (1, 1), (2, 2)]
 </code></pre>
@@ -256,12 +253,17 @@ these variables.</p>
     See documentation for `bytewax.run_cluster()` for semantics of
     these variables.
 
-    &gt;&gt;&gt; __skip_doctest_on_win_gha()
     &gt;&gt;&gt; from bytewax import Dataflow, run_cluster
+    &gt;&gt;&gt; from bytewax.testing import doctest_ctx
     &gt;&gt;&gt; flow = Dataflow()
     &gt;&gt;&gt; flow.capture()
     &gt;&gt;&gt; args = &#34;-w2 -n2&#34;.split()
-    &gt;&gt;&gt; out = run_cluster(flow, enumerate(range(3)), **cluster_args(args))
+    &gt;&gt;&gt; out = run_cluster(
+    ...     flow,
+    ...     enumerate(range(3)),
+    ...     mp_ctx=doctest_ctx,
+    ...     **cluster_args(args),
+    ... )
     &gt;&gt;&gt; sorted(out)
     [(0, 0), (1, 1), (2, 2)]
 
@@ -307,17 +309,14 @@ these variables.</p>
 cluster.</p>
 <p>See documentation for <code><a title="bytewax.cluster_main" href="index.html#bytewax.cluster_main">cluster_main()</a></code> for semantics of
 these variables.</p>
-<pre><code class="language-python-repl">&gt;&gt;&gt; __skip_doctest_on_win_gha()
-&gt;&gt;&gt; from bytewax import Dataflow, cluster_main
+<pre><code class="language-python-repl">&gt;&gt;&gt; from bytewax import Dataflow, cluster_main
 &gt;&gt;&gt; flow = Dataflow()
 &gt;&gt;&gt; flow.capture()
 &gt;&gt;&gt; ib = lambda i, n: enumerate(range(3))
 &gt;&gt;&gt; ob = lambda i, n: print
 &gt;&gt;&gt; args = &quot;-w2 -p0 -a localhost:2101&quot;.split()
 &gt;&gt;&gt; cluster_main(flow, ib, ob, **proc_args(args))  # doctest: +ELLIPSIS
-(0, 0)
-...
-(2, 2)
+(...)
 </code></pre>
 <h2 id="args">Args</h2>
 <dl>
@@ -338,7 +337,6 @@ these variables.</p>
     See documentation for `bytewax.cluster_main()` for semantics of
     these variables.
 
-    &gt;&gt;&gt; __skip_doctest_on_win_gha()
     &gt;&gt;&gt; from bytewax import Dataflow, cluster_main
     &gt;&gt;&gt; flow = Dataflow()
     &gt;&gt;&gt; flow.capture()
@@ -346,9 +344,7 @@ these variables.</p>
     &gt;&gt;&gt; ob = lambda i, n: print
     &gt;&gt;&gt; args = &#34;-w2 -p0 -a localhost:2101&#34;.split()
     &gt;&gt;&gt; cluster_main(flow, ib, ob, **proc_args(args))  # doctest: +ELLIPSIS
-    (0, 0)
-    ...
-    (2, 2)
+    (...)
 
     Args:
 
@@ -427,8 +423,7 @@ E.g. <code>cluster_name-0</code> and <code>cluster_name</code> and we will calcu
 the process ID from that.</p>
 </li>
 </ul>
-<pre><code class="language-python-repl">&gt;&gt;&gt; __skip_doctest_on_win_gha()
-&gt;&gt;&gt; from bytewax import Dataflow, cluster_main
+<pre><code class="language-python-repl">&gt;&gt;&gt; from bytewax import Dataflow, cluster_main
 &gt;&gt;&gt; flow = Dataflow()
 &gt;&gt;&gt; flow.capture()
 &gt;&gt;&gt; ib = lambda i, n: enumerate(range(3))
@@ -439,9 +434,7 @@ the process ID from that.</p>
 ...     &quot;BYTEWAX_WORKERS_PER_PROCESS&quot;: &quot;2&quot;,
 ... }
 &gt;&gt;&gt; cluster_main(flow, ib, ob, **proc_env(env))  # doctest: +ELLIPSIS
-(0, 0)
-...
-(2, 2)
+(...)
 </code></pre>
 <h2 id="args">Args</h2>
 <dl>
@@ -484,7 +477,6 @@ the process ID from that.</p>
       E.g. `cluster_name-0` and `cluster_name` and we will calculate
       the process ID from that.
 
-    &gt;&gt;&gt; __skip_doctest_on_win_gha()
     &gt;&gt;&gt; from bytewax import Dataflow, cluster_main
     &gt;&gt;&gt; flow = Dataflow()
     &gt;&gt;&gt; flow.capture()
@@ -496,9 +488,7 @@ the process ID from that.</p>
     ...     &#34;BYTEWAX_WORKERS_PER_PROCESS&#34;: &#34;2&#34;,
     ... }
     &gt;&gt;&gt; cluster_main(flow, ib, ob, **proc_env(env))  # doctest: +ELLIPSIS
-    (0, 0)
-    ...
-    (2, 2)
+    (...)
 
     Args:
 

--- a/apidocs/html/bytewax/testing.html
+++ b/apidocs/html/bytewax/testing.html
@@ -1,0 +1,287 @@
+<main class="api__content">
+<article class="api__article" id="content">
+<header class="api__article-header">
+<h1 class="api__article-title">Module <strong>bytewax.testing</strong></h1>
+</header>
+<section class="api__article-intro" id="section-intro">
+<p>Helper tools for testing dataflows.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre class="language-python line-numbers"><code class="language-python">&#34;&#34;&#34;Helper tools for testing dataflows.
+&#34;&#34;&#34;
+import multiprocessing.dummy
+from contextlib import contextmanager
+from threading import Lock
+
+
+_print_lock = Lock()
+
+
+def test_print(*args, **kwargs):
+    &#34;&#34;&#34;A version of `print()` which takes an in-process lock to prevent
+    multiple worker threads from writing simultaneously which results
+    in interleaved output.
+
+    You&#39;d use this if you&#39;re integration testing a dataflow and want
+    more deterministic output. Remember that even with this, the items
+    from multi-worker output might be &#34;out-of-order&#34; because each
+    worker is racing each other. You probably want to sort your output
+    in some way.
+
+    Arguments are passed through to `print()` unmodified.
+
+    &#34;&#34;&#34;
+    with _print_lock:
+        print(*args, flush=True, **kwargs)
+
+
+doctest_ctx = multiprocessing.dummy
+&#34;&#34;&#34;Use this `multiprocessing` context when running in doctests.
+
+Pass to `bytewax.spawn_cluster()` and `bytewax.run_cluster()`.
+
+Spawning subprocesses is fraught in doctest contexts, so use this to
+demonstrate the API works, but not actually run via multiple
+processes. We have other normal `pytest` tests which actually test
+behavior. Don&#39;t worry.
+
+&#34;&#34;&#34;
+
+
+@contextmanager
+def _Manager():
+    &#34;&#34;&#34;`multiprocessing.dummy.Manager()` doesn&#39;t support being a context
+    manager like a real `multiprocessing.Manager()` does... So let&#39;s
+    monkey patch it.
+
+    &#34;&#34;&#34;
+    yield doctest_ctx
+
+
+doctest_ctx.Manager = _Manager</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+<h2 class="api__article-subtitle" id="header-variables">Global variables</h2>
+<dl>
+<dt id="bytewax.testing.doctest_ctx"><code class="language-python name">var <span class="ident">doctest_ctx</span></code></dt>
+<dd>
+<div class="desc"><p>Use this <code>multiprocessing</code> context when running in doctests.</p>
+<p>Pass to <code><a title="bytewax.spawn_cluster" href="index.html#bytewax.spawn_cluster">spawn_cluster()</a></code> and <code><a title="bytewax.run_cluster" href="index.html#bytewax.run_cluster">run_cluster()</a></code>.</p>
+<p>Spawning subprocesses is fraught in doctest contexts, so use this to
+demonstrate the API works, but not actually run via multiple
+processes. We have other normal <code>pytest</code> tests which actually test
+behavior. Don't worry.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre class="language-python line-numbers"><code class="language-python">#
+# Support for the API of the multiprocessing package using threads
+#
+# multiprocessing/dummy/__init__.py
+#
+# Copyright (c) 2006-2008, R Oudkerk
+# Licensed to PSF under a Contributor Agreement.
+#
+
+__all__ = [
+    &#39;Process&#39;, &#39;current_process&#39;, &#39;active_children&#39;, &#39;freeze_support&#39;,
+    &#39;Lock&#39;, &#39;RLock&#39;, &#39;Semaphore&#39;, &#39;BoundedSemaphore&#39;, &#39;Condition&#39;,
+    &#39;Event&#39;, &#39;Barrier&#39;, &#39;Queue&#39;, &#39;Manager&#39;, &#39;Pipe&#39;, &#39;Pool&#39;, &#39;JoinableQueue&#39;
+    ]
+
+#
+# Imports
+#
+
+import threading
+import sys
+import weakref
+import array
+
+from .connection import Pipe
+from threading import Lock, RLock, Semaphore, BoundedSemaphore
+from threading import Event, Condition, Barrier
+from queue import Queue
+
+#
+#
+#
+
+class DummyProcess(threading.Thread):
+
+    def __init__(self, group=None, target=None, name=None, args=(), kwargs={}):
+        threading.Thread.__init__(self, group, target, name, args, kwargs)
+        self._pid = None
+        self._children = weakref.WeakKeyDictionary()
+        self._start_called = False
+        self._parent = current_process()
+
+    def start(self):
+        if self._parent is not current_process():
+            raise RuntimeError(
+                &#34;Parent is {0!r} but current_process is {1!r}&#34;.format(
+                    self._parent, current_process()))
+        self._start_called = True
+        if hasattr(self._parent, &#39;_children&#39;):
+            self._parent._children[self] = None
+        threading.Thread.start(self)
+
+    @property
+    def exitcode(self):
+        if self._start_called and not self.is_alive():
+            return 0
+        else:
+            return None
+
+#
+#
+#
+
+Process = DummyProcess
+current_process = threading.current_thread
+current_process()._children = weakref.WeakKeyDictionary()
+
+def active_children():
+    children = current_process()._children
+    for p in list(children):
+        if not p.is_alive():
+            children.pop(p, None)
+    return list(children)
+
+def freeze_support():
+    pass
+
+#
+#
+#
+
+class Namespace(object):
+    def __init__(self, /, **kwds):
+        self.__dict__.update(kwds)
+    def __repr__(self):
+        items = list(self.__dict__.items())
+        temp = []
+        for name, value in items:
+            if not name.startswith(&#39;_&#39;):
+                temp.append(&#39;%s=%r&#39; % (name, value))
+        temp.sort()
+        return &#39;%s(%s)&#39; % (self.__class__.__name__, &#39;, &#39;.join(temp))
+
+dict = dict
+list = list
+
+def Array(typecode, sequence, lock=True):
+    return array.array(typecode, sequence)
+
+class Value(object):
+    def __init__(self, typecode, value, lock=True):
+        self._typecode = typecode
+        self._value = value
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        self._value = value
+
+    def __repr__(self):
+        return &#39;&lt;%s(%r, %r)&gt;&#39;%(type(self).__name__,self._typecode,self._value)
+
+def Manager():
+    return sys.modules[__name__]
+
+def shutdown():
+    pass
+
+def Pool(processes=None, initializer=None, initargs=()):
+    from ..pool import ThreadPool
+    return ThreadPool(processes, initializer, initargs)
+
+JoinableQueue = Queue</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+<h2 class="api__article-subtitle" id="header-functions">Functions</h2>
+<dl>
+<dt id="bytewax.testing.test_print"><code class="language-python name flex">
+<span>def <span class="ident">test_print</span></span>(<span>*args, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A version of <code>print()</code> which takes an in-process lock to prevent
+multiple worker threads from writing simultaneously which results
+in interleaved output.</p>
+<p>You'd use this if you're integration testing a dataflow and want
+more deterministic output. Remember that even with this, the items
+from multi-worker output might be "out-of-order" because each
+worker is racing each other. You probably want to sort your output
+in some way.</p>
+<p>Arguments are passed through to <code>print()</code> unmodified.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre class="language-python line-numbers"><code class="language-python">def test_print(*args, **kwargs):
+    &#34;&#34;&#34;A version of `print()` which takes an in-process lock to prevent
+    multiple worker threads from writing simultaneously which results
+    in interleaved output.
+
+    You&#39;d use this if you&#39;re integration testing a dataflow and want
+    more deterministic output. Remember that even with this, the items
+    from multi-worker output might be &#34;out-of-order&#34; because each
+    worker is racing each other. You probably want to sort your output
+    in some way.
+
+    Arguments are passed through to `print()` unmodified.
+
+    &#34;&#34;&#34;
+    with _print_lock:
+        print(*args, flush=True, **kwargs)</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+</section>
+<footer class="api__footer" id="footer">
+<p class="api__footer-copyright">
+Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.
+</p>
+</footer>
+</article>
+<nav class="api__sidebar" id="sidebar">
+<ul class="api__sidebar-nav" id="index">
+<li class="api__sidebar-nav-item">
+<h3 class="api__sidebar-nav-title">Super-module</h3>
+<ul class="api__sidebar-nav-menu">
+<li class="api__sidebar-nav-menu-item">
+<a class="api__sidebar-nav-menu-link api-supermodule">
+bytewax
+</a>
+</li>
+</ul>
+</li>
+<li class="api__sidebar-nav-item">
+<h3 class="api__sidebar-nav-title"><a href="#header-variables">Global variables</a></h3>
+<ul class="api__sidebar-nav-menu">
+<li class="api__sidebar-nav-menu-item"><a title="bytewax.testing.doctest_ctx" href="#bytewax.testing.doctest_ctx">doctest_ctx</a></li>
+</ul>
+</li>
+<li class="api__sidebar-nav-item">
+<h3 class="api__sidebar-nav-title"><a href="#header-functions">Functions</a></h3>
+<ul class="api__sidebar-nav-menu">
+<li class="api__sidebar-nav-menu-item"><a title="bytewax.testing.test_print" href="#bytewax.testing.test_print">test_print</a></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>

--- a/docs/articles/getting-started/simple-example.md
+++ b/docs/articles/getting-started/simple-example.md
@@ -12,7 +12,7 @@ And by opposing end them.
 
 And a copy of the code in a file called `wordcount.py`.
 
-``` python
+```python doctest:SORT_OUTPUT doctest:ELLIPSIS doctest:NORMALIZE_WHITESPACE
 import re
 
 from bytewax import Dataflow, run
@@ -40,33 +40,31 @@ def add(count1, count2):
 
 
 flow = Dataflow()
-flow.map(str.lower)
+flow.map(lower)
 flow.flat_map(tokenize)
 flow.map(initial_count)
 flow.reduce_epoch(add)
-flow.inspect(print)
+flow.capture()
 
 
-if __name__ == "__main__":
-    for epoch, item in run(flow, file_input()):
-        print(item)
+for epoch, item in run(flow, file_input()):
+    print(item)
 ```
 
 ## Running the example
 
-Now that we have our program and our input, we can run our example and see the completed result:
+Now that we have our program and our input, we can run our example via `python ./wordcount.py` and see the completed result:
 
-``` bash
-> python ./wordcount.py
-
+```{testoutput}
 ("'tis", 1)
-('that', 1)
-('fortune', 1)
-('opposing', 1)
-('the', 3)
-('end', 1)
-('be', 2)
+('a', 1)
+('against', 1)
+('and', 2)
 ...
+('them', 1)
+('to', 4)
+('troubles', 1)
+('whether', 1)
 ```
 
 ## Unpacking the program
@@ -85,26 +83,28 @@ We'll start with how to get input we'll push through our dataflow.
 
 ### Take a line from the file
 
-``` python
+```python
 def file_input():
     for line in open("wordcount.txt"):
         yield 1, line
 ```
 
-To provide input to our program, we've defined a [Python generator](https://docs.python.org/3/glossary.html#term-generator) that will read our input file.
+To provide our program needs an **input iterator**. We've defined a [Python generator](https://docs.python.org/3/glossary.html#term-generator) that will read our input file. There are also more advanced ways to provide input, which you can read about later when we talk about [execution modes](/getting-started/execution/).
 
 This generator yields two-tuples of `1` and a line from our file. The `1` in this example is significant, but we'll talk more about it when we discuss [epochs](/getting-started/epochs/).
 
-Let's define the steps that we want to execute for each line of input that we receive. We will add these steps to a **dataflow object**.
+Let's define the steps that we want to execute for each line of input that we receive. We will add these steps to a **dataflow object**, `bytewax.Dataflow()`.
 
 ### Lowercase all characters in the line
 
 If you look closely at our input, we have instances of both `To` and `to`. Let's add a step to our dataflow that transforms each line into lowercase letters. At the same time, we'll introduce our first operator, [map](/operators/operators/#map).
 
-``` python
+```python
 def lower(line):
     return line.lower()
 
+
+flow = Dataflow()
 flow.map(lower)
 ```
 
@@ -114,25 +114,29 @@ For each item that our generator produces, the map operator will use the [built-
 
 When our `file_input()` function is called, it will receive an entire line from our file. In order to count the words in the file, we'll need to break that line up into individual words.
 
-Enter our `tokenize` function:
+Enter our `tokenize()` function, which uses a Python regular expression to split the line of input into a list of words:
 
-``` python
+```python
 def tokenize(line):
     return re.findall(r'[^\s!,.?":;0-9]+', line)
 ```
 
-Here, we use a Python regular expression to split the line of input into a list of words:
+For example,
 
+```python
+to_be = "To be, or not to be, that is the question:"
+print(tokenize(to_be))
+```
 
-``` python
-line = "To be, or not to be, that is the question:"
-tokenize(line)
+results in:
+
+```{testoutput}
 ['To', 'be', 'or', 'not', 'to', 'be', 'that', 'is', 'the', 'question']
 ```
 
 To make use of `tokenize` function, we'll use the [flat map operator](/operators/operators/#flat-map):
 
-``` python
+```python
 flow.flat_map(tokenize)
 ```
 
@@ -142,29 +146,28 @@ The flat map operator defines a step which calls a function on each input item. 
 
 At this point in the dataflow, the items of data are the individual words.
 
-Let's skip ahead slightly and look at one of the more useful operators in bytewax, [reduce epoch](/operators/operators#reduce-epoch).
+Let's skip ahead to the second operator here, [reduce epoch](/operators/operators#reduce-epoch).
 
-``` python
+```python
+def initial_count(word):
+    return word, 1
+    
+    
 def add(count1, count2):
     return count1 + count2
     
+
+flow.map(initial_count)
 flow.reduce_epoch(add)
 ```
 
 Its super power is that it can repeatedly combine together items into a single, aggregate value via a reducing function. Think about it like reducing a sauce while cooking; you are boiling all of the values down to something more concentrated.
 
-In this case, we pass it the reducing function `add` which will sum together the counts of words so that the final aggregator value is the total.
+In this case, we pass it the reducing function `add()` which will sum together the counts of words so that the final aggregator value is the total.
 
 How does reduce epoch know which items to combine? Part of its requirements are that the input items from the previous step in the dataflow are `(key, value)` two-tuples, and it will make sure that all values for a given key are passed to the reducing function, but two separate keys will never have their values mixed. Thus, if we make the word the key, we'll be able to get separate counts!
 
-That explains the previous step in the dataflow:
-
-``` python
-def initial_count(word):
-    return word, 1
-    
-flow.map(initial_count)
-```
+That explains the previous map step in the dataflow with `initial_count()`.
 
 This map sets up the shape that reduce epoch needs: two-tuples where the key is the word, and the value is something we can add together. In this case, since we have a copy of a word for each instance, it represents that we should add `1` to the total count, so label that here.
 
@@ -172,53 +175,59 @@ The "epoch" part of reduce epoch means that we repeat the reduction in each epoc
 
 ### Print out the counts
 
-The last part of our dataflow program will use the [inspect operator](/operators/operators#inspect) to see the results of our reduction. For this example, we're supplying the built-in Python function `print`.
+The last part of our dataflow program will use the [capture operator](/operators/operators#capture) to mark the output of our reduction as the dataflow's final output.
 
-Here is the complete output when running the example:
+```python
+flow.capture()
+```
 
-```
-("'tis", 1)
-('that', 1)
-('fortune', 1)
-('opposing', 1)
-('the', 3)
-('end', 1)
-('be', 2)
-('and', 2)
-('of', 2)
-('in', 1)
-('take', 1)
-('arrows', 1)
-('outrageous', 1)
-('troubles', 1)
-('is', 1)
-('slings', 1)
-('not', 1)
-('a', 1)
-('by', 1)
-('them', 1)
-('sea', 1)
-('whether', 1)
-('question', 1)
-('to', 4)
-('mind', 1)
-('nobler', 1)
-('suffer', 1)
-('arms', 1)
-('or', 2)
-('against', 1)
-```
+This means that whatever items are flowing through this point in the dataflow will be passed on as outp
+ut. Output is routed in different ways depending on how the dataflow is run.
 
 ### Running
 
-To run the example, we'll need to introduce one more function, `run`:
+To run the example, we'll need to introduce one more function, `bytewax.run()`:
 
-``` python
-if __name__ == "__main__":
-    for epoch, item in run(flow, file_input()):
-        print(item)
+```python doctest:SORT_OUTPUT doctest:SORT_EXPECTED
+for epoch, item in run(flow, file_input()):
+    print(item)
 ```
 
-When we call `run`, our dataflow program will begin running, Bytewax will read the input items and epoch from your input generator, push the data through each step in the dataflow, and return the output. We then print the output of the final step.
+When we call `run()`, our dataflow program will begin running, Bytewax will read the input items and epoch from your input generator, push the data through each step in the dataflow, and return the captured output. We then print the output of the final step.
+
+Here is the complete output when running the example:
+
+```{testoutput}
+('opposing', 1)
+('and', 2)
+('of', 2)
+('end', 1)
+('whether', 1)
+('arrows', 1)
+('that', 1)
+('them', 1)
+('not', 1)
+('by', 1)
+('sea', 1)
+('arms', 1)
+('a', 1)
+('is', 1)
+('against', 1)
+('to', 4)
+("'tis", 1)
+('nobler', 1)
+('take', 1)
+('question', 1)
+('troubles', 1)
+('or', 2)
+('slings', 1)
+('mind', 1)
+('outrageous', 1)
+('suffer', 1)
+('be', 2)
+('in', 1)
+('the', 3)
+('fortune', 1)
+```
 
 To learn more about possible modes of execution, [read our page on execution](/getting-started/execution).

--- a/docs/articles/getting-started/wordcount.txt
+++ b/docs/articles/getting-started/wordcount.txt
@@ -1,0 +1,5 @@
+To be, or not to be, that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles
+And by opposing end them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,10 @@ long_description = "file: README.md"
 long_description_content_type = "text/markdown"
 
 [tool.pytest.ini_options]
-addopts = "-v --doctest-modules"
+addopts = "-v"
 doctest_optionflags = "NORMALIZE_WHITESPACE"
 testpaths = [
     "pytests",
-    "pysrc",
+    # TODO: Add back in doctests when we can figure out how to run them without import problems.
     "docs",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,4 +37,5 @@ doctest_optionflags = "NORMALIZE_WHITESPACE"
 testpaths = [
     "pytests",
     "pysrc",
+    "docs",
 ]

--- a/pysrc/bytewax/parse.py
+++ b/pysrc/bytewax/parse.py
@@ -7,13 +7,6 @@ from argparse import ArgumentParser
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
-def __skip_doctest_on_win_gha():
-    import os, pytest
-
-    if os.name == "nt" and os.environ.get("GITHUB_ACTION"):
-        pytest.skip("Hangs in Windows GitHub Actions")
-
-
 def cluster_args(args: Iterable[str] = None) -> Dict[str, Any]:
     """Parse command line arguments to generate arguments for
     `bytewax.run_cluster()`.
@@ -21,12 +14,17 @@ def cluster_args(args: Iterable[str] = None) -> Dict[str, Any]:
     See documentation for `bytewax.run_cluster()` for semantics of
     these variables.
 
-    >>> __skip_doctest_on_win_gha()
     >>> from bytewax import Dataflow, run_cluster
+    >>> from bytewax.testing import doctest_ctx
     >>> flow = Dataflow()
     >>> flow.capture()
     >>> args = "-w2 -n2".split()
-    >>> out = run_cluster(flow, enumerate(range(3)), **cluster_args(args))
+    >>> out = run_cluster(
+    ...     flow,
+    ...     enumerate(range(3)),
+    ...     mp_ctx=doctest_ctx,
+    ...     **cluster_args(args),
+    ... )
     >>> sorted(out)
     [(0, 0), (1, 1), (2, 2)]
 
@@ -93,7 +91,6 @@ def proc_env(env: Dict[str, str] = os.environ) -> Dict[str, Any]:
       E.g. `cluster_name-0` and `cluster_name` and we will calculate
       the process ID from that.
 
-    >>> __skip_doctest_on_win_gha()
     >>> from bytewax import Dataflow, cluster_main
     >>> flow = Dataflow()
     >>> flow.capture()
@@ -105,9 +102,7 @@ def proc_env(env: Dict[str, str] = os.environ) -> Dict[str, Any]:
     ...     "BYTEWAX_WORKERS_PER_PROCESS": "2",
     ... }
     >>> cluster_main(flow, ib, ob, **proc_env(env))  # doctest: +ELLIPSIS
-    (0, 0)
-    ...
-    (2, 2)
+    (...)
 
     Args:
 
@@ -149,7 +144,6 @@ def proc_args(args: Iterable[str] = None) -> Dict[str, Any]:
     See documentation for `bytewax.cluster_main()` for semantics of
     these variables.
 
-    >>> __skip_doctest_on_win_gha()
     >>> from bytewax import Dataflow, cluster_main
     >>> flow = Dataflow()
     >>> flow.capture()
@@ -157,9 +151,7 @@ def proc_args(args: Iterable[str] = None) -> Dict[str, Any]:
     >>> ob = lambda i, n: print
     >>> args = "-w2 -p0 -a localhost:2101".split()
     >>> cluster_main(flow, ib, ob, **proc_args(args))  # doctest: +ELLIPSIS
-    (0, 0)
-    ...
-    (2, 2)
+    (...)
 
     Args:
 

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -1,0 +1,52 @@
+"""Helper tools for testing dataflows.
+"""
+import multiprocessing.dummy
+from contextlib import contextmanager
+from threading import Lock
+
+
+_print_lock = Lock()
+
+
+def test_print(*args, **kwargs):
+    """A version of `print()` which takes an in-process lock to prevent
+    multiple worker threads from writing simultaneously which results
+    in interleaved output.
+
+    You'd use this if you're integration testing a dataflow and want
+    more deterministic output. Remember that even with this, the items
+    from multi-worker output might be "out-of-order" because each
+    worker is racing each other. You probably want to sort your output
+    in some way.
+
+    Arguments are passed through to `print()` unmodified.
+
+    """
+    with _print_lock:
+        print(*args, flush=True, **kwargs)
+
+
+doctest_ctx = multiprocessing.dummy
+"""Use this `multiprocessing` context when running in doctests.
+
+Pass to `bytewax.spawn_cluster()` and `bytewax.run_cluster()`.
+
+Spawning subprocesses is fraught in doctest contexts, so use this to
+demonstrate the API works, but not actually run via multiple
+processes. We have other normal `pytest` tests which actually test
+behavior. Don't worry.
+
+"""
+
+
+@contextmanager
+def _Manager():
+    """`multiprocessing.dummy.Manager()` doesn't support being a context
+    manager like a real `multiprocessing.Manager()` does... So let's
+    monkey patch it.
+
+    """
+    yield doctest_ctx
+
+
+doctest_ctx.Manager = _Manager

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -1,0 +1,7 @@
+from multiprocess import get_context
+from pytest import fixture
+
+
+@fixture
+def mp_ctx():
+    return get_context("spawn")

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -87,33 +87,33 @@ def test_run_cluster_reraises_exception():
     reason="Sending os.kill(test_proc.pid, signal.CTRL_C_EVENT) sends event to all processes on this console so interrupts pytest itself",
 )
 def test_run_can_be_ctrl_c():
-    manager = Manager()
-    is_running = manager.Event()
-    out = manager.list()
+    with Manager() as man:
+        is_running = man.Event()
+        out = man.list()
 
-    def proc_main():
-        def mapper(item):
-            is_running.set()
+        def proc_main():
+            def mapper(item):
+                is_running.set()
 
-        flow = Dataflow()
-        flow.map(mapper)
-        flow.capture()
+            flow = Dataflow()
+            flow.map(mapper)
+            flow.capture()
 
-        try:
-            for epoch_item in run(flow, inputs.fully_ordered(range(1000))):
-                out.append(epoch_item)
-        except KeyboardInterrupt:
-            exit(99)
+            try:
+                for epoch_item in run(flow, inputs.fully_ordered(range(1000))):
+                    out.append(epoch_item)
+            except KeyboardInterrupt:
+                exit(99)
 
-    test_proc = Process(target=proc_main)
-    test_proc.start()
+        test_proc = Process(target=proc_main)
+        test_proc.start()
 
-    assert is_running.wait(timeout=5.0), "Timeout waiting for test proc to start"
-    os.kill(test_proc.pid, signal.SIGINT)
-    test_proc.join()
+        assert is_running.wait(timeout=5.0), "Timeout waiting for test proc to start"
+        os.kill(test_proc.pid, signal.SIGINT)
+        test_proc.join()
 
-    assert test_proc.exitcode == 99
-    assert len(out) < 1000
+        assert test_proc.exitcode == 99
+        assert len(out) < 1000
 
 
 @mark.skipif(
@@ -121,38 +121,38 @@ def test_run_can_be_ctrl_c():
     reason="Sending os.kill(test_proc.pid, signal.CTRL_C_EVENT) sends event to all processes on this console so interrupts pytest itself",
 )
 def test_run_cluster_can_be_ctrl_c():
-    manager = Manager()
-    is_running = manager.Event()
-    out = manager.list()
+    with Manager() as man:
+        is_running = man.Event()
+        out = man.list()
 
-    def proc_main():
-        def mapper(item):
-            is_running.set()
+        def proc_main():
+            def mapper(item):
+                is_running.set()
 
-        flow = Dataflow()
-        flow.map(mapper)
-        flow.capture()
+            flow = Dataflow()
+            flow.map(mapper)
+            flow.capture()
 
-        try:
-            for epoch_item in run_cluster(
-                flow,
-                inputs.fully_ordered(range(1000)),
-                proc_count=2,
-                worker_count_per_proc=2,
-            ):
-                out.append(epoch_item)
-        except KeyboardInterrupt:
-            exit(99)
+            try:
+                for epoch_item in run_cluster(
+                    flow,
+                    inputs.fully_ordered(range(1000)),
+                    proc_count=2,
+                    worker_count_per_proc=2,
+                ):
+                    out.append(epoch_item)
+            except KeyboardInterrupt:
+                exit(99)
 
-    test_proc = Process(target=proc_main)
-    test_proc.start()
+        test_proc = Process(target=proc_main)
+        test_proc.start()
 
-    assert is_running.wait(timeout=5.0), "Timeout waiting for test proc to start"
-    os.kill(test_proc.pid, signal.SIGINT)
-    test_proc.join()
+        assert is_running.wait(timeout=5.0), "Timeout waiting for test proc to start"
+        os.kill(test_proc.pid, signal.SIGINT)
+        test_proc.join()
 
-    assert test_proc.exitcode == 99
-    assert len(out) < 1000
+        assert test_proc.exitcode == 99
+        assert len(out) < 1000
 
 
 @mark.skipif(
@@ -160,38 +160,38 @@ def test_run_cluster_can_be_ctrl_c():
     reason="Sending os.kill(test_proc.pid, signal.CTRL_C_EVENT) sends event to all processes on this console so interrupts pytest itself",
 )
 def test_cluster_main_can_be_ctrl_c():
-    manager = Manager()
-    is_running = manager.Event()
-    out = manager.list()
+    with Manager() as man:
+        is_running = man.Event()
+        out = man.list()
 
-    def proc_main():
-        def input_builder(worker_index, worker_count):
-            return inputs.fully_ordered(range(1000))
+        def proc_main():
+            def input_builder(worker_index, worker_count):
+                return inputs.fully_ordered(range(1000))
 
-        def output_builder(worker_index, worker_count):
-            def out_handler(epoch_item):
-                out.append(epoch_item)
+            def output_builder(worker_index, worker_count):
+                def out_handler(epoch_item):
+                    out.append(epoch_item)
 
-            return out_handler
+                return out_handler
 
-        def mapper(item):
-            is_running.set()
+            def mapper(item):
+                is_running.set()
 
-        flow = Dataflow()
-        flow.map(mapper)
-        flow.capture()
+            flow = Dataflow()
+            flow.map(mapper)
+            flow.capture()
 
-        try:
-            cluster_main(flow, input_builder, output_builder, [], 0, 1)
-        except KeyboardInterrupt:
-            exit(99)
+            try:
+                cluster_main(flow, input_builder, output_builder, [], 0, 1)
+            except KeyboardInterrupt:
+                exit(99)
 
-    test_proc = Process(target=proc_main)
-    test_proc.start()
+        test_proc = Process(target=proc_main)
+        test_proc.start()
 
-    assert is_running.wait(timeout=5.0), "Timeout waiting for test proc to start"
-    os.kill(test_proc.pid, signal.SIGINT)
-    test_proc.join()
+        assert is_running.wait(timeout=5.0), "Timeout waiting for test proc to start"
+        os.kill(test_proc.pid, signal.SIGINT)
+        test_proc.join()
 
-    assert test_proc.exitcode == 99
-    assert len(out) < 1000
+        assert test_proc.exitcode == 99
+        assert len(out) < 1000

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -19,10 +19,6 @@ def test_run():
     assert sorted(out) == sorted([(0, 1), (1, 2), (2, 3)])
 
 
-@mark.skipif(
-    os.name == "nt" and os.environ.get("GITHUB_ACTION") is not None,
-    reason="Hangs in Windows GitHub Actions",
-)
 def test_run_cluster():
     flow = Dataflow()
     flow.map(lambda x: x + 1)
@@ -41,10 +37,6 @@ def test_run_requires_capture():
         run(flow, enumerate(range(3)))
 
 
-@mark.skipif(
-    os.name == "nt" and os.environ.get("GITHUB_ACTION") is not None,
-    reason="Hangs in Windows GitHub Actions",
-)
 def test_run_cluster_requires_capture():
     flow = Dataflow()
 

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -102,7 +102,7 @@ def test_run_can_be_ctrl_c():
 
         assert is_running.wait(timeout=5.0), "Timeout waiting for test proc to start"
         os.kill(test_proc.pid, signal.SIGINT)
-        test_proc.join()
+        test_proc.join(timeout=5.0)
 
         assert test_proc.exitcode == 99
         assert len(out) < 1000
@@ -141,7 +141,7 @@ def test_run_cluster_can_be_ctrl_c():
 
         assert is_running.wait(timeout=5.0), "Timeout waiting for test proc to start"
         os.kill(test_proc.pid, signal.SIGINT)
-        test_proc.join()
+        test_proc.join(timeout=5.0)
 
         assert test_proc.exitcode == 99
         assert len(out) < 1000
@@ -183,7 +183,7 @@ def test_cluster_main_can_be_ctrl_c():
 
         assert is_running.wait(timeout=5.0), "Timeout waiting for test proc to start"
         os.kill(test_proc.pid, signal.SIGINT)
-        test_proc.join()
+        test_proc.join(timeout=5.0)
 
         assert test_proc.exitcode == 99
         assert len(out) < 1000

--- a/pytests/test_operators.py
+++ b/pytests/test_operators.py
@@ -196,10 +196,6 @@ def test_reduce_epoch():
     )
 
 
-@mark.skipif(
-    os.name == "nt" and os.environ.get("GITHUB_ACTION") is not None,
-    reason="Hangs in Windows GitHub Actions",
-)
 def test_reduce_epoch_local():
     def add_initial_count(event):
         return event["user"], 1

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -201,7 +201,8 @@ pub(crate) fn run_main(
 /// ...     return enumerate(range(3))
 /// >>> def output_builder(worker_index, worker_count):
 /// ...     return print
-/// >>> cluster_main(flow, input_builder, output_builder)
+/// >>> cluster_main(flow, input_builder, output_builder)  # doctest: +ELLIPSIS
+/// (...)
 ///
 /// See `bytewax.run_main()` for a way to test input and output
 /// builders without the complexity of starting a cluster.


### PR DESCRIPTION
Updates our docs to 0.8.0 API and gets all the documentation tests working again. I had to jump through some test runner and multiprocessing hoops to make that happen. Then something about changing the multiprocessing context caused the other execution tests to break, so had to fix them there too. Unfortunately, even though I fixed up the _docstring_ doctests and they pass locally, CI can't run them because the hacks to enable them in an installed package broke multiprocessing elsewhere; we should still run them locally during development with `pytest --doctest-modules`. See individual commits for compartmentalized changes and detailed descriptions.