### PR TITLE
Frontier psychiatry

### DIFF
--- a/docs/articles/getting-started/execution.md
+++ b/docs/articles/getting-started/execution.md
@@ -98,13 +98,14 @@ The per-worker input of `spawn_cluster()` has the extra requirement that the inp
 `run_cluster()` blocks until all output has been collected.
 
 ```python doctest:SORT_OUTPUT
-from bytewax import spawn_cluster
+from bytewax import spawn_cluster, AdvanceTo, Emit
 from bytewax.testing import test_print
 
 
 def input_builder(worker_index, worker_count):
     for epoch, x in enumerate(range(3)):
-        yield epoch, {"input_from": worker_index, "x": x}
+        yield AdvanceTo(epoch)
+        yield Emit({"input_from": worker_index, "x": x})
 
 
 def output_builder(worker_index, worker_count):
@@ -170,7 +171,8 @@ from bytewax import cluster_main
 
 def input_builder(worker_index, worker_count):
     for epoch, x in enumerate(range(3)):
-        yield epoch, {"input_from": worker_index, "x": x}
+        yield AdvanceTo(epoch)
+        yield Emit({"input_from": worker_index, "x": x})
 
 
 def output_builder(worker_index, worker_count):

--- a/examples/twitter_stream.py
+++ b/examples/twitter_stream.py
@@ -39,6 +39,8 @@ flow.capture()
 
 if __name__ == "__main__":
     for epoch, item in run_cluster(
-        flow, inputs.tumbling_epoch(twitter.get_stream(), timedelta(seconds=2)), **parse.cluster_args()
+        flow,
+        inputs.tumbling_epoch(twitter.get_stream(), timedelta(seconds=2)),
+        **parse.cluster_args()
     ):
         print(epoch, item)

--- a/pysrc/bytewax/__init__.py
+++ b/pysrc/bytewax/__init__.py
@@ -5,7 +5,7 @@ scalable dataflows in a streaming or batch context.
 documentation.](https://github.com/bytewax/bytewax)
 
 """
-from .bytewax import cluster_main, Dataflow, run_main
+from .bytewax import cluster_main, Dataflow, run_main, AdvanceTo, Send
 from .execution import run, run_cluster, spawn_cluster
 
 __all__ = [
@@ -15,6 +15,8 @@ __all__ = [
     "run_cluster",
     "spawn_cluster",
     "cluster_main",
+    "AdvanceTo",
+    "Send",
 ]
 
 __pdoc__ = {

--- a/pysrc/bytewax/__init__.py
+++ b/pysrc/bytewax/__init__.py
@@ -5,7 +5,7 @@ scalable dataflows in a streaming or batch context.
 documentation.](https://github.com/bytewax/bytewax)
 
 """
-from .bytewax import cluster_main, Dataflow, run_main, AdvanceTo, Send
+from .bytewax import cluster_main, Dataflow, run_main, AdvanceTo, Emit
 from .execution import run, run_cluster, spawn_cluster
 
 __all__ = [
@@ -16,7 +16,7 @@ __all__ = [
     "spawn_cluster",
     "cluster_main",
     "AdvanceTo",
-    "Send",
+    "Emit",
 ]
 
 __pdoc__ = {

--- a/pysrc/bytewax/execution.py
+++ b/pysrc/bytewax/execution.py
@@ -61,7 +61,7 @@ def _gen_addresses(proc_count: int) -> Iterable[str]:
 
 def spawn_cluster(
     flow: Dataflow,
-    input_builder: Callable[[int, int], Iterable[Tuple[int, Any]]],
+    input_builder: Callable[[int, int], Iterable[Tuple[Any]]],
     output_builder: Callable[[int, int], Callable[[Tuple[int, Any]], None]],
     proc_count: int = 1,
     worker_count_per_proc: int = 1,
@@ -149,7 +149,7 @@ def spawn_cluster(
 
 def run_cluster(
     flow: Dataflow,
-    inp: Iterable[Tuple[Any]],
+    inp: Iterable[Tuple[int, Any]],
     proc_count: int = 1,
     worker_count_per_proc: int = 1,
     mp_ctx=get_context("spawn"),

--- a/pysrc/bytewax/execution.py
+++ b/pysrc/bytewax/execution.py
@@ -1,7 +1,7 @@
 """Entry point functions to execute `bytewax.Dataflow`s.
 
 """
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Iterable, List, Tuple, Union
 
 from multiprocess import get_context
 
@@ -61,7 +61,7 @@ def _gen_addresses(proc_count: int) -> Iterable[str]:
 
 def spawn_cluster(
     flow: Dataflow,
-    input_builder: Callable[[int, int], Iterable[Tuple[Any]]],
+    input_builder: Callable[[int, int], Iterable[Union[AdvanceTo, Send]]],
     output_builder: Callable[[int, int], Callable[[Tuple[int, Any]], None]],
     proc_count: int = 1,
     worker_count_per_proc: int = 1,
@@ -79,8 +79,10 @@ def spawn_cluster(
     >>> from bytewax.testing import doctest_ctx
     >>> flow = Dataflow()
     >>> flow.capture()
-    >>> def input_builder(worker_index, worker_count):
-    ...     return enumerate(range(3))
+    >>> def input_builder(i, n):
+    ...   for epoch, item in enumerate(range(3)):
+    ...     yield AdvanceTo(epoch)
+    ...     yield Send(item)
     >>> def output_builder(worker_index, worker_count):
     ...     return print
     >>> spawn_cluster(

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Iterable, Tuple
 
 def yield_epochs(fn: Callable):
     """A decorator function to unwrap an iterator of [epoch, item]
-    into successive `AdvanceTo` and `Send` classes with the
+    into successive `AdvanceTo` and `Emit` classes with the
     contents of the iterator.
 
     Use this when you have an input_builder function that returns

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -3,8 +3,12 @@
 Use these to wrap an existing iterator which yields items.
 
 """
+
 import datetime
 import heapq
+
+from .bytewax import AdvanceTo, Send
+
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, Tuple
 

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -7,7 +7,7 @@ Use these to wrap an existing iterator which yields items.
 import datetime
 import heapq
 
-from .bytewax import AdvanceTo, Send
+from .bytewax import AdvanceTo, Emit
 
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, Tuple
@@ -39,7 +39,7 @@ def yield_epochs(fn: Callable):
         gen = fn(worker_index, worker_count)
         for (epoch, item) in gen:
             yield AdvanceTo(epoch)
-            yield Send(item)
+            yield Emit(item)
 
     return inner_fn
 

--- a/pysrc/bytewax/parse.py
+++ b/pysrc/bytewax/parse.py
@@ -91,13 +91,13 @@ def proc_env(env: Dict[str, str] = os.environ) -> Dict[str, Any]:
       E.g. `cluster_name-0` and `cluster_name` and we will calculate
       the process ID from that.
 
-    >>> from bytewax import Dataflow, cluster_main, AdvanceTo, Send
+    >>> from bytewax import Dataflow, cluster_main, AdvanceTo, Emit
     >>> flow = Dataflow()
     >>> flow.capture()
     >>> def ib(i, n):
     ...   for epoch, item in enumerate(range(3)):
     ...     yield AdvanceTo(epoch)
-    ...     yield Send(item)
+    ...     yield Emit(item)
     >>> ob = lambda i, n: print
     >>> env = {
     ...     "BYTEWAX_ADDRESSES": "localhost:2101",
@@ -147,13 +147,13 @@ def proc_args(args: Iterable[str] = None) -> Dict[str, Any]:
     See documentation for `bytewax.cluster_main()` for semantics of
     these variables.
 
-    >>> from bytewax import Dataflow, cluster_main, AdvanceTo, Send
+    >>> from bytewax import Dataflow, cluster_main, AdvanceTo, Emit
     >>> flow = Dataflow()
     >>> flow.capture()
     >>> def ib(i, n):
     ...   for epoch, item in enumerate(range(3)):
     ...     yield AdvanceTo(epoch)
-    ...     yield Send(item)
+    ...     yield Emit(item)
     >>> ob = lambda i, n: print
     >>> args = "-w2 -p0 -a localhost:2101".split()
     >>> cluster_main(flow, ib, ob, **proc_args(args))  # doctest: +ELLIPSIS

--- a/pysrc/bytewax/parse.py
+++ b/pysrc/bytewax/parse.py
@@ -91,10 +91,13 @@ def proc_env(env: Dict[str, str] = os.environ) -> Dict[str, Any]:
       E.g. `cluster_name-0` and `cluster_name` and we will calculate
       the process ID from that.
 
-    >>> from bytewax import Dataflow, cluster_main
+    >>> from bytewax import Dataflow, cluster_main, AdvanceTo, Send
     >>> flow = Dataflow()
     >>> flow.capture()
-    >>> ib = lambda i, n: enumerate(range(3))
+    >>> def ib(i, n):
+    ...   for epoch, item in enumerate(range(3)):
+    ...     yield AdvanceTo(epoch)
+    ...     yield Send(item)
     >>> ob = lambda i, n: print
     >>> env = {
     ...     "BYTEWAX_ADDRESSES": "localhost:2101",
@@ -144,10 +147,13 @@ def proc_args(args: Iterable[str] = None) -> Dict[str, Any]:
     See documentation for `bytewax.cluster_main()` for semantics of
     these variables.
 
-    >>> from bytewax import Dataflow, cluster_main
+    >>> from bytewax import Dataflow, cluster_main, AdvanceTo, Send
     >>> flow = Dataflow()
     >>> flow.capture()
-    >>> ib = lambda i, n: enumerate(range(3))
+    >>> def ib(i, n):
+    ...   for epoch, item in enumerate(range(3)):
+    ...     yield AdvanceTo(epoch)
+    ...     yield Send(item)
     >>> ob = lambda i, n: print
     >>> args = "-w2 -p0 -a localhost:2101".split()
     >>> cluster_main(flow, ib, ob, **proc_args(args))  # doctest: +ELLIPSIS

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -3,7 +3,7 @@ import signal
 import threading
 from sys import exit
 
-from bytewax import cluster_main, Dataflow, inputs, run, run_cluster, AdvanceTo, Send
+from bytewax import cluster_main, Dataflow, inputs, run, run_cluster, AdvanceTo, Emit
 
 from pytest import mark, raises
 
@@ -162,7 +162,7 @@ def test_cluster_main_can_be_ctrl_c(mp_ctx):
             def input_builder(worker_index, worker_count):
                 for epoch, input in inputs.fully_ordered(range(1000)):
                     yield AdvanceTo(epoch)
-                    yield Send(input)
+                    yield Emit(input)
 
             def output_builder(worker_index, worker_count):
                 def out_handler(epoch_item):

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -3,7 +3,7 @@ import signal
 import threading
 from sys import exit
 
-from bytewax import cluster_main, Dataflow, inputs, run, run_cluster
+from bytewax import cluster_main, Dataflow, inputs, run, run_cluster, AdvanceTo, Send
 
 from pytest import mark, raises
 
@@ -160,7 +160,9 @@ def test_cluster_main_can_be_ctrl_c(mp_ctx):
 
         def proc_main():
             def input_builder(worker_index, worker_count):
-                return inputs.fully_ordered(range(1000))
+                for epoch, input in inputs.fully_ordered(range(1000)):
+                    yield AdvanceTo(epoch)
+                    yield Send(input)
 
             def output_builder(worker_index, worker_count):
                 def out_handler(epoch_item):

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::PyLong;
 use timely::dataflow::InputHandle;
 use timely::dataflow::ProbeHandle;
 
@@ -27,9 +26,8 @@ pub(crate) struct TdAdvanceTo {
 #[pymethods]
 impl TdAdvanceTo {
     #[new]
-    fn new(epoch: Py<PyLong>) -> Self {
-        let new_epoch = Python::with_gil(|py| with_traceback!(py, epoch.extract(py)));
-        Self { epoch: new_epoch }
+    fn new(epoch: u64) -> Self {
+        Self { epoch }
     }
 }
 

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -16,7 +16,8 @@ use crate::dataflow::{build_dataflow, Dataflow};
 use crate::pyo3_extensions::{TdPyAny, TdPyCallable, TdPyIterator};
 use crate::with_traceback;
 
-#[pyclass(name = "AdvanceTo")]
+
+#[pyclass(name = "AdvanceTo", module = "bytewax")]
 #[pyo3(text_signature = "(epoch)")]
 pub(crate) struct TdAdvanceTo {
     #[pyo3(get)]
@@ -32,7 +33,7 @@ impl TdAdvanceTo {
     }
 }
 
-#[pyclass(name = "Send")]
+#[pyclass(name = "Send", module = "bytewax")]
 #[pyo3(text_signature = "(item)")]
 pub(crate) struct TdSend {
     #[pyo3(get)]
@@ -84,7 +85,7 @@ impl Pump {
                         }
                     }
                     Err(err) => {
-                        panic!("Error during pump: {err}");
+                        std::panic::panic_any(err);
                     }
                 }
             } else {

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -253,7 +253,8 @@ pub(crate) fn run_main(
 ///     flow: Dataflow to run.
 ///
 ///     input_builder: Returns input that each worker thread should
-///         process.
+///         process. Should yield either `AdvanceTo` or `Send` to
+///         advance the epoch, or input new data into the dataflow.
 ///
 ///     output_builder: Returns a callback function for each worker
 ///         thread, called with `(epoch, item)` whenever and item

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+use pyo3::basic::CompareOp;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use timely::dataflow::InputHandle;
@@ -26,6 +27,17 @@ impl AdvanceTo {
     #[new]
     fn new(epoch: u64) -> Self {
         Self { epoch }
+    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.epoch < other.epoch),
+            CompareOp::Le => Ok(self.epoch <= other.epoch),
+            CompareOp::Eq => Ok(self.epoch == other.epoch),
+            CompareOp::Ne => Ok(self.epoch != other.epoch),
+            CompareOp::Gt => Ok(self.epoch > other.epoch),
+            CompareOp::Ge => Ok(self.epoch >= other.epoch),
+        }
     }
 }
 

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -83,8 +83,8 @@ impl Pump {
     fn pump(&mut self) {
         Python::with_gil(|py| {
             let mut pull_from_pyiter = self.pull_from_pyiter.0.as_ref(py);
-            if let Some(input_action) = pull_from_pyiter.next() {
-                match input_action {
+            if let Some(input_or_action) = pull_from_pyiter.next() {
+                match input_or_action {
                     Ok(item) => {
                         if let Ok(send) = item.downcast::<PyCell<Emit>>() {
                             self.push_to_timely.send(send.borrow().item.clone());


### PR DESCRIPTION
## Overview

This PR adds two new primitives to bytewax: `AdvanceTo` and ~`Send`~ `Emit`. These two primitives expose two more fundamental constructs of Timely Dataflow to our users, and allow you to influence when work is performed in your dataflow.

## Rationale

In some of our examples that use Kafka, I discovered that outputs for a particular epoch would not be generated until new input was introduced into the dataflow. This coupling of inputs to outputs allows us to have a very fluent Python interface, but it led to some confusion when expecting the results of your latest input.

## Changes

All of the execution parts of the code, save `cluster_main` and `spawn_cluser` now utilize `AdvanceTo` and `Send` with their input builder. This allows us to keep almost the same interface for executors that use generators.
