### PR TITLE
Fix inputs helper

### DIFF
--- a/examples/feast/feast_dataflow.py
+++ b/examples/feast/feast_dataflow.py
@@ -12,7 +12,7 @@ store = FeatureStore(repo_path=".")
 
 
 @inputs.yield_epochs
-def input_builder(worker_index, worker_count):
+def input_builder(worker_index, worker_count, resume_epoch):
     def consume_from_kafka():
         consumer = KafkaConsumer(
             bootstrap_servers="localhost:9092", auto_offset_reset="earliest"
@@ -112,5 +112,4 @@ if __name__ == "__main__":
         output_builder,
         [],  # addresses
         0,  # process id
-        1,  # number of workers
     )

--- a/examples/k8s_cluster.py
+++ b/examples/k8s_cluster.py
@@ -7,7 +7,7 @@ read_dir = Path("./examples/sample_data/cluster/")
 write_dir = Path("./cluster_out/")
 
 
-def input_builder(worker_index, worker_count):
+def input_builder(worker_index, worker_count, resume_epoch):
     # List all the input partitions in the reading directory.
     all_partitions = read_dir.glob("*.txt")
     # Then have this worker only read every `n` files so each worker

--- a/examples/manual_cluster.py
+++ b/examples/manual_cluster.py
@@ -7,7 +7,7 @@ read_dir = Path("./examples/sample_data/cluster/")
 write_dir = Path("./cluster_out/")
 
 
-def input_builder(worker_index, worker_count):
+def input_builder(worker_index, worker_count, resume_epoch):
     # List all the input partitions in the reading directory.
     all_partitions = read_dir.glob("*.txt")
     # Then have this worker only read every `n` files so each worker

--- a/examples/wikistream.py
+++ b/examples/wikistream.py
@@ -23,8 +23,8 @@ def open_stream():
     for event in client.events():
         yield event.data
 
-
-def input_builder(worker_index, worker_count):
+@inputs.yield_epochs
+def input_builder(worker_index, worker_count, resume_epoch):
     try:
         epoch_start = int(r.get("epoch_index")) + 1
     except IndexError:

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -89,7 +89,7 @@ def yield_epochs(fn: Callable):
     >>> flow = Dataflow()
     >>> flow.capture()
     >>> @yield_epochs
-    ... def input_builder(i, n):
+    ... def input_builder(i, n, re):
     ...   return fully_ordered(["a", "b", "c"])
     >>> cluster_main(flow, input_builder, lambda i, n: print, [], 0, 1)
     (0, 'a')
@@ -98,8 +98,8 @@ def yield_epochs(fn: Callable):
 
     """
 
-    def inner_fn(worker_index, worker_count):
-        gen = fn(worker_index, worker_count)
+    def inner_fn(worker_index, worker_count, resume_epoch):
+        gen = fn(worker_index, worker_count, resume_epoch)
         for (epoch, item) in gen:
             yield AdvanceTo(epoch)
             yield Emit(item)

--- a/pytests/test_inputs.py
+++ b/pytests/test_inputs.py
@@ -61,7 +61,7 @@ def test_yield_epoch():
         return item["timestamp"]
 
     @yield_epochs
-    def input_builder(i, n):
+    def input_builder(i, n, re):
         items = [
             {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 3), "value": "a"},
             {"timestamp": datetime.datetime(2022, 2, 22, 1, 2, 4), "value": "b"},
@@ -73,7 +73,7 @@ def test_yield_epoch():
             time_getter,
         )
 
-    assert list(input_builder(0, 1)) == [
+    assert list(input_builder(0, 1, 0)) == [
         AdvanceTo(0),
         ANY,
         AdvanceTo(0),


### PR DESCRIPTION
We forgot to update the `yield_epochs` decorator when we added the `resume_epoch` argument.