### PR TITLE
Fix broken links in longform documentation

### DIFF
--- a/apidocs/html/bytewax/index.html
+++ b/apidocs/html/bytewax/index.html
@@ -114,10 +114,8 @@ locally on one machine.</p>
 <dd>Dataflow to run.</dd>
 <dt><strong><code>input_builder</code></strong></dt>
 <dd>Returns input that each worker thread should
-process. Should yield either <code><a title="bytewax.AdvanceTo" href="#bytewax.AdvanceTo">AdvanceTo</a></code> or <code>Send</code> to
-advance the epoch, or input new data into the dataflow.
-If you are recovering a stateful dataflow, you must ensure
-your input resumes from the last finalized epoch.</dd>
+process. Should yield either <code><a title="bytewax.AdvanceTo" href="#bytewax.AdvanceTo">AdvanceTo</a></code> or <code><a title="bytewax.Emit" href="#bytewax.Emit">Emit</a></code> to
+advance the epoch, or input new data into the dataflow.</dd>
 <dt><strong><code>output_builder</code></strong></dt>
 <dd>Returns a callback function for each worker
 thread, called with <code>(epoch, item)</code> whenever and item

--- a/apidocs/html/bytewax/inputs.html
+++ b/apidocs/html/bytewax/inputs.html
@@ -30,9 +30,9 @@ def yield_epochs(fn: Callable):
     into successive `AdvanceTo` and `Emit` classes with the
     contents of the iterator.
 
-    Use this when you have an input_builder function that returns
-    a generator of (epoch, item) to be used with `cluster_main` or
-    `spawn_cluster`:
+    Use this when you have an input_builder function that returns a
+    generator of (epoch, item) to be used with
+    `bytewax.cluster_main()` or `bytewax.spawn_cluster()`:
 
     &gt;&gt;&gt; from bytewax import Dataflow, cluster_main
     &gt;&gt;&gt; from bytewax.inputs import yield_epochs, fully_ordered
@@ -45,6 +45,7 @@ def yield_epochs(fn: Callable):
     (0, &#39;a&#39;)
     (1, &#39;b&#39;)
     (2, &#39;c&#39;)
+
     &#34;&#34;&#34;
 
     def inner_fn(worker_index, worker_count):
@@ -788,9 +789,9 @@ This can be used for continuity during processing.</dd>
 <div class="desc"><p>A decorator function to unwrap an iterator of [epoch, item]
 into successive <code>AdvanceTo</code> and <code>Emit</code> classes with the
 contents of the iterator.</p>
-<p>Use this when you have an input_builder function that returns
-a generator of (epoch, item) to be used with <code>cluster_main</code> or
-<code>spawn_cluster</code>:</p>
+<p>Use this when you have an input_builder function that returns a
+generator of (epoch, item) to be used with
+<code><a title="bytewax.cluster_main" href="index.html#bytewax.cluster_main">cluster_main()</a></code> or <code><a title="bytewax.spawn_cluster" href="index.html#bytewax.spawn_cluster">spawn_cluster()</a></code>:</p>
 <pre><code class="language-python-repl">&gt;&gt;&gt; from bytewax import Dataflow, cluster_main
 &gt;&gt;&gt; from bytewax.inputs import yield_epochs, fully_ordered
 &gt;&gt;&gt; flow = Dataflow()
@@ -812,9 +813,9 @@ a generator of (epoch, item) to be used with <code>cluster_main</code> or
     into successive `AdvanceTo` and `Emit` classes with the
     contents of the iterator.
 
-    Use this when you have an input_builder function that returns
-    a generator of (epoch, item) to be used with `cluster_main` or
-    `spawn_cluster`:
+    Use this when you have an input_builder function that returns a
+    generator of (epoch, item) to be used with
+    `bytewax.cluster_main()` or `bytewax.spawn_cluster()`:
 
     &gt;&gt;&gt; from bytewax import Dataflow, cluster_main
     &gt;&gt;&gt; from bytewax.inputs import yield_epochs, fully_ordered
@@ -827,6 +828,7 @@ a generator of (epoch, item) to be used with <code>cluster_main</code> or
     (0, &#39;a&#39;)
     (1, &#39;b&#39;)
     (2, &#39;c&#39;)
+
     &#34;&#34;&#34;
 
     def inner_fn(worker_index, worker_count):

--- a/docs/articles/getting-started/epochs.md
+++ b/docs/articles/getting-started/epochs.md
@@ -200,9 +200,9 @@ Since each line in the file corresponds to an epoch, we get counts grouped by li
 
 ## Epoch-aware operators and ordering
 
-This different grouping happened "automatically" because of the behavior of the [reduce epoch](/operators/operators#reduce-epoch) operator. It "ends" its window of aggregation for each key at the end of each epoch.
+This different grouping happened "automatically" because of the behavior of the [reduce epoch](/apidocs#bytewax.Dataflow.reduce_epoch) operator. It "ends" its window of aggregation for each key at the end of each epoch.
 
-There are a few other operators that use the epoch as part of their semantcs: [reduce](/operators/operators#reduce), [stateful_map](/operators/operators#stateful-map), and others. You'll have to read the specifications of each to know how it interacts with epochs and what kind of ordering guarantees it gives you.
+There are a few other operators that use the epoch as part of their semantcs: [reduce](/apidocs#bytewax.Dataflow.reduce), [stateful_map](/apidocs#bytewax.Dataflow.stateful_map), and others. You'll have to read the specifications of each to know how it interacts with epochs and what kind of ordering guarantees it gives you.
 
 On that note, remember unless explicitly declared by a given operator _there are no ordering guarantees_. Bytewax might run your operator functions with data in any epoch order, and there's usually no order within an epoch!
 
@@ -239,7 +239,7 @@ These allow you to conveniently assign epochs, but you can also assign them by h
 
 ## A closer look at epochs
 
-As mentioned previously, bytewax will "automatically" produce results from operators like [reduce epoch](/operators/operators#reduce-epoch) by "ending" its window of aggregation for each key at the end of each epoch. Let's look more closely at how this is accomplished, and how we can use this to control when work is done with bytewax.
+As mentioned previously, bytewax will "automatically" produce results from operators like [reduce epoch](/apidocs#bytewax.Dataflow.reduce_epoch) by "ending" its window of aggregation for each key at the end of each epoch. Let's look more closely at how this is accomplished, and how we can use this to control when work is done with bytewax.
 
 To do that, let's examine how `run()` works under the hood.
 
@@ -253,7 +253,7 @@ def input_builder(worker_index, worker_count):
         yield Emit(input)
 ```
 
-Here we introduce two new primitives in Bytewax: `AdvanceTo` and `Emit`.
+Here we introduce two new primitives in Bytewax: [`AdvanceTo`](/apidocs#bytewax.AdvanceTo) and [`Emit`](/apidocs#bytewax.Emit).
 
 These two dataclasses are how we inform Bytewax of new input and of the progress of epochs. `Emit` will introduce input into the dataflow at the current epoch, and `AdvanceTo` advances the current epoch to the value supplied.
 

--- a/docs/articles/getting-started/overview.md
+++ b/docs/articles/getting-started/overview.md
@@ -4,6 +4,8 @@ Dataflow programming is a programming paradigm where program execution is concep
 
 Bytewax is a Python native binding to the [Timely Dataflow](https://github.com/TimelyDataflow/timely-dataflow) library. Timely Dataflow is a dataflow processing library written in [Rust](https://www.rust-lang.org/).
 
+## Benefits
+
 At a high level, Bytewax provides a few major benefits:
 
 - The operators in Bytewax are largely "data-parallel", meaning they can operate on independent parts of the data concurrently.

--- a/docs/articles/getting-started/simple-example.md
+++ b/docs/articles/getting-started/simple-example.md
@@ -97,7 +97,7 @@ Let's define the steps that we want to execute for each line of input that we re
 
 ### Lowercase all characters in the line
 
-If you look closely at our input, we have instances of both `To` and `to`. Let's add a step to our dataflow that transforms each line into lowercase letters. At the same time, we'll introduce our first operator, [map](/operators/operators/#map).
+If you look closely at our input, we have instances of both `To` and `to`. Let's add a step to our dataflow that transforms each line into lowercase letters. At the same time, we'll introduce our first operator, [map](/apidocs#bytewax.Dataflow.map).
 
 ```python
 def lower(line):
@@ -134,7 +134,7 @@ results in:
 ['To', 'be', 'or', 'not', 'to', 'be', 'that', 'is', 'the', 'question']
 ```
 
-To make use of `tokenize` function, we'll use the [flat map operator](/operators/operators/#flat-map):
+To make use of `tokenize` function, we'll use the [flat map operator](/apidocs#bytewax.Dataflow.flat_map):
 
 ```python
 flow.flat_map(tokenize)
@@ -146,7 +146,7 @@ The flat map operator defines a step which calls a function on each input item. 
 
 At this point in the dataflow, the items of data are the individual words.
 
-Let's skip ahead to the second operator here, [reduce epoch](/operators/operators#reduce-epoch).
+Let's skip ahead to the second operator here, [reduce epoch](/apidocs#bytewax.Dataflow.reduce_epoch).
 
 ```python
 def initial_count(word):
@@ -175,7 +175,7 @@ The "epoch" part of reduce epoch means that we repeat the reduction in each epoc
 
 ### Print out the counts
 
-The last part of our dataflow program will use the [capture operator](/operators/operators#capture) to mark the output of our reduction as the dataflow's final output.
+The last part of our dataflow program will use the [capture operator](/apidocs#bytewax.Dataflow.capture) to mark the output of our reduction as the dataflow's final output.
 
 ```python
 flow.capture()
@@ -230,4 +230,4 @@ Here is the complete output when running the example:
 ('fortune', 1)
 ```
 
-To learn more about possible modes of execution, [read our page on execution](/getting-started/execution).
+To learn more about possible modes of execution, [read our page on execution](/getting-started/execution/).

--- a/docs/examples/search-session.md
+++ b/docs/examples/search-session.md
@@ -87,7 +87,7 @@ the concept of time in your execution via attaching a kind of
 timestamp called an **epoch** to each **item** of input data.
 
 [You can read more about the details of epochs in our
-documentation](epochs), but the most important facet of them for this
+documentation](/getting-started/epochs/), but the most important facet of them for this
 example is that they are the _only_ way you can set up a sense of
 order in your data.
 
@@ -95,7 +95,7 @@ Since we are going to use the order in which events happen to divvy
 them up into user sessions, we need to take advantage of epochs at
 some level. In this basic example, we're going to label each input
 event with a monotonically increasing epoch. [There are some some
-scaling downsides to this approach](epochs/scaling), but we will be
+scaling downsides to this approach](/getting-started/epochs/), but we will be
 using it here anyway to demonstrate the basics of epochs.
 
 You tell Bytewax what epoch each input item has by having your input
@@ -135,7 +135,7 @@ You can then add a series of **steps** to the dataflow. Steps are made
 up of **operators**, that provide a "shape" of transformation, and
 **logic functions**, that you supply to do your specific
 transformation. [You can read more about all the operators in our
-documentation.](operators)
+documentation.](/getting-started/operators)
 
 Our first task is to make sure to group incoming events by user since
 no session deals with multiple users.
@@ -145,7 +145,7 @@ be in the form of a `(key, value)` tuple, where `key` is the value the
 dataflow will group by before passing to the operator logic.
 
 The operator which modifies all data flowing through it is
-[map](operators/map). Let's use that and pull each event's user into
+[map](/apidocs#bytewax.Dataflow.map). Let's use that and pull each event's user into
 that key position.
 
 ```python
@@ -157,7 +157,7 @@ flow.map(initial_session)
 
 For the value, we're planning ahead a little bit to our next task:
 sessionization. The operator best shaped for this is the [reduce
-operator](operators/reduce) which groups items by key, then combines
+operator](/apidocs#bytewax.Dataflow.reduce) which groups items by key, then combines
 them together into an **aggregator** in order. We can think about our
 reduce step as "combine together sessions if they should be
 joined". We'll be modeling a session as a list of events, so have the
@@ -204,7 +204,7 @@ flow.map(remove_key)
 ```
 
 Our next task is to split user sessions into search sessions. To do
-that, we'll use the [flat map operator](operators/flat-map), that
+that, we'll use the [flat map operator](/apidocs#bytewax.Dataflow.flat_map), that
 allows you to emit multiple items downstream (search sessions) for
 each input item (user session).
 
@@ -230,7 +230,7 @@ def split_into_searches(user_session):
 flow.flat_map(split_into_searches)
 ```
 
-We can use the [filter operator](operators/filter) to get rid of all
+We can use the [filter operator](/apidocs#bytewax.Dataflow.filter) to get rid of all
 search sessions that don't contain searches and shouldn't contribute
 to metrics.
 
@@ -275,7 +275,7 @@ Execution
 ---------
 
 [Bytewax provides a few different entry points for executing your
-dataflow](execution), but because we're focusing on the dataflow in
+dataflow](/getting-started/execution/), but because we're focusing on the dataflow in
 this example, we're going to use `bytewax.run` which is the most basic
 execution mode that pushes input items in an iterator through the
 dataflow.
@@ -298,7 +298,7 @@ Let's inspect the output and see if it makes sense.
 11 0.0
 ```
 
-Since the [capture](operators/capture) step is immediately after
+Since the [capture](/apidocs#bytewax.Dataflow.capture) step is immediately after
 calculating CTR, we should see one output item for each search
 session. That checks out! There were three searches in the input:
 "dogs", "cats", and "fruit". Only the first two resulted in a click,
@@ -308,7 +308,7 @@ contributed `0.0`.
 The first number on each output line is the epoch of that data
 item. Most operators do not modify the epoch attached to each item as
 they transform it. The only operator that modifies the epoch in this
-example is [reduce](operators/reduce) which emits output at the epoch
+example is [reduce](/apidocs#bytewax.Dataflow.reduce) which emits output at the epoch
 of the input that is marked as "complete". Since we are marking user
 sessions as complete when reduce has an `AppClose` event as input
 (originally assigned epochs `10` and `11`), those epochs are applied

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -18,9 +18,9 @@ def yield_epochs(fn: Callable):
     into successive `AdvanceTo` and `Emit` classes with the
     contents of the iterator.
 
-    Use this when you have an input_builder function that returns
-    a generator of (epoch, item) to be used with `cluster_main` or
-    `spawn_cluster`:
+    Use this when you have an input_builder function that returns a
+    generator of (epoch, item) to be used with
+    `bytewax.cluster_main()` or `bytewax.spawn_cluster()`:
 
     >>> from bytewax import Dataflow, cluster_main
     >>> from bytewax.inputs import yield_epochs, fully_ordered
@@ -33,6 +33,7 @@ def yield_epochs(fn: Callable):
     (0, 'a')
     (1, 'b')
     (2, 'c')
+
     """
 
     def inner_fn(worker_index, worker_count):

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -279,7 +279,7 @@ pub(crate) fn run_main(
 ///     flow: Dataflow to run.
 ///
 ///     input_builder: Returns input that each worker thread should
-///         process. Should yield either `AdvanceTo` or `Send` to
+///         process. Should yield either `AdvanceTo` or `Emit` to
 ///         advance the epoch, or input new data into the dataflow.
 ///         If you are recovering a stateful dataflow, you must ensure
 ///         your input resumes from the last finalized epoch.


### PR DESCRIPTION
Done:
- [x] Fix broken links in `Understanding epochs` and `A simple example` articles
- [x] Fix broken links in `Building Sessions from Search Logs` example
- [x] Add links to AdvanceTo and Emit dataclasses in  `Understanding epochs`
- [x] Add 'Benefits' H2 in `Overview` article

To do - we need to fix broken links in API Docs submodules:
- [x] All links in [bytewax.parse](https://docs-vue.staging.bytewax.io/apidocs/parse), removing 'index.html' from their target should solve that problem
- [x] Links in [bytewax.testing](https://docs-vue.staging.bytewax.io/apidocs/testing) require the same treatment as above