### PR TITLE
Automatic state recovery / garbage collection

### DIFF
--- a/docs/articles/getting-started/epochs.md
+++ b/docs/articles/getting-started/epochs.md
@@ -243,12 +243,14 @@ As mentioned previously, bytewax will "automatically" produce results from opera
 
 To do that, let's examine how `run()` works under the hood.
 
-Inside of the run function, the generator of input (named `inp` here) yields tuples of (epoch, input). That input generator is wrapped in an input_builder function:
+Inside of the run function, the generator of input (named `inp` here) yields tuples of (epoch, input). That input generator is wrapped in an `input_builder()` function:
 
-``` python
-def input_builder(worker_index, worker_count):
+```python
+def input_builder(worker_index, worker_count, resume_epoch):
     assert worker_index == 0
     for epoch, input in inp:
+        if epoch < resume_epoch:
+            continue
         yield AdvanceTo(epoch)
         yield Emit(input)
 ```
@@ -258,4 +260,3 @@ Here we introduce two new primitives in Bytewax: `AdvanceTo` and `Emit`.
 These two dataclasses are how we inform Bytewax of new input and of the progress of epochs. `Emit` will introduce input into the dataflow at the current epoch, and `AdvanceTo` advances the current epoch to the value supplied.
 
 Importantly, when you advance the epoch, you are informing bytewax that it will no longer see any input at any of the previous epoch values. At that point, bytewax will continue to do work until output is produced for the previous epoch.
-

--- a/docs/articles/getting-started/execution.md
+++ b/docs/articles/getting-started/execution.md
@@ -91,19 +91,21 @@ Our next entry point introduces a more complex API to allow for more performance
 
 ### Builders
 
-You provide a input and output **builders**, functions that are called on each worker and will produce the input and handle the output for that worker. The input builder function should return an iterable that yields `(epoch, item)` tuples. The output builder function should return a callback **output handler** function that can be called with each epoch and item of output produced.
+You provide a input and output **builders**, functions that are called on each worker and will produce the input and handle the output for that worker. The input builder function should return an iterable that yields `Emit(item)` or `AdvanceTo(epoch)`. The output builder function should return a callback **output handler** function that can be called with each epoch and item of output produced.
+
+The input builder also recieves the epoch to resume processing on in the case of restarting the dataflow. The input builder must somehow skip ahead in its input data to start at that epoch.
 
 The per-worker input of `spawn_cluster()` has the extra requirement that the input data is not duplicated between workers. All data from each worker is introduced into the same dataflow. For example, if each worker reads the content of the same file, the input will be duplicated by the number of workers. Data sources like Apache Kafka or Redpanda can provide a partitioned stream of input which can be consumed by multiple workers in parallel without duplication, as each worker sees a unique partition.
 
-`run_cluster()` blocks until all output has been collected.
+`spawn_cluster()` blocks until all output has been collected.
 
 ```python doctest:SORT_OUTPUT
 from bytewax import spawn_cluster, AdvanceTo, Emit
 from bytewax.testing import test_print
 
 
-def input_builder(worker_index, worker_count):
-    for epoch, x in enumerate(range(3)):
+def input_builder(worker_index, worker_count, resume_epoch):
+    for epoch, x in enumerate(range(resume_epoch, 3)):
         yield AdvanceTo(epoch)
         yield Emit({"input_from": worker_index, "x": x})
 
@@ -169,8 +171,8 @@ The input builder function should return an iterable that yields `(epoch, item)`
 from bytewax import cluster_main
 
 
-def input_builder(worker_index, worker_count):
-    for epoch, x in enumerate(range(3)):
+def input_builder(worker_index, worker_count, resume_epoch):
+    for epoch, x in enumerate(range(resume_epoch, 3)):
         yield AdvanceTo(epoch)
         yield Emit({"input_from": worker_index, "x": x})
 

--- a/docs/articles/getting-started/execution.md
+++ b/docs/articles/getting-started/execution.md
@@ -91,7 +91,7 @@ Our next entry point introduces a more complex API to allow for more performance
 
 ### Builders
 
-You provide a input and output **builders**, functions that are called on each worker and will produce the input and handle the output for that worker. The input builder function should return an iterable that yields `Emit(item)` or `AdvanceTo(epoch)`. The output builder function should return a callback **output handler** function that can be called with each epoch and item of output produced.
+You provide input and output **builders**, functions that are called on each worker and will produce the input and handle the output for that worker. The input builder function should return an iterable that yields `Emit(item)` or `AdvanceTo(epoch)`. The output builder function should return a callback **output handler** function that can be called with each epoch and item of output produced.
 
 The input builder also recieves the epoch to resume processing on in the case of restarting the dataflow. The input builder must somehow skip ahead in its input data to start at that epoch.
 

--- a/docs/articles/getting-started/recovery.md
+++ b/docs/articles/getting-started/recovery.md
@@ -13,17 +13,12 @@ requirements:
    minimum unit of recovery. Design your dataflow so that epochs are
    regularly occurring because it is not possible to coherently resume
    processing mid-epoch.
-   
-2. _Log output epochs_ - You need to use the epoch associated with
-   output to determine where in your input stream you should resume
-   processing data. Log or save the epoch associated with each output
-   item to be able to do this.
 
-3. _Replayable Input_ - Your data source needs to support re-playing
-   input from a specific epoch in the past to resume making progress
-   from where the failure happened.
+2. _Replayable Input_ - Your data source needs to support re-playing
+   input from a specific epoch in the past we call the **resume
+   epoch** to resume making progress from where the failure happened.
    
-4. _At-least-once Output_ - Bytewax only provides at-least-once
+3. _At-least-once Output_ - Bytewax only provides at-least-once
    guarantees when sending data into a downstream system when
    performing a recovery. You should design your architecture to
    support this via some sort of idempotency.
@@ -32,10 +27,10 @@ requirements:
 
 Your dataflow needs a few features to enable recovery on Bytewax:
 
-1. Design your [input builder](/getting-started/execution#builders) to
-   be able to resume and replay all data from a specific epoch
-   onwards. You are given the freedom to implement this however you'd
-   like.
+1. You must design your [input
+   builder](/getting-started/execution#builders) to be able to resume
+   and replay all data from the `resume_epoch` epoch onwards. Do not
+   ignore this argument!
 
 2. Create a **recovery config** for your workers to know how to
    connect to the **recovery store**, the database or file system that
@@ -46,6 +41,9 @@ Your dataflow needs a few features to enable recovery on Bytewax:
    whatever execution [entry point](/getting-started/execution)
    (e.g. `cluster_main()`) you are using.
    
+4. Run the dataflow! Bytewax will automatically snapshots of state and
+   the resume epoch to the recovery store.
+   
 ## Performing Recovery
 
 If a dataflow has failed, follow this high-level game plan to recover
@@ -53,13 +51,9 @@ and have it resume processing from where it failed:
 
 1. Terminate the dataflow processes.
 
-2. Observe the previous dataflow output and note the last epoch
-   emitted from each worker. Find the oldest / smallest epoch out of
-   the set of the last from each worker. The epoch just _before_ this
-   will be the recovery epoch.
-
-3. Restart your dataflow, but pass in this recovery epoch as the point
-   in the input the input builder should resume from.
+2. Restart your dataflow using the same recovery config. Bytewax will
+   read the resume epoch from the recovery store and resume output
+   from the latest possible epoch in the stream.
    
 ## Examples
 

--- a/pysrc/bytewax/execution.py
+++ b/pysrc/bytewax/execution.py
@@ -50,7 +50,8 @@ def run(
 
     """
 
-    def input_builder(worker_index, worker_count):
+    def input_builder(worker_index, worker_count, resume_epoch):
+        assert resume_epoch == 0, "Recovery doesn't work with iterator based input"
         assert worker_index == 0
         for epoch, item in inp:
             yield AdvanceTo(epoch)
@@ -98,8 +99,8 @@ def spawn_cluster(
     >>> from bytewax.testing import doctest_ctx
     >>> flow = Dataflow()
     >>> flow.capture()
-    >>> def input_builder(i, n):
-    ...   for epoch, item in enumerate(range(3)):
+    >>> def input_builder(i, n, r):
+    ...   for epoch, item in enumerate(range(r, 3)):
     ...     yield AdvanceTo(epoch)
     ...     yield Emit(item)
     >>> def output_builder(worker_index, worker_count):
@@ -247,7 +248,8 @@ def run_cluster(
     with mp_ctx.Manager() as man:
         inp = man.list(list(inp))
 
-        def input_builder(worker_index, worker_count):
+        def input_builder(worker_index, worker_count, resume_epoch):
+            assert resume_epoch == 0, "Recovery doesn't work with iterator based input"
             for i, epoch_item in enumerate(inp):
                 if i % worker_count == worker_index:
                     (epoch, item) = epoch_item

--- a/pysrc/bytewax/execution.py
+++ b/pysrc/bytewax/execution.py
@@ -79,8 +79,8 @@ def _gen_addresses(proc_count: int) -> Iterable[str]:
 
 def spawn_cluster(
     flow: Dataflow,
-    input_builder: Callable[[int, int], Iterable[Union[AdvanceTo, Emit]]],
-    output_builder: Callable[[int, int], Callable[[Tuple[int, Any]], None]],
+    input_builder: Callable[[int, int, int], Iterable[Union[AdvanceTo, Emit]]],
+    output_builder: Callable[[int, int, int], Callable[[Tuple[int, Any]], None]],
     *,
     recovery_config: Optional[RecoveryConfig] = None,
     proc_count: int = 1,
@@ -99,8 +99,8 @@ def spawn_cluster(
     >>> from bytewax.testing import doctest_ctx
     >>> flow = Dataflow()
     >>> flow.capture()
-    >>> def input_builder(i, n, r):
-    ...   for epoch, item in enumerate(range(r, 3)):
+    >>> def input_builder(worker_index, worker_count, resume_epoch):
+    ...   for epoch, item in enumerate(range(resume_epoch, 3)):
     ...     yield AdvanceTo(epoch)
     ...     yield Emit(item)
     >>> def output_builder(worker_index, worker_count):
@@ -127,10 +127,8 @@ def spawn_cluster(
 
         flow: Dataflow to run.
 
-        input_builder: Returns input that each worker thread should
-            process. If you are recovering a stateful dataflow, you
-            must ensure your input resumes from the last finalized
-            epoch.
+        input_builder: Yields `AdvanceTo()` or `Emit()` with this
+            worker's input. Must resume from the epoch specified.
 
         output_builder: Returns a callback function for each worker
             thread, called with `(epoch, item)` whenever and item

--- a/pysrc/bytewax/recovery.py
+++ b/pysrc/bytewax/recovery.py
@@ -1,32 +1,52 @@
 """Bytewax's state recovery machinery.
 
+Preparation
+-----------
+
 This allows you to **recover** a stateful dataflow; it will let you
-resume processing and output due to system outage or error without
-re-processing all initial data to re-calculate all internal state.
+resume processing and output due to a failure without re-processing
+all initial data to re-calculate all internal state.
 
-0. Pick a **recovery store** in which internal state will be
-   continuously backed up. Different storage systems will have
-   different performance and reconfiguration trade-offs.
+0. Pick a **recovery store** in which internal state and progress will
+be continuously backed up. Different storage systems will have
+different performance and reconfiguration trade-offs.
 
-1. Create a **recovery config** for connecting to your recovery store.
+1. Create a **recovery config** for connecting to your recovery
+store. See the class types in this module for the datstores supported.
 
 2. Pass that created config as the `recovery_config` argument to the
-   entry point running your dataflow (e.g. `bytewax.run_cluster()`).
+entry point running your dataflow (e.g. `bytewax.cluster_main()`).
 
-3. Run your dataflow consuming input either from the beginning or
-   resuming input from the last finalized epoch.
+3. Run your dataflow! It will start backing up state data
+automatically.
 
 The epoch is the unit of recovery. It is your responsibility to design
-your input builders or iterators in such a way that it can be resumed
-from a given epoch; if it can't (because the input is ephemeral) then
-this feature won't allow complete recovery. It is possible that your
-output systems will see duplicate data right around the resumed epoch;
-design your systems to be idempotent or support at-least-once
+your input handlers in such a way that it jumps to the point in the
+input that corresponds to the `resume_epoch` argument; if it can't
+(because the input is ephemeral) you can still recover the dataflow,
+but the lost input is unable to be replayed so the output will be
+different.
+
+It is possible that your output systems will see duplicate data right
+around the resume epoch; design your systems to support at-least-once
 processing.
 
-Bytewax will automatically save and recover state from the recovery
-store during the execution of stateful operators. You know an operator
-is stateful when it takes a `step_id` argument.
+Recovery
+--------
+
+If the dataflow fails, first you must fix whatever underlying fault
+caused the issue. That might mean deploying new code which fixes a
+bug, removing bad data from a Kafka stream, or resolving an issue with
+a connected system.
+
+Once that is done, re-run the dataflow using the _same recovery
+config_. Bytewax will automatically recover state from the recovery
+store and tell your input handlers to fast forward to the resume
+epoch. Output should resume.
+
+If you want to fully _restart_ a dataflow and ignore previous state,
+you either have to create a recovery config that points at a new
+datastore or delete the recovery data in the datastore.
 
 """
 from .bytewax import RecoveryConfig, SqliteRecoveryConfig

--- a/pysrc/bytewax/recovery.py
+++ b/pysrc/bytewax/recovery.py
@@ -35,9 +35,8 @@ Recovery
 --------
 
 If the dataflow fails, first you must fix whatever underlying fault
-caused the issue. That might mean deploying new code which fixes a
-bug, removing bad data from a Kafka stream, or resolving an issue with
-a connected system.
+caused the issue. That might mean deploying new code which fixes a bug
+or resolving an issue with a connected system.
 
 Once that is done, re-run the dataflow using the _same recovery
 config_. Bytewax will automatically recover state from the recovery

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -164,8 +164,8 @@ def test_cluster_main_can_be_ctrl_c(mp_ctx):
         out = man.list()
 
         def proc_main():
-            def input_builder(worker_index, worker_count):
-                for epoch, item in inputs.fully_ordered(range(1000)):
+            def input_builder(worker_index, worker_count, resume_epoch):
+                for epoch, item in inputs.fully_ordered(range(resume_epoch, 1000)):
                     yield AdvanceTo(epoch)
                     yield Emit(item)
 

--- a/pytests/test_operators.py
+++ b/pytests/test_operators.py
@@ -3,7 +3,6 @@ import os
 from collections import defaultdict
 
 from bytewax import Dataflow, run, run_cluster
-from bytewax.recovery import SqliteRecoveryConfig
 from pytest import mark
 
 
@@ -167,50 +166,6 @@ def test_reduce():
     )
 
 
-def test_reduce_recovery(tmp_path):
-    recovery_config = SqliteRecoveryConfig(str(tmp_path / "state.sqlite3"), create=True)
-
-    inp1 = [
-        (0, ("blake", 5)),
-        (1, ("dan", 3)),
-        (2, ("blake", 5)),
-    ]
-
-    def is_10(total_points):
-        return total_points >= 10
-
-    def sum_total(total_points, points):
-        return total_points + points
-
-    flow = Dataflow()
-    flow.reduce("sum", sum_total, is_10)
-    flow.capture()
-
-    out1 = run(flow, inp1, recovery_config=recovery_config)
-
-    assert sorted(out1) == sorted(
-        [
-            (2, ("blake", 10)),
-        ]
-    )
-
-    # Simulate restart a little back at epoch 2.
-
-    inp2 = [
-        (2, ("blake", 10)),
-        (3, ("dan", 8)),
-    ]
-
-    out2 = run(flow, inp2, recovery_config=recovery_config)
-
-    assert sorted(out2) == sorted(
-        [
-            (2, ("blake", 15)),
-            (3, ("dan", 11)),
-        ]
-    )
-
-
 def test_reduce_epoch():
     def add_initial_count(event):
         return event["user"], 1
@@ -315,51 +270,6 @@ def test_stateful_map():
         [
             (0, "a"),
             (1, "b"),
-        ]
-    )
-
-
-def test_stateful_map_recovery(tmp_path):
-    recovery_config = SqliteRecoveryConfig(str(tmp_path / "state.sqlite3"), create=True)
-
-    inp1 = [
-        (0, ("a", 8)),
-        (1, ("b", 2)),
-        (2, ("a", 5)),
-    ]
-
-    def keep_max(previous_max, new_item):
-        if previous_max is None:
-            new_max = new_item
-        else:
-            new_max = max(previous_max, new_item)
-        return new_max, new_max
-
-    flow = Dataflow()
-    flow.stateful_map("max", lambda key: None, keep_max)
-    flow.capture()
-
-    out1 = run(flow, inp1, recovery_config=recovery_config)
-
-    assert sorted(out1) == sorted(
-        [
-            (0, ("a", 8)),
-            (1, ("b", 2)),
-            (2, ("a", 8)),
-        ]
-    )
-
-    inp2 = [
-        (2, ("a", 15)),
-        (3, ("b", 1)),
-    ]
-
-    out2 = run(flow, inp2, recovery_config=recovery_config)
-
-    assert sorted(out2) == sorted(
-        [
-            (2, ("a", 15)),
-            (3, ("b", 2)),
         ]
     )
 

--- a/pytests/test_recovery.py
+++ b/pytests/test_recovery.py
@@ -1,0 +1,249 @@
+from threading import Event
+
+from bytewax import AdvanceTo, Dataflow, Emit, run_main
+from bytewax.recovery import SqliteRecoveryConfig
+
+from pytest import fixture, raises
+
+
+RECOVERY_CONFIG_TYPES = [
+    "SqliteRecoveryConfig",
+]
+
+
+# Will run a version of each test in this file with each recovery
+# store type.
+def pytest_generate_tests(metafunc):
+    if "recovery_config" in metafunc.fixturenames:
+        metafunc.parametrize("recovery_config", RECOVERY_CONFIG_TYPES, indirect=True)
+
+
+@fixture
+def recovery_config(tmp_path, request):
+    if request.param == "SqliteRecoveryConfig":
+        yield SqliteRecoveryConfig(str(tmp_path / "state.sqlite3"), create=True)
+    else:
+        raise ValueError("unknown recovery config type: {request.param!r}")
+
+
+def test_recover_with_latest_state(recovery_config):
+    armed = Event()
+    armed.set()
+
+    def trigger(item):
+        """Odd numbers cause exception if armed."""
+        key, value = item
+        if armed.is_set() and value % 2 == 1:
+            raise RuntimeError("BOOM")
+        return item
+
+    def keep_max(previous_max, new_item):
+        if previous_max is None:
+            new_max = new_item
+        else:
+            new_max = max(previous_max, new_item)
+        return new_max, new_max
+
+    flow = Dataflow()
+    flow.map(trigger)
+    flow.stateful_map("keep_max", lambda key: None, keep_max)
+    flow.capture()
+
+    inp = [
+        ("a", 4),
+        ("b", 4),
+        ("a", 1),  # Will fail here on first pass cuz odd.
+        ("b", 1),
+    ]
+
+    def ib(i, n, r):
+        for epoch, item in enumerate(inp):
+            if epoch < r:
+                continue
+            yield Emit(item)
+            yield AdvanceTo(epoch + 1)
+
+    out = []
+
+    def ob(i, n):
+        return out.append
+
+    # First pass.
+    with raises(RuntimeError):
+        run_main(flow, ib, ob, recovery_config=recovery_config)
+
+    assert sorted(out) == sorted(
+        [
+            (0, ("a", 4)),
+            (1, ("b", 4)),
+        ]
+    )
+
+    # Disable bomb.
+    armed.clear()
+    out.clear()
+
+    # Recover.
+    run_main(flow, ib, ob, recovery_config=recovery_config)
+
+    assert sorted(out) == sorted(
+        [
+            (1, ("b", 4)),
+            (2, ("a", 4)),
+            (3, ("b", 4)),
+        ]
+    )
+
+
+def test_recover_doesnt_gc_last_write(recovery_config):
+    armed = Event()
+    armed.set()
+
+    def trigger(item):
+        """Odd numbers cause exception if armed."""
+        key, value = item
+        if armed.is_set() and value % 2 == 1:
+            raise RuntimeError("BOOM")
+        return item
+
+    def keep_max(previous_max, new_item):
+        if previous_max is None:
+            new_max = new_item
+        else:
+            new_max = max(previous_max, new_item)
+        return new_max, new_max
+
+    flow = Dataflow()
+    flow.map(trigger)
+    flow.stateful_map("keep_max", lambda key: None, keep_max)
+    flow.capture()
+
+    inp = [
+        (
+            "a",
+            4,
+        ),  # "a" is old enough to be GCd by time failure happens, but shouldn't be because the key hasn't been seen again.
+        ("b", 4),
+        ("b", 4),
+        ("b", 4),
+        ("b", 4),
+        ("b", 5),  # Will fail here on first pass cuz odd.
+        ("a", 1),
+    ]
+
+    def ib(i, n, r):
+        for epoch, item in enumerate(inp):
+            if epoch < r:
+                continue
+            yield Emit(item)
+            yield AdvanceTo(epoch + 1)
+
+    out = []
+
+    def ob(i, n):
+        return out.append
+
+    # First pass.
+    with raises(RuntimeError):
+        run_main(flow, ib, ob, recovery_config=recovery_config)
+
+    assert sorted(out) == sorted(
+        [
+            (0, ("a", 4)),
+            (1, ("b", 4)),
+            (2, ("b", 4)),
+            (3, ("b", 4)),
+            (4, ("b", 4)),
+        ]
+    )
+
+    # Disable bomb.
+    armed.clear()
+    out.clear()
+
+    # Recover.
+    run_main(flow, ib, ob, recovery_config=recovery_config)
+
+    assert sorted(out) == sorted(
+        [
+            (4, ("b", 4)),
+            (5, ("b", 5)),
+            (6, ("a", 4)),  # Remembered "a" => 4
+        ]
+    )
+
+
+def test_recover_respects_delete(recovery_config):
+    armed = Event()
+    armed.set()
+
+    def trigger(item):
+        """Odd numbers cause exception if armed."""
+        key, value = item
+        if armed.is_set() and value is not None and value % 2 == 1:
+            raise RuntimeError("BOOM")
+        return item
+
+    def keep_max(previous_max, new_item):
+        if previous_max is None:
+            new_max = new_item
+        else:
+            if new_item is not None:
+                new_max = max(previous_max, new_item)
+            else:
+                new_max = None
+        return new_max, new_max
+
+    flow = Dataflow()
+    flow.map(trigger)
+    flow.stateful_map("keep_max", lambda key: None, keep_max)
+    flow.capture()
+
+    inp = [
+        ("a", 4),
+        ("b", 4),
+        ("a", None),
+        ("b", 2),
+        ("b", 5),  # Will fail here on first pass cuz odd.
+        ("a", 2),  # Should be max for "a" on resume.
+    ]
+
+    def ib(i, n, r):
+        for epoch, item in enumerate(inp):
+            if epoch < r:
+                continue
+            yield Emit(item)
+            yield AdvanceTo(epoch + 1)
+
+    out = []
+
+    def ob(i, n):
+        return out.append
+
+    # First pass.
+    with raises(RuntimeError):
+        run_main(flow, ib, ob, recovery_config=recovery_config)
+
+    assert sorted(out) == sorted(
+        [
+            (0, ("a", 4)),
+            (1, ("b", 4)),
+            (2, ("a", None)),
+            (3, ("b", 4)),
+        ]
+    )
+
+    # Disable bomb.
+    armed.clear()
+    out.clear()
+
+    # Recover.
+    run_main(flow, ib, ob, recovery_config=recovery_config)
+
+    assert sorted(out) == sorted(
+        [
+            (3, ("b", 4)),
+            (4, ("b", 5)),
+            (5, ("a", 2)),  # Notice not 4.
+        ]
+    )

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -10,11 +10,182 @@ use std::time::Duration;
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+use timely::dataflow::operators::aggregation::*;
+use timely::dataflow::operators::*;
 use timely::dataflow::InputHandle;
 use timely::dataflow::ProbeHandle;
 
-use crate::dataflow::{build_dataflow, Dataflow};
+use crate::dataflow::{Dataflow, Step};
+use crate::operators::build;
+use crate::operators::check_complete;
+use crate::operators::stateful_map;
+use crate::operators::Reduce;
+use crate::operators::{
+    capture, filter, flat_map, inspect, inspect_epoch, map, reduce, reduce_epoch,
+    reduce_epoch_local, StatefulMap,
+};
+use crate::pyo3_extensions::{hash, lift_2tuple, wrap_2tuple};
 use crate::pyo3_extensions::{TdPyAny, TdPyCallable, TdPyIterator};
+use crate::recovery::NoOpRecoveryStore;
+use crate::recovery::RecoveryStore;
+use crate::recovery::SqliteRecoveryConfig;
+use crate::recovery::SqliteRecoveryStore;
+use std::collections::HashMap;
+
+pub(crate) fn build_dataflow<A>(
+    timely_worker: &mut timely::worker::Worker<A>,
+    py: Python,
+    flow: &Dataflow,
+    input_builder: TdPyCallable,
+    output_builder: TdPyCallable,
+    recovery_config: Option<Py<RecoveryConfig>>,
+) -> Result<(Pump, ProbeHandle<u64>), String>
+where
+    A: timely::communication::Allocate,
+{
+    let worker_index = timely_worker.index();
+    let worker_count = timely_worker.peers();
+
+    timely_worker.dataflow(|scope| {
+        let mut timely_input = InputHandle::new();
+        let mut end_of_steps_probe = ProbeHandle::new();
+        let mut has_capture = false;
+        let mut stream = timely_input.to_stream(scope);
+
+        let worker_input: TdPyIterator = input_builder
+            .call1(py, (worker_index, worker_count))
+            .unwrap()
+            .extract(py)
+            .unwrap();
+        let worker_output: TdPyCallable = output_builder
+            .call1(py, (worker_index, worker_count))
+            .unwrap()
+            .extract(py)
+            .unwrap();
+
+        let recovery_store: Box<dyn RecoveryStore> = match recovery_config {
+            None => Box::new(NoOpRecoveryStore::new()),
+            Some(recovery_config) => {
+                let recovery_config = recovery_config.as_ref(py);
+                if let Ok(sqlite_recovery_config) =
+                    recovery_config.downcast::<PyCell<SqliteRecoveryConfig>>()
+                {
+                    let sqlite_recovery_config = sqlite_recovery_config.borrow();
+                    Box::new(SqliteRecoveryStore::new(sqlite_recovery_config))
+                } else {
+                    let pytype = recovery_config.get_type();
+                    return Err(format!("Unknown recovery_config type: {pytype}"));
+                }
+            }
+        };
+
+        let steps = &flow.steps;
+        for step in steps {
+            match step {
+                Step::Map { mapper } => {
+                    // All these closure lifetimes are static, so tell
+                    // Python's GC that there's another pointer to the
+                    // mapping function that's going to hang around
+                    // for a while when it's moved into the closure.
+                    let mapper = mapper.clone_ref(py);
+                    stream = stream.map(move |item| map(&mapper, item));
+                }
+                Step::FlatMap { mapper } => {
+                    let mapper = mapper.clone_ref(py);
+                    stream = stream.flat_map(move |item| flat_map(&mapper, item));
+                }
+                Step::Filter { predicate } => {
+                    let predicate = predicate.clone_ref(py);
+                    stream = stream.filter(move |item| filter(&predicate, item));
+                }
+                Step::Inspect { inspector } => {
+                    let inspector = inspector.clone_ref(py);
+                    stream = stream.inspect(move |item| inspect(&inspector, item));
+                }
+                Step::InspectEpoch { inspector } => {
+                    let inspector = inspector.clone_ref(py);
+                    stream = stream
+                        .inspect_time(move |epoch, item| inspect_epoch(&inspector, epoch, item));
+                }
+                Step::Reduce {
+                    step_id,
+                    reducer,
+                    is_complete,
+                } => {
+                    let reducer = reducer.clone_ref(py);
+                    let is_complete = is_complete.clone_ref(py);
+                    stream = stream
+                        .map(lift_2tuple)
+                        .reduce(
+                            recovery_store.for_step(step_id),
+                            move |key, aggregator, value| reduce(&reducer, key, aggregator, value),
+                            move |key, aggregator| check_complete(&is_complete, key, aggregator),
+                            hash,
+                        )
+                        .map(wrap_2tuple);
+                }
+                Step::ReduceEpoch { reducer } => {
+                    let reducer = reducer.clone_ref(py);
+                    stream = stream.map(lift_2tuple).aggregate(
+                        move |key, value, aggregator: &mut Option<TdPyAny>| {
+                            reduce_epoch(&reducer, aggregator, key, value);
+                        },
+                        move |key, aggregator: Option<TdPyAny>| {
+                            // Aggregator will only exist for keys
+                            // that exist, so it will have been filled
+                            // into Some(value) above.
+                            wrap_2tuple((key, aggregator.unwrap()))
+                        },
+                        hash,
+                    );
+                }
+                Step::ReduceEpochLocal { reducer } => {
+                    let reducer = reducer.clone_ref(py);
+                    stream = stream
+                        .map(lift_2tuple)
+                        .accumulate(
+                            HashMap::new(),
+                            move |aggregators, all_key_value_in_epoch| {
+                                reduce_epoch_local(&reducer, aggregators, &all_key_value_in_epoch);
+                            },
+                        )
+                        .flat_map(|aggregators| aggregators.into_iter().map(wrap_2tuple));
+                }
+                Step::StatefulMap {
+                    step_id,
+                    builder,
+                    mapper,
+                } => {
+                    let builder = builder.clone_ref(py);
+                    let mapper = mapper.clone_ref(py);
+                    stream = stream
+                        .map(lift_2tuple)
+                        .stateful_map(
+                            recovery_store.for_step(step_id),
+                            move |key| build(&builder, key),
+                            move |key, state, value| stateful_map(&mapper, key, state, value),
+                            hash,
+                        )
+                        .map(wrap_2tuple);
+                }
+                Step::Capture {} => {
+                    let worker_output = worker_output.clone_ref(py);
+                    stream
+                        .inspect_time(move |epoch, item| capture(&worker_output, epoch, item))
+                        .probe_with(&mut end_of_steps_probe);
+                    has_capture = true;
+                }
+            }
+        }
+
+        if has_capture {
+            let pump = Pump::new(worker_input, timely_input);
+            Ok((pump, end_of_steps_probe))
+        } else {
+            Err("Dataflow needs to contain at least one capture".into())
+        }
+    })
+}
 
 #[pyclass(module = "bytewax")]
 #[pyo3(text_signature = "(epoch)")]

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -398,8 +398,10 @@ where
 ///
 /// >>> flow = Dataflow()
 /// >>> flow.capture()
-/// >>> def input_builder(worker_index, worker_count):
-/// ...     return enumerate(range(3))
+/// >>> def input_builder(worker_index, worker_count, resume_epoch):
+/// ...     for epoch, item in enumerate(range(resume_epoch, 3)):
+/// ...         yield AdvanceTo(epoch)
+/// ...         yield Emit(item)
 /// >>> def output_builder(worker_index, worker_count):
 /// ...     return print
 /// >>> run_main(flow, input_builder, output_builder)  # doctest: +ELLIPSIS
@@ -415,10 +417,8 @@ where
 ///
 ///     flow: Dataflow to run.
 ///
-///     input_builder: Returns input that each worker thread should
-///         process. If you are recovering a stateful dataflow, you
-///         must ensure your input resumes from the last finalized
-///         epoch.
+///     input_builder: Yields `AdvanceTo()` or `Emit()` with this
+///         worker's input. Must resume from the epoch specified.
 ///
 ///     output_builder: Returns a callback function for each worker
 ///         thread, called with `(epoch, item)` whenever and item
@@ -489,8 +489,10 @@ pub(crate) fn run_main(
 /// Blocks until execution is complete.
 ///
 /// >>> flow = Dataflow()
-/// >>> def input_builder(worker_index, worker_count):
-/// ...     return enumerate(range(3))
+/// >>> def input_builder(worker_index, worker_count, resume_epoch):
+/// ...     for epoch, item in enumerate(range(resume_epoch, 3)):
+/// ...         yield AdvanceTo(epoch)
+/// ...         yield Emit(item)
 /// >>> def output_builder(worker_index, worker_count):
 /// ...     return print
 /// >>> cluster_main(flow, input_builder, output_builder)  # doctest: +ELLIPSIS
@@ -509,11 +511,8 @@ pub(crate) fn run_main(
 ///
 ///     flow: Dataflow to run.
 ///
-///     input_builder: Returns input that each worker thread should
-///         process. Should yield either `AdvanceTo` or `Send` to
-///         advance the epoch, or input new data into the dataflow.
-///         If you are recovering a stateful dataflow, you must ensure
-///         your input resumes from the last finalized epoch.
+///     input_builder: Yields `AdvanceTo()` or `Emit()` with this
+///         worker's input. Must resume from the epoch specified.
 ///
 ///     output_builder: Returns a callback function for each worker
 ///         thread, called with `(epoch, item)` whenever and item

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -723,11 +723,17 @@ where
                 // in-progress epoch. Thus -1 is the epoch who's state
                 // we need to fully recreate during recovery and we
                 // shouldn't GC it. Thus -2 is the first GC-able
-                // epoch. And then since there's no
-                // [`Anitchain::greater_than()`], we use !less_than().
+                // epoch. We'd like to be able to write
+                // `dataflow_frontier - 2 >= epoch` but since there's
+                // no [`Anitchain::greater_than()`], we use
+                // `!less_than()` and since you can't do math on the
+                // frontier set, we move the `-2` to the other side
+                // and it becomes `+2`.
+
                 // TODO: Is there a way to do this without a fixed
                 // offset? It feels kinda hacky and would be cool to
                 // support arbitrary timestamp types.
+
                     |epoch: &u64| -> bool { !dataflow_frontier.less_than(&(epoch + 2)) };
                 // We save the dataflow frontier here in the garbage
                 // collector and not in the dataflow frontier operator

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -173,11 +173,12 @@ impl<S: Scope, K: ExchangeData + Hash + Eq, V: ExchangeData> Reduce<S, K, V> for
                                         value
                                     };
 
-                                // Save the aggregator so we can use it if
-                                // multiple values within this epoch. We
-                                // do not save to the recovery store here
-                                // because we don't have finalized state
-                                // for the epoch.
+                                // Save the aggregator so we can use
+                                // it if there are multiple values
+                                // within this epoch. We do not save
+                                // to the recovery store here because
+                                // we don't have finalized state for
+                                // the epoch.
                                 if is_complete(&key, &updated_aggregator_for_key) {
                                     let mut downstream_output_session =
                                         downstream_output_handle.session(&downstream_cap);
@@ -450,10 +451,11 @@ impl<S: Scope, K: ExchangeData + Hash + Eq, V: ExchangeData> StatefulMap<S, K, V
                                 );
 
                                 // Save the state so we can use it if
-                                // multiple values within this epoch. We
-                                // do not save to the recovery store here
-                                // because we don't have finalized state
-                                // for the epoch.
+                                // there are multiple values within
+                                // this epoch. We do not save to the
+                                // recovery store here because we
+                                // don't have finalized state for the
+                                // epoch.
                                 if let Some(updated_state) = updated_state_for_key {
                                     state_cache.insert(key.clone(), updated_state);
                                 } else {

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -1,9 +1,27 @@
-/// These are all shims which map the Timely Rust API into equivalent
-/// calls to Python functions through PyO3.
-use crate::recovery::StepRecovery;
+//! Code implementing Bytewax's operators on top of Timely's
+//! operators.
+//!
+//! The two big things in here are:
+//!
+//!     1. Totally custom Timely operators to implement Bytewax's
+//!     behavior.
+//!
+//!     2. Shim functions that totally encapsulate PyO3 and Python
+//!     calling boilerplate to easily pass into Timely operators.
+
+use crate::dataflow::StepId;
+use crate::recovery::RecoveryStore;
+use crate::recovery::UpdateType;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fmt::Debug;
 use std::hash::Hash;
+use std::rc::Rc;
 use timely::dataflow::channels::pact;
+use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use timely::dataflow::operators::generic::FrontieredInputHandle;
+use timely::dataflow::operators::FrontierNotificator;
 use timely::dataflow::operators::Operator;
 use timely::dataflow::Scope;
 use timely::dataflow::Stream;
@@ -65,17 +83,20 @@ pub(crate) fn inspect_epoch(inspector: &TdPyCallable, epoch: &u64, item: &TdPyAn
 // Based on the good work in
 // https://github.com/TimelyDataflow/timely-dataflow/blob/0d0d84885672d6369a78cd9aff7beb2048390d3b/timely/src/dataflow/operators/aggregation/state_machine.rs#L57
 pub(crate) trait Reduce<S: Scope, K: ExchangeData + Hash + Eq, V: ExchangeData> {
+    /// First return stream is reduction output, second is aggregator
+    /// updates for recovery you'll probably pass into a [`Backup`]
+    /// operator.
     fn reduce<
         R: Fn(&K, V, V) -> V + 'static,  // Reducer
         C: Fn(&K, &V) -> bool + 'static, // Is reduction complete and send aggregator downstream?
         H: Fn(&K) -> u64 + 'static,      // Hash function of key to worker
     >(
         &self,
-        store: Box<dyn StepRecovery<S::Timestamp, K, V>>,
+        state_cache: HashMap<K, V>,
         reducer: R,
         is_complete: C,
         hasher: H,
-    ) -> Stream<S, (K, V)>
+    ) -> (Stream<S, (K, V)>, Stream<S, (K, Option<V>)>)
     where
         S::Timestamp: Hash + Eq;
 }
@@ -87,106 +108,129 @@ impl<S: Scope, K: ExchangeData + Hash + Eq, V: ExchangeData> Reduce<S, K, V> for
         H: Fn(&K) -> u64 + 'static,      // Hash function of key to worker
     >(
         &self,
-        store: Box<dyn StepRecovery<S::Timestamp, K, V>>,
+        mut state_cache: HashMap<K, V>,
         reducer: R,
         is_complete: C,
         hasher: H,
-    ) -> Stream<S, (K, V)> {
-        let mut tmp_key_values: Vec<(K, V)> = Vec::new();
+    ) -> (Stream<S, (K, V)>, Stream<S, (K, Option<V>)>) {
+        let mut op_builder = OperatorBuilder::new("Reduce".to_owned(), self.scope());
 
-        let mut epoch_to_key_values_buffer: HashMap<S::Timestamp, Vec<(K, V)>> = HashMap::new();
-        // A value will not exist in the hash map if we need to go to
-        // the recovery store to check for a value, but will exist and
-        // be None if it has been reset by logic code.
-        let mut state_cache: HashMap<K, Option<V>> = HashMap::new();
-        // Fill this with which keys have had their state updated and
-        // flush to recovery store each epoch. Will be emptied after
-        // each epoch.
-        let mut updated_keys_buffer = Vec::new();
-
-        self.unary_notify(
+        let mut input = op_builder.new_input(
+            self,
             pact::Exchange::new(move |&(ref key, ref _value)| hasher(key)),
-            "Reduce",
-            vec![],
-            move |input, output, ncater| {
-                input.for_each(|time, key_values| {
+        );
+
+        let (mut downstream_output_wrapper, downstream_stream) = op_builder.new_output();
+        let (mut state_update_output_wrapper, state_update_stream) = op_builder.new_output();
+
+        op_builder.build(move |_init_capabilities| {
+            let mut tmp_key_values = Vec::new();
+            let mut incoming_epoch_to_key_values_buffer = HashMap::new();
+
+            let mut tmp_updated_keys = HashSet::new();
+            let mut outgoing_epoch_to_state_updates_buffer = HashMap::new();
+
+            let mut downstream_fncater = FrontierNotificator::new();
+            let mut state_update_fncater = FrontierNotificator::new();
+            move |input_frontiers| {
+                let mut input_handle = FrontieredInputHandle::new(&mut input, &input_frontiers[0]);
+                let mut downstream_output_handle = downstream_output_wrapper.activate();
+                let mut state_update_output_handle = state_update_output_wrapper.activate();
+
+                input_handle.for_each(|cap, key_values| {
                     key_values.swap(&mut tmp_key_values);
 
-                    epoch_to_key_values_buffer
-                        .entry(time.time().clone())
+                    let epoch = cap.time();
+                    incoming_epoch_to_key_values_buffer
+                        .entry(epoch.clone())
                         .or_insert_with(Vec::new)
                         .extend(tmp_key_values.drain(..));
 
-                    ncater.notify_at(time.retain());
+                    downstream_fncater.notify_at(cap.delayed_for_output(epoch, 0));
+                    state_update_fncater.notify_at(cap.delayed_for_output(epoch, 1));
                 });
 
                 // This runs once per epoch that will be no longer be
                 // seen in the input of this operator (not the whole
                 // dataflow, though).
-                ncater.for_each(|time, _, _| {
-                    let timestamp = time.time();
-                    if let Some(key_values) = epoch_to_key_values_buffer.remove(timestamp) {
-                        let mut output_session = output.session(&time);
-                        // TODO: Fetch all new keys in one DB round
-                        // trip?
-                        for (key, value) in key_values {
-                            let aggregator_for_key = state_cache
-                                .remove(&key)
-                                // If we've never seen this key before
-                                // (not even in the state cache),
-                                .unwrap_or_else(|| {
-                                    // Find what the last aggregator
-                                    // for this key was in the
-                                    // recovery store, which might be
-                                    // explicitly (the logic threw it
-                                    // away by returning None) or
-                                    // implicitly (a new key we've
-                                    // never seen) None.
-                                    store.recover_last(time.time(), &key)
-                                });
+                downstream_fncater.for_each(
+                    &[input_handle.frontier()],
+                    |downstream_cap, _ncater| {
+                        let epoch = downstream_cap.time();
+                        if let Some(key_values) = incoming_epoch_to_key_values_buffer.remove(epoch)
+                        {
+                            for (key, value) in key_values {
+                                let aggregator_for_key = state_cache.remove(&key);
 
-                            let updated_aggregator_for_key =
-                                if let Some(aggregator_for_key) = aggregator_for_key {
-                                    // If there's previous aggregator,
-                                    // reduce.
-                                    reducer(&key, aggregator_for_key, value)
+                                let updated_aggregator_for_key =
+                                    if let Some(aggregator_for_key) = aggregator_for_key {
+                                        // If there's previous aggregator,
+                                        // reduce.
+                                        reducer(&key, aggregator_for_key, value)
+                                    } else {
+                                        // If there's no previous aggregator,
+                                        // pass through the current value.
+                                        value
+                                    };
+
+                                // Save the aggregator so we can use it if
+                                // multiple values within this epoch. We
+                                // do not save to the recovery store here
+                                // because we don't have finalized state
+                                // for the epoch.
+                                if is_complete(&key, &updated_aggregator_for_key) {
+                                    let mut downstream_output_session =
+                                        downstream_output_handle.session(&downstream_cap);
+                                    downstream_output_session
+                                        .give((key.clone(), updated_aggregator_for_key));
+                                    state_cache.remove(&key);
                                 } else {
-                                    // If there's no previous aggregator,
-                                    // pass through the current value.
-                                    value
-                                };
+                                    state_cache.insert(key.clone(), updated_aggregator_for_key);
+                                }
+                                // Note which keys have had their state
+                                // modified. Write that updated state to
+                                // the recovery store once the epoch is
+                                // complete.
+                                tmp_updated_keys.insert(key);
+                            }
 
-                            // Note which keys have had their state
-                            // modified. Write that updated state to
-                            // the recovery store once the epoch is
-                            // complete.
-                            updated_keys_buffer.push(key.clone());
-                            // Save the aggregator so we can use it if
-                            // multiple values within this epoch. We
-                            // do not save to the recovery store here
-                            // because we don't have finalized state
-                            // for the epoch.
-                            if is_complete(&key, &updated_aggregator_for_key) {
-                                output_session.give((key.clone(), updated_aggregator_for_key));
-                                state_cache.insert(key, None);
-                            } else {
-                                state_cache.insert(key, Some(updated_aggregator_for_key));
+                            // Now that this epoch is over, find the final
+                            // updated state for all keys that were
+                            // touched and save that to be emitted
+                            // downstream for the second output.
+                            for key in tmp_updated_keys.drain() {
+                                let updated_state = state_cache.get(&key).cloned();
+                                outgoing_epoch_to_state_updates_buffer
+                                    .entry(epoch.clone())
+                                    .or_insert_with(Vec::new)
+                                    .push((key, updated_state));
                             }
                         }
+                    },
+                );
 
-                        // Now that this epoch is complete, write out
-                        // any modified state.
-                        for key in updated_keys_buffer.drain(..) {
-                            if let Some(updated_aggregator_for_key) = state_cache.get(&key) {
-                                // TODO: Save all updated keys in one DB
-                                // round trip?
-                                store.save_complete(time.time(), &key, updated_aggregator_for_key);
+                state_update_fncater.for_each(
+                    &[input_handle.frontier()],
+                    |state_update_cap, _ncater| {
+                        let epoch = state_update_cap.time();
+                        let mut state_update_output_session =
+                            state_update_output_handle.session(&state_update_cap);
+                        // Now that this epoch is complete, write out any
+                        // modified state. `remove()` will ensure we
+                        // slowly drain the buffer.
+                        if let Some(state_updates) =
+                            outgoing_epoch_to_state_updates_buffer.remove(epoch)
+                        {
+                            for (key, updated_state) in state_updates {
+                                state_update_output_session.give((key, updated_state));
                             }
                         }
-                    }
-                });
-            },
-        )
+                    },
+                );
+            }
+        });
+
+        (downstream_stream, state_update_stream)
     }
 }
 
@@ -297,20 +341,22 @@ pub(crate) fn reduce_epoch_local(
 // Based on the good work in
 // https://github.com/TimelyDataflow/timely-dataflow/blob/0d0d84885672d6369a78cd9aff7beb2048390d3b/timely/src/dataflow/operators/aggregation/state_machine.rs#L57
 pub(crate) trait StatefulMap<S: Scope, K: ExchangeData + Hash + Eq, V: ExchangeData> {
+    /// First return stream is output, second is state updates for
+    /// recovery you'll probably pass into a [`Backup`] operator.
     fn stateful_map<
         R: Data,                                     // Output item type
-        D: 'static,                                  // Per-key state
+        D: Data,                                     // Per-key state
         I: IntoIterator<Item = R>,                   // Iterator of output items
         B: Fn(&K) -> D + 'static,                    // Builder of new per-key state
         M: Fn(&K, D, V) -> (Option<D>, I) + 'static, // Mapper
         H: Fn(&K) -> u64 + 'static,                  // Hash function of key to worker
     >(
         &self,
-        store: Box<dyn StepRecovery<S::Timestamp, K, D>>,
+        state_cache: HashMap<K, D>,
         builder: B,
         mapper: M,
         hasher: H,
-    ) -> Stream<S, (K, R)>
+    ) -> (Stream<S, (K, R)>, Stream<S, (K, Option<D>)>)
     where
         S::Timestamp: Hash + Eq;
 }
@@ -320,105 +366,141 @@ impl<S: Scope, K: ExchangeData + Hash + Eq, V: ExchangeData> StatefulMap<S, K, V
 {
     fn stateful_map<
         R: Data,                                     // Output item type
-        D: 'static,                                  // Per-key state
+        D: Data,                                     // Per-key state
         I: IntoIterator<Item = R>,                   // Iterator of output items
         B: Fn(&K) -> D + 'static,                    // Builder of new per-key state
         M: Fn(&K, D, V) -> (Option<D>, I) + 'static, // Mapper
         H: Fn(&K) -> u64 + 'static,                  // Hash function of key to worker
     >(
         &self,
-        store: Box<dyn StepRecovery<S::Timestamp, K, D>>,
+        mut state_cache: HashMap<K, D>,
         builder: B,
         mapper: M,
         hasher: H,
-    ) -> Stream<S, (K, R)> {
-        let mut tmp_key_values: Vec<(K, V)> = Vec::new();
+    ) -> (Stream<S, (K, R)>, Stream<S, (K, Option<D>)>) {
+        let mut op_builder = OperatorBuilder::new("StatefulMap".to_owned(), self.scope());
 
-        let mut epoch_to_key_values_buffer: HashMap<S::Timestamp, Vec<(K, V)>> = HashMap::new();
-        // A value will not exist in the hash map if we need to go to
-        // the recovery store to check for a value, but will exist and
-        // be None if it has been reset by logic code.
-        let mut state_cache: HashMap<K, Option<D>> = HashMap::new();
-        // Fill this with which keys have had their state updated and
-        // flush to recovery store each epoch. Will be emptied after
-        // each epoch.
-        let mut updated_keys_buffer = Vec::new();
-
-        self.unary_notify(
+        let mut input = op_builder.new_input(
+            self,
             pact::Exchange::new(move |&(ref key, ref _value)| hasher(key)),
-            "StatefulMap",
-            vec![],
-            move |input, output, ncater| {
-                input.for_each(|time, key_values| {
+        );
+
+        let (mut downstream_output_wrapper, downstream_stream) = op_builder.new_output();
+        let (mut state_update_output_wrapper, state_update_stream) = op_builder.new_output();
+
+        op_builder.build(move |_init_capabilities| {
+            let mut tmp_key_values = Vec::new();
+            let mut incoming_epoch_to_key_values_buffer = HashMap::new();
+
+            let mut tmp_updated_keys = HashSet::new();
+            let mut outgoing_epoch_to_state_updates_buffer = HashMap::new();
+
+            // We have to jump through hoops to retain separate
+            // capabilities per-output. See
+            // https://github.com/TimelyDataflow/timely-dataflow/pull/187
+            let mut downstream_fncater = FrontierNotificator::new();
+            let mut state_update_fncater = FrontierNotificator::new();
+            move |input_frontiers| {
+                let mut input_handle = FrontieredInputHandle::new(&mut input, &input_frontiers[0]);
+                let mut downstream_output_handle = downstream_output_wrapper.activate();
+                let mut state_update_output_handle = state_update_output_wrapper.activate();
+
+                input_handle.for_each(|cap, key_values| {
                     key_values.swap(&mut tmp_key_values);
 
-                    epoch_to_key_values_buffer
-                        .entry(time.time().clone())
+                    let epoch = cap.time();
+                    incoming_epoch_to_key_values_buffer
+                        .entry(epoch.clone())
                         .or_insert_with(Vec::new)
                         .extend(tmp_key_values.drain(..));
 
-                    ncater.notify_at(time.retain());
+                    // AFAICT, ports are in order of `new_output()`
+                    // calls. Also I don't understand how to use
+                    // `retain_for_output()` multiple times since it
+                    // takes an owned
+                    // capability. `delayed_for_output()` seems to
+                    // work but might be incorrect?
+                    downstream_fncater.notify_at(cap.delayed_for_output(epoch, 0));
+                    state_update_fncater.notify_at(cap.delayed_for_output(epoch, 1));
                 });
 
                 // This runs once per epoch that will be no longer be
                 // seen in the input of this operator (not the whole
                 // dataflow, though).
-                ncater.for_each(|time, _, _| {
-                    let timestamp = time.time();
-                    if let Some(key_values) = epoch_to_key_values_buffer.remove(timestamp) {
-                        let mut output_session = output.session(&time);
-                        // TODO: Fetch all new keys in one DB round
-                        // trip?
-                        for (key, value) in key_values {
-                            let state_for_key = state_cache
-                                .remove(&key)
-                                // If we've never seen this key before
-                                // (not even in the state cache),
-                                .unwrap_or_else(|| {
-                                    // Find what the last state for
-                                    // this key was in the recovery
-                                    // store, which might be
-                                    // explicitly (the logic threw it
-                                    // away by returning None) or
-                                    // implicitly (a new key we've
-                                    // never seen) None.
-                                    store.recover_last(time.time(), &key)
-                                })
-                                // If there's no previous state, build
-                                // anew.
-                                .unwrap_or_else(|| builder(&key));
+                downstream_fncater.for_each(
+                    &[input_handle.frontier()],
+                    |downstream_cap, _ncater| {
+                        let epoch = downstream_cap.time();
+                        if let Some(key_values) = incoming_epoch_to_key_values_buffer.remove(epoch)
+                        {
+                            let mut downstream_output_session =
+                                downstream_output_handle.session(&downstream_cap);
+                            for (key, value) in key_values {
+                                let state_for_key = state_cache
+                                    .remove(&key)
+                                    // If there's no previous state, build
+                                    // anew.
+                                    .unwrap_or_else(|| builder(&key));
 
-                            let (updated_state_for_key, output) =
-                                mapper(&key, state_for_key, value);
+                                let (updated_state_for_key, output) =
+                                    mapper(&key, state_for_key, value);
 
-                            // Note which keys have had their state
-                            // modified. Write that updated state to
-                            // the recovery store once the epoch is
-                            // complete.
-                            updated_keys_buffer.push(key.clone());
-                            output_session
-                                .give_iterator(output.into_iter().map(|item| (key.clone(), item)));
-                            // Save the state so we can use it if
-                            // multiple values within this epoch. We
-                            // do not save to the recovery store here
-                            // because we don't have finalized state
-                            // for the epoch.
-                            state_cache.insert(key, updated_state_for_key);
-                        }
+                                downstream_output_session.give_iterator(
+                                    output.into_iter().map(|item| (key.clone(), item)),
+                                );
 
-                        // Now that this epoch is complete, write out
-                        // any modified state.
-                        for key in updated_keys_buffer.drain(..) {
-                            if let Some(updated_state_for_key) = state_cache.get(&key) {
-                                // TODO: Save all updated keys in one DB
-                                // round trip?
-                                store.save_complete(time.time(), &key, updated_state_for_key);
+                                // Save the state so we can use it if
+                                // multiple values within this epoch. We
+                                // do not save to the recovery store here
+                                // because we don't have finalized state
+                                // for the epoch.
+                                if let Some(updated_state) = updated_state_for_key {
+                                    state_cache.insert(key.clone(), updated_state);
+                                } else {
+                                    state_cache.remove(&key);
+                                }
+                                // Note which keys have had their state
+                                // updated.
+                                tmp_updated_keys.insert(key);
+                            }
+
+                            // Now that this epoch is over, find the final
+                            // updated state for all keys that were
+                            // touched and save that to be emitted
+                            // downstream for the second output.
+                            for key in tmp_updated_keys.drain() {
+                                let updated_state = state_cache.get(&key).cloned();
+                                outgoing_epoch_to_state_updates_buffer
+                                    .entry(epoch.clone())
+                                    .or_insert_with(Vec::new)
+                                    .push((key, updated_state));
                             }
                         }
-                    }
-                });
-            },
-        )
+                    },
+                );
+
+                state_update_fncater.for_each(
+                    &[input_handle.frontier()],
+                    |state_update_cap, _ncater| {
+                        let epoch = state_update_cap.time();
+                        let mut state_update_output_session =
+                            state_update_output_handle.session(&state_update_cap);
+                        // Now that this epoch is complete, write out any
+                        // modified state. `remove()` will ensure we
+                        // slowly drain the buffer.
+                        if let Some(state_updates) =
+                            outgoing_epoch_to_state_updates_buffer.remove(epoch)
+                        {
+                            for (key, updated_state) in state_updates {
+                                state_update_output_session.give((key, updated_state));
+                            }
+                        }
+                    },
+                );
+            }
+        });
+
+        (downstream_stream, state_update_stream)
     }
 }
 
@@ -451,4 +533,250 @@ pub(crate) fn stateful_map(
 
 pub(crate) fn capture(captor: &TdPyCallable, epoch: &u64, item: &TdPyAny) {
     Python::with_gil(|py| with_traceback!(py, captor.call1(py, ((*epoch, item.clone_ref(py)),))));
+}
+
+/// Utility operator which persists state changes coming out of the
+/// stateful operators to the recovery store.
+///
+/// Emits a stream of update summaries for use in garbage collection.
+pub(crate) trait Backup<S: Scope, K: ExchangeData + Hash + Eq, D: ExchangeData> {
+    fn backup(
+        &self,
+        step_id: StepId,
+        recovery_writer: Rc<Box<dyn RecoveryStore<S::Timestamp, K, D>>>,
+    ) -> Stream<S, (StepId, K, UpdateType)>
+    where
+        S::Timestamp: Hash + Eq;
+}
+
+impl<S: Scope, K: ExchangeData + Hash + Eq, D: ExchangeData> Backup<S, K, D>
+    for Stream<S, (K, Option<D>)>
+{
+    fn backup(
+        &self,
+        step_id: StepId,
+        recovery_writer: Rc<Box<dyn RecoveryStore<S::Timestamp, K, D>>>,
+    ) -> Stream<S, (StepId, K, UpdateType)> {
+        self.unary(pact::Pipeline, "Backup", |_init_capability, _info| {
+            let mut items_buffer = Vec::new();
+            move |input, output| {
+                input.for_each(|cap, data| {
+                    data.swap(&mut items_buffer);
+                    let epoch = cap.time();
+
+                    let mut output_session = output.session(&cap);
+                    for (key, updated_state) in items_buffer.drain(..) {
+                        recovery_writer.save_state(&step_id, &key, epoch, &updated_state);
+                        output_session.give((step_id.clone(), key, updated_state.into()));
+                    }
+                });
+            }
+        })
+    }
+}
+
+/// Utility operator which calculates the dataflow frontier.
+///
+/// Connect to all backups and captures in the dataflow during
+/// building.
+///
+/// It outputs a kind of "heartbeat" `()` but the epochs attached to
+/// that will be the dataflow frontiers.
+pub(crate) trait DataflowFrontier<S: Scope, K: ExchangeData + Hash + Eq> {
+    fn dataflow_frontier<IB, IC>(&self, backups: IB, captures: IC) -> Stream<S, ()>
+    where
+        IB: IntoIterator<Item = Stream<S, (StepId, K, UpdateType)>>,
+        IC: IntoIterator<Item = Stream<S, TdPyAny>>;
+}
+
+impl<S: Scope, K: ExchangeData + Hash + Eq> DataflowFrontier<S, K> for S {
+    fn dataflow_frontier<IB, IC>(&self, backups: IB, captures: IC) -> Stream<S, ()>
+    where
+        IB: IntoIterator<Item = Stream<S, (StepId, K, UpdateType)>>,
+        IC: IntoIterator<Item = Stream<S, TdPyAny>>,
+    {
+        let mut op_builder = OperatorBuilder::new("DataflowFrontier".to_string(), self.clone());
+
+        let mut backup_inputs = backups
+            .into_iter()
+            .map(|s| op_builder.new_input(&s, pact::Pipeline))
+            .collect::<Vec<_>>();
+        let mut capture_inputs = captures
+            .into_iter()
+            .map(|s| op_builder.new_input(&s, pact::Pipeline))
+            .collect::<Vec<_>>();
+
+        let (mut output_wrapper, stream) = op_builder.new_output();
+
+        op_builder.build(move |_init_capabilities| {
+            let mut fncater = FrontierNotificator::new();
+            move |input_frontiers| {
+                let mut output_handle = output_wrapper.activate();
+
+                for input in backup_inputs.iter_mut() {
+                    input.for_each(|cap, _data| {
+                        fncater.notify_at(cap.retain());
+                    });
+                }
+                for input in capture_inputs.iter_mut() {
+                    input.for_each(|cap, _data| {
+                        fncater.notify_at(cap.retain());
+                    });
+                }
+
+                // I don't get
+                // this. https://stackoverflow.com/questions/37797242/how-to-get-a-slice-of-references-from-a-vector-in-rust
+                let tmp_input_frontiers = &input_frontiers.iter().collect::<Vec<_>>();
+                fncater.for_each(tmp_input_frontiers, |cap, _ncater| {
+                    output_handle.session(&cap).give(());
+                });
+            }
+        });
+
+        stream
+    }
+}
+
+/// Utility operator which listens to the dataflow frontier and
+/// streams of backup summaries and will coordinate with the recovery
+/// store to garbage collect old state.
+///
+/// It also records the dataflow frontier.
+///
+/// This should be called on the dataflow frontier stream itself.
+pub(crate) trait GarbageCollector<S: Scope, K: ExchangeData + Hash + Eq> {
+    fn garbage_collector<IB, D: 'static>(
+        &self,
+        recovery_store_summary: Vec<(StepId, K, S::Timestamp, UpdateType)>,
+        backups: IB,
+        recovery_collector: Rc<Box<dyn RecoveryStore<S::Timestamp, K, D>>>,
+    ) where
+        IB: IntoIterator<Item = Stream<S, (StepId, K, UpdateType)>>;
+}
+
+impl<S, K: ExchangeData + Hash + Eq + Debug> GarbageCollector<S, K> for Stream<S, ()>
+where
+    S: Scope<Timestamp = u64>,
+{
+    fn garbage_collector<IB, D: 'static>(
+        &self,
+        recovery_store_log: Vec<(StepId, K, S::Timestamp, UpdateType)>,
+        backups: IB,
+        recovery_collector: Rc<Box<dyn RecoveryStore<S::Timestamp, K, D>>>,
+    ) where
+        IB: IntoIterator<Item = Stream<S, (StepId, K, UpdateType)>>,
+    {
+        let mut op_builder = OperatorBuilder::new("GarbageCollector".to_string(), self.scope());
+
+        let mut dataflow_frontier_input = op_builder.new_input(self, pact::Pipeline);
+        let mut backup_inputs = backups
+            .into_iter()
+            .map(|s| op_builder.new_input(&s, pact::Pipeline))
+            .collect::<Vec<_>>();
+
+        op_builder.build(move |_init_capabilities| {
+            let mut tmp_recovery_keys = Vec::new();
+            let mut garbage_key_buffer = Vec::new();
+            let mut recovery_store_summary: HashMap<
+                (StepId, K),
+                BTreeSet<(S::Timestamp, UpdateType)>,
+            > = HashMap::new();
+
+            // Load the initial summary of the recovery store into
+            // this special query structure in memory.
+            for (step_id, key, epoch, update_type) in recovery_store_log {
+                recovery_store_summary
+                    .entry((step_id, key))
+                    .or_default()
+                    .insert((epoch, update_type));
+            }
+
+            move |input_frontiers| {
+                let mut dataflow_frontier_input_handle =
+                    FrontieredInputHandle::new(&mut dataflow_frontier_input, &input_frontiers[0]);
+
+                // Gotta drain the data on this input to advance its
+                // frontier, even if we do nothing with it.
+                dataflow_frontier_input_handle.for_each(|_cap, _data| {});
+
+                for input in backup_inputs.iter_mut() {
+                    input.for_each(|cap, data| {
+                        data.swap(&mut tmp_recovery_keys);
+                        let epoch = cap.time();
+
+                        // Drain items so we don't have to re-allocate.
+                        for (step_id, key, update_type) in tmp_recovery_keys.drain(..) {
+                            recovery_store_summary
+                                .entry((step_id, key))
+                                .or_default()
+                                .insert((epoch.clone(), update_type));
+                        }
+                    });
+                }
+
+                // TODO: This runs on every operator activation. We
+                // only need to run when the dataflow frontier has
+                // actually updated, though.
+                let dataflow_frontier = dataflow_frontier_input_handle.frontier().frontier();
+                let is_collectable =
+                // Why +2? The dataflow frontier is the oldest
+                // in-progress epoch. Thus -1 is the epoch who's state
+                // we need to fully recreate during recovery and we
+                // shouldn't GC it. Thus -2 is the first GC-able
+                // epoch. And then since there's no
+                // [`Anitchain::greater_than()`], we use !less_than().
+                // TODO: Is there a way to do this without a fixed
+                // offset? It feels kinda hacky and would be cool to
+                // support arbitrary timestamp types.
+                    |epoch: &u64| -> bool { !dataflow_frontier.less_than(&(epoch + 2)) };
+                // We save the dataflow frontier here in the garbage
+                // collector and not in the dataflow frontier operator
+                // because we are downstream of broadcast() which
+                // ensures we'll be getting the true cluster dataflow
+                // frontier, not local to any worker.
+                recovery_collector.save_frontier(dataflow_frontier);
+
+                for ((step_id, key), epoch_updates) in recovery_store_summary.iter() {
+                    // [`BTreeSet::iter()`] is in asc order.
+                    let mut collectable_updates = epoch_updates
+                        .range(..)
+                        .filter(|(epoch, _update_type)| is_collectable(epoch))
+                        .map(|(epoch, update_type)| {
+                            (step_id.clone(), key.clone(), *epoch, update_type.clone())
+                        })
+                        .collect::<Vec<_>>();
+
+                    // Never collect the last upsert; that's the most
+                    // recent recovery data! If the final update is a
+                    // delete, though then collect that so abandoned
+                    // keys are GCd.
+                    if let Some((_step_id, _key, _epoch, UpdateType::Upsert)) =
+                        collectable_updates.last()
+                    {
+                        collectable_updates.pop();
+                    }
+
+                    garbage_key_buffer.append(&mut collectable_updates);
+                }
+
+                // Now remove all GCd items from the recovery store
+                // and the local copy of the keyspace.
+                for (step_id, key, epoch, update_type) in garbage_key_buffer.drain(..) {
+                    recovery_collector.delete_state(&step_id, &key, &epoch);
+
+                    // Do this multi-step process so we don't have
+                    // empty BTreeSets in the summary.
+                    let recovery_key = (step_id, key);
+                    let mut epochs_remaining = recovery_store_summary
+                        .remove(&recovery_key)
+                        .unwrap_or_default();
+                    let recovery_value = (epoch, update_type);
+                    epochs_remaining.remove(&recovery_value);
+                    if !epochs_remaining.is_empty() {
+                        recovery_store_summary.insert(recovery_key, epochs_remaining);
+                    }
+                }
+            }
+        });
+    }
 }

--- a/src/pyo3_extensions/mod.rs
+++ b/src/pyo3_extensions/mod.rs
@@ -70,6 +70,13 @@ impl From<&PyAny> for TdPyAny {
 }
 
 /// Conveniently re-wrap Python objects for use in Timely.
+impl From<&PyString> for TdPyAny {
+    fn from(x: &PyString) -> Self {
+        Self(x.into())
+    }
+}
+
+/// Conveniently re-wrap Python objects for use in Timely.
 impl From<Py<PyAny>> for TdPyAny {
     fn from(x: Py<PyAny>) -> Self {
         Self(x)

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -483,6 +483,10 @@ impl RecoveryStore<u64, TdPyAny, TdPyAny> for SqliteRecoveryStore {
         debug!("sqlite load dataflow_frontier={dataflow_frontier:?}");
 
         let resume_epoch = dataflow_frontier;
+        // Notice we only select < dataflow frontier. Not <=. Any
+        // state written during the previous execution's dataflow
+        // frontier itself was still "in progress" and so shouldn't be
+        // re-introduced in this run.
         let future = query("SELECT step_id, key, epoch, state FROM states WHERE epoch < ?1 ORDER BY step_id, key, epoch ASC")
             .bind(Self::epoch_to_i64(&resume_epoch))
             .map(|row: SqliteRow| {

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -1,4 +1,113 @@
+//! Internal code for writing to recovery stores.
+//!
+//! For a user-centric version of recovery, read the
+//! `bytewax.recovery` Python module docstring. Read that first.
+//!
+//! Because the recovery system is complex and requires coordination
+//! at many points in execution, not all code for recovery lives
+//! here. There are some custom operators and execution and dataflow
+//! building code which all help implement the recovery logic. An
+//! overview of it is given here, though.
+//!
+//! The recovery system uses a few custom **utility operators**
+//! ([`crate::operators::Backup`],
+//! [`crate::operators::DataflowFrontier`],
+//! [`crate::operators::GarbageCollector`]) to implement
+//! behavior. These operators do not represent user-facing dataflow
+//! logic, but instead implement our recovery
+//! guarantees.
+//!
+//! [`crate::execution::build_dataflow()`] is where all the
+//! coordination for recovery is strung together and you can see the
+//! implementation of the things described here.
+//!
+//! The [`RecoveryStore`] trait provides an interface that the rest of
+//! the components use to save data to the recovery store. To
+//! implement a new backing type, create a new impl of that.
+//!
+//! ```mermaid
+//! graph TD
+//! R{{Recovery Loader}} -. Recovered State .-> S1
+//! R -. Recovered State .-> S2
+//! R -. Resume Epoch .-> I
+//! I(Input) --> X1([... More Dataflow ...])
+//! X1 --> S1(Stateful Operator)
+//! S1 -. Updated State .-> B1{{Backup 1}}
+//! S1 -- Logic Output --> X2([... More Dataflow ...]) --> C1(Capture)
+//! X1 --> S2(Stateful Operator)
+//! S2 -. Updated State .-> B2{{Backup 2}}
+//! S2 -- Logic Output --> X3([... More Dataflow ...]) --> C2(Capture)
+//! B1 -. Updated Keys .-> GC
+//! B1 -. Frontier .-> FF{{Final Frontier Calc}}
+//! B2 -. Frontier .-> FF
+//! C1 -. Frontier .-> FF
+//! C2 -. Frontier .-> FF
+//! FF -.-> GC{{Garbage Collection}}
+//! B2 -. Updated Kyes .-> GC
+//! FF -.-> FFL{{Final Frontier Logger}}
+//! ```
+//!
+//! Backup
+//! ------
+//!
+//! Each stateful operator ([`crate::operators::Reduce`],
+//! [`crate::operators::StatefulMap`]) only contains execution logic;
+//! they do not load recovery data or backup themselves. Instead, they
+//! emit a second **state update stream** of `(key, state)` updates to
+//! feed into the rest of the recovery machinery.
+//!
+//! Each state update stream is fed into a
+//! [`crate::operators::Backup`] operator which writes out the state
+//! to the state store with the ID of that step. It emits **backup
+//! stream** of `(key, update_type)` which the rest of the machinery
+//! uses to know what has been backed up.
+//!
+//! All backups and capture operators then flow into a
+//! [`crate::operators::DataflowFrontier`] operator, which calculates
+//! the **dataflow frontier**. This is the oldest in-progress epoch
+//! (meaning all data has not been backed up or output yet).
+//!
+//! Finally, all backup streams are fed into the
+//! [`crate::operators::GarbageCollector`] operator, which keeps a
+//! summary of the keys and epochs that are currently in the recovery
+//! store. We can use this summary and the latest dataflow frontier to
+//! detect when some state is no longer necessary for recovery at the
+//! dataflow frontier and garbage collect it.
+//!
+//! As one extra quirk, the dataflow frontier must be passed through
+//! [`timely::dataflow::operators::broadcast::Broadcast`] so that
+//! every worker has the true whole dataflow frontier, not just what
+//! work happens to be complete on the local worker.
+//!
+//! Recovery
+//! --------
+//!
+//! Recovery happens whenever a dataflow is built with a recovery
+//! store that has data in it. Most of this logic is implemented in
+//! [`crate::execution::build_dataflow()`].
+//!
+//! First the last dataflow frontier and is read from the recovery
+//! store. This will be passed to the input builder to ensure that the
+//! user's code starts from the correct location.
+//!
+//! Next, all of the state data is dumped out of the recovery store
+//! into memory. It is divvied up into state for each stateful
+//! operator using [`build_state_caches()`] and passed as the initial
+//! `state_cache` argument to each operator. (See
+//! e.g. [`crate::operators::StatefulMap`]).
+//!
+//! Finally, that state dump is summarized into "which keys and epochs
+//! does the recovery store know about" and passed into the
+//! [`crate::operators::GarbageCollector`] so it can provide correct
+//! and up-to-date GC requests to the state store.
+//!
+//! If the underlying data or bug has been fixed, then things should
+//! start right up again!
+
+use std::collections::HashMap;
+use crate::dataflow::StepId;
 use pyo3::exceptions::PyValueError;
+use pyo3::types::PyString;
 use retry::delay::Fixed;
 use retry::retry;
 use retry::OperationResult;
@@ -13,6 +122,8 @@ use sqlx::Sqlite;
 use std::fmt::Debug;
 use std::rc::Rc;
 use std::time::Duration;
+use timely::progress::frontier::AntichainRef;
+use timely::progress::Timestamp;
 use tokio::runtime::Runtime;
 
 use crate::pyo3_extensions::TdPyAny;
@@ -65,7 +176,8 @@ pub(crate) struct SqliteRecoveryConfig {
 
 #[pymethods]
 impl SqliteRecoveryConfig {
-    #[new(db_file_path, "*", create = "false")]
+    #[new]
+    #[args(db_file_path, "*", create = "false")]
     fn new(db_file_path: String, create: bool) -> (Self, RecoveryConfig) {
         (
             Self {
@@ -106,46 +218,27 @@ impl SqliteRecoveryConfig {
     }
 }
 
-/// Rust-side trait which represents actions the dataflow execution
-/// will need to delegate to a recovery store.
+/// During dataflow building in
+/// [`crate::execution::build_dataflow()`], this creates the
+/// [`RecoveryStore`] instance for this worker.
 ///
-/// We'll implement this for each kind of recovery store we need to
-/// talk to. This is not exposed Python-side.
-pub(crate) trait RecoveryStore {
-    // TODO: I wanted to make a trait RecoveryStore statically typed, but I
-    // think that'll require GAT / generic associated types.
-
-    /// Build recovery interface for this step.
-    fn for_step(&self, step_id: &str) -> Box<dyn StepRecovery<u64, TdPyAny, TdPyAny>>;
-
-    // TODO: We can implement state compaction / GC once we know
-    // epochs are output by every capture() operator.
-    //fn compact(&self, done_epoch: u64);
-}
-
-/// Per-operator interface for state recovery.
-///
-/// Each [`RecoveryStore`] will need to implement this with the
-/// specific queries or inserts needed.
-pub(crate) trait StepRecovery<T, K, D> {
-    fn recover_last(&self, current_epoch: &T, key: &K) -> Option<D>;
-
-    fn save_complete(&self, completed_epoch: &T, key: &K, state: &Option<D>) -> ();
-}
-
+/// This is the Python -- Rust barrier; everything after this is pure
+/// Rust and should obtain the GIL to function on Bytewax objects.
 pub(crate) fn build_recovery_store(
     py: Python,
     recovery_config: Option<Py<RecoveryConfig>>,
-) -> Result<Box<dyn RecoveryStore>, String> {
+) -> Result<Rc<Box<dyn RecoveryStore<u64, TdPyAny, TdPyAny>>>, String> {
     match recovery_config {
-        None => Ok(Box::new(NoOpRecoveryStore::new())),
+        None => Ok(Rc::new(Box::new(NoOpRecoveryStore::new()))),
         Some(recovery_config) => {
             let recovery_config = recovery_config.as_ref(py);
             if let Ok(sqlite_recovery_config) =
                 recovery_config.downcast::<PyCell<SqliteRecoveryConfig>>()
             {
                 let sqlite_recovery_config = sqlite_recovery_config.borrow();
-                Ok(Box::new(SqliteRecoveryStore::new(sqlite_recovery_config)))
+                Ok(Rc::new(Box::new(SqliteRecoveryStore::new(
+                    sqlite_recovery_config,
+                ))))
             } else {
                 let pytype = recovery_config.get_type();
                 Err(format!("Unknown recovery_config type: {pytype}"))
@@ -154,9 +247,106 @@ pub(crate) fn build_recovery_store(
     }
 }
 
+/// Convert the unstructured log format of recovery data into a
+/// structured HashMap that the stateful operators can use during
+/// execution.
+pub(crate) fn build_state_caches(
+    recovery_data: Vec<(StepId, TdPyAny, u64, Option<TdPyAny>)>,
+) -> HashMap<StepId, HashMap<TdPyAny, TdPyAny>> {
+    let mut last_epochs: HashMap<(StepId, TdPyAny), u64> = HashMap::new();
+    let mut state_caches: HashMap<StepId, HashMap<TdPyAny, TdPyAny>> = HashMap::new();
+    for (step_id, key, epoch, state) in recovery_data {
+        debug!("state_cache step_id={step_id:?} key={key:?} epoch={epoch:?} state={state:?}");
+        // Let's double check that RecoveryStore.load() is loading
+        // things in order and panic otherwise because the code below
+        // is only correct if state is in epoch order.
+        last_epochs
+            .entry((step_id.clone(), key.clone()))
+            .and_modify(|last_epoch| {
+                assert!(
+                    epoch > *last_epoch,
+                    "Recovery store must return data in epoch order"
+                );
+                *last_epoch = epoch;
+            })
+            .or_insert(epoch);
+
+        let state_cache = state_caches.entry(step_id).or_default();
+        match state {
+            Some(state) => state_cache.insert(key, state),
+            None => state_cache.remove(&key),
+        };
+    }
+    state_caches
+}
+
+/// Use this instead of [`Option`] so we don't have to actually retain
+/// the value of the state in memory to track what the recovery store
+/// knows. We only care about keys and if the value was a delete to
+/// allow GCing now-unused keys.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum UpdateType {
+    Upsert,
+    Delete,
+}
+
+impl<T> From<Option<T>> for UpdateType {
+    fn from(option: Option<T>) -> Self {
+        match option {
+            Some(_) => Self::Upsert,
+            None => Self::Delete,
+        }
+    }
+}
+
+/// Rust-side trait which represents actions the dataflow execution
+/// will need to delegate to a recovery store.
+///
+/// We'll implement this for each kind of recovery store we need to
+/// talk to. This is not exposed Python-side.
+pub(crate) trait RecoveryStore<T: Timestamp, K, D> {
+    /// Load all state to recover the dataflow from the most recent
+    /// dataflow frontier.
+    ///
+    /// This returns a vector of known state snapshots and the resume
+    /// epoch.
+    ///
+    /// You must not hold the GIL when calling this function.
+    // TODO: Somehow only load data relevant to this worker. Hash the
+    // key?
+    // TODO: What does it mean to recover to a non-fully ordered
+    // timestamp?
+    fn load(&self) -> (Vec<(StepId, K, T, Option<D>)>, T);
+
+    /// Save some updated state for a key in a stateful operator in an
+    /// epoch.
+    ///
+    /// If the state was deleted, pass in `None`.
+    ///
+    /// You should only call this once per epoch per key, when the
+    /// epoch is complete to avoid saving unnecessary between-epoch
+    /// state.
+    ///
+    /// You must not hold the GIL when calling this function.
+    fn save_state(&self, step_id: &StepId, key: &K, epoch: &T, state: &Option<D>);
+
+    /// Save the current dataflow frontier.
+    ///
+    /// This is what is returned as the resume epoch from [`load()`].
+    ///
+    /// You must not hold the GIL when calling this function.
+    fn save_frontier(&self, dataflow_frontier: AntichainRef<T>);
+
+    /// Called when recovery state is no longer needed and should be
+    /// deleted.
+    ///
+    /// You must not hold the GIL when calling this function.
+    fn delete_state(&self, step_id: &StepId, key: &K, epoch: &T);
+}
+
 /// A recovery store which does nothing.
 ///
-/// Saves are dropped and all recoveries result in "not found".
+/// Saves are logged but dropped and all recoveries result in no data.
 pub(crate) struct NoOpRecoveryStore;
 
 impl NoOpRecoveryStore {
@@ -165,157 +355,208 @@ impl NoOpRecoveryStore {
     }
 }
 
-impl RecoveryStore for NoOpRecoveryStore {
-    fn for_step(&self, step_id: &str) -> Box<dyn StepRecovery<u64, TdPyAny, TdPyAny>> {
-        Box::new(NoOpStepRecovery {
-            step_id: step_id.to_string(),
-        })
+impl<T: Timestamp, K: Debug, D: Debug> RecoveryStore<T, K, D> for NoOpRecoveryStore {
+    fn load(&self) -> (Vec<(StepId, K, T, Option<D>)>, T) {
+        debug!("noop load");
+        (Vec::new(), T::minimum())
+    }
+
+    fn save_state(&self, step_id: &StepId, key: &K, epoch: &T, state: &Option<D>) {
+        debug!("noop save_state step_id={step_id:?} key={key:?} epoch={epoch:?} state={state:?}");
+    }
+
+    fn save_frontier(&self, dataflow_frontier: AntichainRef<T>) {
+        debug!("noop save_frontier dataflow_frontier={dataflow_frontier:?}");
+    }
+
+    fn delete_state(&self, step_id: &StepId, key: &K, epoch: &T) {
+        debug!("noop delete_state step_id={step_id:?} key={key:?} epoch={epoch:?}");
     }
 }
 
-struct NoOpStepRecovery {
-    step_id: String,
-}
-
-impl<T: Debug, K: Debug, D: Debug> StepRecovery<T, K, D> for NoOpStepRecovery {
-    fn recover_last(&self, current_epoch: &T, key: &K) -> Option<D> {
-        debug!(
-            "noop recovery queried step_id={} key={key:?}:state=None@epoch={current_epoch:?}",
-            self.step_id
-        );
-        None
-    }
-    fn save_complete(&self, completed_epoch: &T, key: &K, state: &Option<D>) -> () {
-        debug!(
-            "noop recovery saved step_id={} key={key:?}:state={state:?}@epoch={completed_epoch:?}",
-            self.step_id
-        );
-        ()
-    }
-}
-
+/// A recovery store which save state to an SQLite DB.
+///
+/// State is stored in a `states` table with the epoch it was
+/// generated at. Backup involves saving `(step_id, key, epoch,
+/// state)` tuples and GC involves deleting them. We really just use
+/// this as a key-value store.
+///
+/// The dataflow frontier is stored in a `frontiers` table.
 pub(crate) struct SqliteRecoveryStore {
+    // SAFETY: Avoid PyO3 Send overloading.
     rt: SendWrapper<Rc<Runtime>>,
     pool: Pool<Sqlite>,
 }
 
 impl SqliteRecoveryStore {
     pub(crate) fn new(config: PyRef<SqliteRecoveryConfig>) -> Self {
-        let rt = SendWrapper::new(Rc::new(
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap(),
-        ));
+        // Horrible news: we have to be very studious and release the
+        // GIL any time we know we have it and we call into sqlx
+        // because internally it might call log!() which because of
+        // pyo3-log might re-acuqire the GIL and sqlx always has a
+        // background thread. We don't need to do this in the
+        // RecoveryStore methods below because we know they won't be
+        // called from a GIL-holding point.
 
-        // For some reason the busy_timeout setting doesn't affect the
-        // initial connection. So manually retry here.
-        let pool = retry(Fixed::from_millis(100), || {
-            let mut options = SqliteConnectOptions::new()
-                .filename(&config.db_file_path)
-                .busy_timeout(Duration::from_secs(5))
-                .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
-                .locking_mode(sqlx::sqlite::SqliteLockingMode::Normal)
-                .synchronous(sqlx::sqlite::SqliteSynchronous::Normal)
-                .thread_name(|i| format!("sqlx-sqlite-{i}"));
-            if config.create {
-                options = options.create_if_missing(true);
-            }
-            config.py().allow_threads(|| {
+        // SAFETY: Avoid PyO3 Send overloading.
+        let config = SendWrapper::new(config);
+        config.py().allow_threads(|| {
+            let rt = SendWrapper::new(Rc::new(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap(),
+            ));
+
+            // For some reason the busy_timeout setting doesn't affect the
+            // initial connection. So manually retry here.
+            let pool = retry(Fixed::from_millis(100), || {
+                let mut options = SqliteConnectOptions::new()
+                    .filename(&config.db_file_path)
+                    .busy_timeout(Duration::from_secs(5))
+                    .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+                    .locking_mode(sqlx::sqlite::SqliteLockingMode::Normal)
+                    .synchronous(sqlx::sqlite::SqliteSynchronous::Normal)
+                    .thread_name(|i| format!("sqlx-sqlite-{i}"));
+                if config.create {
+                    options = options.create_if_missing(true);
+                }
                 let future = SqlitePoolOptions::new().connect_with(options);
                 match rt.block_on(future) {
                     Ok(pool) => OperationResult::Ok(pool),
                     Err(err) => OperationResult::Err(err),
                 }
             })
-        })
-        .unwrap();
-        debug!("Opened Sqlite connection pool to {}", config.db_file_path);
+                .unwrap();
+            debug!("Opened Sqlite connection pool to {}", config.db_file_path);
 
-        let future = query(
-            "CREATE TABLE IF NOT EXISTS states(epoch INTEGER, step_id, key, state, PRIMARY KEY (epoch, step_id, key));"
-        ).execute(&pool);
-        rt.block_on(future).unwrap();
+            if config.create {
+                let future = query(
+                    "CREATE TABLE IF NOT EXISTS states(step_id, key, epoch INTEGER, state, PRIMARY KEY (step_id, key, epoch));"
+                ).execute(&pool);
+                rt.block_on(future).unwrap();
+                let future = query("CREATE TABLE IF NOT EXISTS frontiers(name PRIMARY KEY, epoch INTEGER);")
+                    .execute(&pool);
+                rt.block_on(future).unwrap();
+                let future = query("INSERT INTO frontiers (name, epoch) VALUES (\"dataflow_frontier\", 0) ON CONFLICT (name) DO NOTHING")
+                    .execute(&pool);
+                rt.block_on(future).unwrap();
+            }
 
-        SqliteRecoveryStore { rt, pool }
-    }
-}
-
-impl RecoveryStore for SqliteRecoveryStore {
-    fn for_step(&self, step_id: &str) -> Box<dyn StepRecovery<u64, TdPyAny, TdPyAny>> {
-        Box::new(SqliteStepRecovery {
-            step_id: step_id.to_string(),
-            rt: self.rt.clone(),
-            pool: self.pool.clone(), // Said to be cheap.
+            SqliteRecoveryStore { rt, pool }
         })
     }
-}
 
-struct SqliteStepRecovery {
-    step_id: String,
-    rt: SendWrapper<Rc<Runtime>>,
-    pool: Pool<Sqlite>,
-}
-
-impl StepRecovery<u64, TdPyAny, TdPyAny> for SqliteStepRecovery {
-    fn recover_last(&self, current_epoch: &u64, key: &TdPyAny) -> Option<TdPyAny> {
-        let current_epoch_int =
-            i64::try_from(*current_epoch).expect("Epoch too big to fit into SQLite int");
-        let key_string: String =
-            Python::with_gil(|py| key.extract(py)).expect("Key cannot be cast to string");
-
-        let future = query("SELECT state FROM states WHERE step_id = ?1 AND key = ?2 AND epoch < ?3 ORDER BY epoch DESC LIMIT 1")
-            .bind(&self.step_id)
-            .bind(key_string)
-            .bind(current_epoch_int)
-            .map(|row: SqliteRow| {
-                let state_pickled: &[u8] = row.get(0);
-                Python::with_gil(|py| {
-                    let pickle = py.import("dill")?;
-                    Ok(pickle.call_method1("loads", (state_pickled, ))?.into())
-                })
-            })
-            .fetch_optional(&self.pool);
-        let state = self
-            .rt
-            .block_on(future)
-            .unwrap()
-            .map(|r: Result<TdPyAny, PyErr>| r.expect("Error unpickling state"));
-
-        debug!(
-            "sqlite recovery queried step_id={} key={key:?}:state={state:?}@epoch={current_epoch}",
-            self.step_id
-        );
-        state
+    fn step_id_to_string(step_id: &StepId) -> String {
+        step_id.clone().into()
     }
 
-    fn save_complete(&self, completed_epoch: &u64, key: &TdPyAny, state: &Option<TdPyAny>) -> () {
-        let completed_epoch_int =
-            i64::try_from(*completed_epoch).expect("Epoch too big to fit into SQLite int");
-        let key_string: String =
-            Python::with_gil(|py| key.extract(py)).expect("Key cannot be cast to string");
-        let state_pickled: Option<Vec<u8>> = state.as_ref().map(|state| {
+    fn key_to_string(key: &TdPyAny) -> String {
+        Python::with_gil(|py| key.extract(py)).expect("Key cannot be cast to string")
+    }
+
+    fn epoch_to_i64(epoch: &u64) -> i64 {
+        i64::try_from(*epoch).expect("Epoch too big to fit into SQLite int")
+    }
+
+    fn state_to_bytes(state: &Option<TdPyAny>) -> Option<Vec<u8>> {
+        state.as_ref().map(|state| {
             Python::with_gil(|py| -> Result<Vec<u8>, PyErr> {
                 let pickle = py.import("dill")?;
                 Ok(pickle.call_method1("dumps", (state,))?.extract()?)
             })
             .expect("Error pickling state")
-        });
+        })
+    }
+}
 
-        let future = query("INSERT INTO states (epoch, step_id, key, state) VALUES (?1, ?2, ?3, ?4) ON CONFLICT (epoch, step_id, key) DO UPDATE SET state = EXCLUDED.state")
-            .bind(completed_epoch_int)
-            .bind(&self.step_id)
-            .bind(key_string)
-            .bind(state_pickled)
+impl RecoveryStore<u64, TdPyAny, TdPyAny> for SqliteRecoveryStore {
+    fn load(&self) -> (Vec<(StepId, TdPyAny, u64, Option<TdPyAny>)>, u64) {
+        let future = query("SELECT epoch FROM frontiers WHERE name = \"dataflow_frontier\"")
+            .map(|row: SqliteRow| {
+                row.get::<i64, _>(0)
+                    .try_into()
+                    .expect("SQLite int can't fit into epoch; might be negative")
+            })
+            .fetch_one(&self.pool);
+        let dataflow_frontier: u64 = self.rt.block_on(future).unwrap();
+
+        debug!("sqlite load dataflow_frontier={dataflow_frontier:?}");
+
+        let resume_epoch = dataflow_frontier;
+        let future = query("SELECT step_id, key, epoch, state FROM states WHERE epoch < ?1 ORDER BY step_id, key, epoch ASC")
+            .bind(Self::epoch_to_i64(&resume_epoch))
+            .map(|row: SqliteRow| {
+                // Because of the whole "PyO3 uses Sync to mark
+                // GIL-bound lifetimes" thing, we can't move this GIL
+                // block outside without jumping through hoops.
+                Python::with_gil(|py| {
+                    let pickle = py.import("dill").expect("Error importing dill");
+
+                    let step_id: StepId = row.get::<String, _>(0).into();
+                    let key: TdPyAny = PyString::new(py, row.get(1)).into();
+                    let epoch: u64 = row.get::<i64, _>(2).try_into().expect("SQLite int can't fit into epoch; might be negative");
+                    let state_pickled: Option<&[u8]> = row.get(3);
+                    let state = state_pickled.map(|bytes| pickle.call_method1("loads", (bytes, )).expect("Error unpickling state").into());
+                    (step_id, key, epoch, state)
+                })
+            })
+            .fetch_all(&self.pool);
+        let state = self.rt.block_on(future).unwrap();
+
+        debug!("sqlite load resume_epoch={resume_epoch:?}");
+        (state, resume_epoch)
+    }
+
+    fn save_state(&self, step_id: &StepId, key: &TdPyAny, epoch: &u64, state: &Option<TdPyAny>) {
+        let future = query("INSERT INTO states (step_id, key, epoch, state) VALUES (?1, ?2, ?3, ?4) ON CONFLICT (step_id, key, epoch) DO UPDATE SET state = EXCLUDED.state")
+            .bind(Self::step_id_to_string(step_id))
+            .bind(Self::key_to_string(key))
+            .bind(Self::epoch_to_i64(epoch))
+            .bind(Self::state_to_bytes(state))
             .execute(&self.pool);
         self.rt.block_on(future).unwrap();
 
-        debug!(
-            "sqlite recovery stored step_id={} key={key:?}:state={state:?}@epoch={completed_epoch}",
-            self.step_id
-        );
+        debug!("sqlite save_state step_id={step_id:?} key={key:?} epoch={epoch:?} state={state:?}");
         // TODO: Warn on state overwriting?
-        ()
+    }
+
+    fn save_frontier(&self, dataflow_frontier: AntichainRef<u64>) {
+        if dataflow_frontier.len() > 0 {
+            let future = query("INSERT INTO frontiers (name, epoch) VALUES (?1, ?2) ON CONFLICT (name) DO UPDATE SET epoch = EXCLUDED.epoch")
+                .bind("dataflow_frontier")
+                // TODO: Will we ever want to save the whole final
+                // frontier? We're using fully ordered epochs in
+                // Bytewax so there should never be more than one
+                // element.
+                .bind(Self::epoch_to_i64(dataflow_frontier.first().expect("Empty dataflow frontier")))
+                .execute(&self.pool);
+            self.rt.block_on(future).unwrap();
+
+            // TODO: Warn on final frontier going backwards? Might stay
+            // the same if recovering.
+        } else {
+            // TODO: More gracefully handle if the dataflow completes
+            // sucessfully. Currently if it does, the recovery store
+            // ends up empty. So if you attempt to recover from it,
+            // the whole dataflow starts again. Delete the state DB?
+            let future = query("DELETE FROM frontiers WHERE name = \"dataflow_frontier\"")
+                .execute(&self.pool);
+            self.rt.block_on(future).unwrap();
+        }
+
+        debug!("sqlite save_frontier dataflow_frontier={dataflow_frontier:?}");
+    }
+
+    fn delete_state(&self, step_id: &StepId, key: &TdPyAny, epoch: &u64) {
+        let future = query("DELETE FROM states WHERE step_id = ?1 AND key = ?2 AND epoch = ?3")
+            .bind(Self::step_id_to_string(step_id))
+            .bind(Self::key_to_string(key))
+            .bind(Self::epoch_to_i64(epoch))
+            .execute(&self.pool);
+        self.rt.block_on(future).unwrap();
+
+        debug!("sqlite delete_state step_id={step_id:?} key={key:?} epoch={epoch:?}");
     }
 }
 

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -38,13 +38,12 @@
 //! S2 -. Updated State .-> B2{{Backup 2}}
 //! S2 -- Logic Output --> X3([... More Dataflow ...]) --> C2(Capture)
 //! B1 -. Updated Keys .-> GC
-//! B1 -. Frontier .-> FF{{Final Frontier Calc}}
-//! B2 -. Frontier .-> FF
-//! C1 -. Frontier .-> FF
-//! C2 -. Frontier .-> FF
-//! FF -.-> GC{{Garbage Collection}}
-//! B2 -. Updated Kyes .-> GC
-//! FF -.-> FFL{{Final Frontier Logger}}
+//! B1 -. Frontier .-> DF{{Dataflow Frontier Calc}}
+//! B2 -. Frontier .-> DF
+//! C1 -. Frontier .-> DF
+//! C2 -. Frontier .-> DF
+//! DF -.-> GC{{Garbage Collection}}
+//! B2 -. Updated Keys .-> GC
 //! ```
 //!
 //! Backup


### PR DESCRIPTION
This is an overhaul of the state recovery system to support two big
new features:

1. _Automatic recovery_ - Bytewax will backup in the recovery store
the **dataflow frontier** which is the oldest in-progress epoch. This
represents the epoch that if the dataflow crashed right now, one
should resume from. The startup machinery now reads this epoch from
the recovery store and will pass it to the input builders so the
system will start up exactly where it failed.

2. _State garbage collection_ - By keeping track of the dataflow
frontier, we can can know what state is no longer necessary for
recovery and GC it from the state store.

See the module docstring in `bytewax.recovery` for what is necessary
from a user's perspective and see the rustdoc in the `recovery` module
to see documentation on how this works internally.
