### PR TITLE
Adds `distribute()` helper

### DIFF
--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -13,6 +13,69 @@ from typing import Any, Callable, Iterable, Tuple
 from .bytewax import AdvanceTo, Emit
 
 
+def distribute(elements: Iterable[Any], index: int, count: int) -> Iterable[Any]:
+    """Distribute elements equally between a number of buckets and return
+    the items for the given bucket index.
+
+    No two buckets will get the same element.
+
+    >>> list(distribute(["blue", "green", "red"], 0, 2))
+    ['blue', 'red']
+    >>> list(distribute(["blue", "green", "red"], 1, 2))
+    ['green']
+
+    Note that if you have more buckets than elements, some buckets
+    will get nothing.
+
+    >>> list(distribute(["blue", "green", "red"], 3, 5))
+    []
+
+    This is very useful when writing input builders and you want each
+    of your workers to handle reading a disjoint partition of your
+    input.
+
+    >>> from bytewax import Dataflow, spawn_cluster
+    >>> def read_topics(topics):
+    ...     for topic in topics:
+    ...         for i in enumerate(3):
+    ...             yield f"topic:{topic} item:{i}"
+    >>> def input_builder(i, n):
+    ...    all_topics = ["red", "green", "blue"]
+    ...    this_workers_topics = distribute(listening_topics, i, n)
+    ...    for item in read_topics(this_workers):
+    ...        yield Emit(f"worker_index:{worker_index}" + item)
+    >>> flow = Dataflow()
+    >>> flow.capture()
+    >>> spawn_cluster(flow, input_builder, lambda i, n: print)
+    (0, 'worker_index:1 topic:red item:0')
+    (0, 'worker_index:1 topic:red item:1')
+    (0, 'worker_index:1 topic:red item:2')
+    (0, 'worker_index:1 topic:blue item:0')
+    (0, 'worker_index:1 topic:blue item:1')
+    (0, 'worker_index:1 topic:blue item:2')
+    (0, 'worker_index:2 topic:green item:0')
+    (0, 'worker_index:2 topic:green item:1')
+    (0, 'worker_index:2 topic:green item:2')
+
+    Args:
+
+        elements: To distribute.
+
+        index: Index of this bucket / worker starting at 0.
+
+        count: Total number of buckets / workers.
+
+    Returns:
+
+        An iterator of the elements only in this bucket.
+
+    """
+    assert index < count, f"Highest index should only be {count - 1}; got {index}"
+    for i, x in enumerate(elements):
+        if i % count == index:
+            yield x
+
+
 def yield_epochs(fn: Callable):
     """A decorator function to unwrap an iterator of [epoch, item]
     into successive `AdvanceTo` and `Emit` classes with the

--- a/pytests/test_inputs.py
+++ b/pytests/test_inputs.py
@@ -4,12 +4,25 @@ from unittest.mock import ANY
 
 from bytewax import AdvanceTo, Dataflow, Emit, run
 from bytewax.inputs import (
+    distribute,
     fully_ordered,
     single_batch,
     sorted_window,
     tumbling_epoch,
     yield_epochs,
 )
+
+
+def test_distribute():
+    inp = ["a", "b", "c"]
+
+    out1 = distribute(inp, 0, 2)
+
+    assert list(out1) == ["a", "c"]
+
+    out2 = distribute(inp, 1, 2)
+
+    assert list(out2) == ["b"]
 
 
 def test_single_batch():


### PR DESCRIPTION
If you're doing multiple worker stuff, you probably will be
distributing work between them, so this will help out.
