### PR TITLE
Uses new `JoinHandle::is_finished`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,7 @@ jobs:
         architecture: x64
     - uses: messense/maturin-action@v1
       with:
+        rust-toolchain: 1.61
         manylinux: auto
         command: build
         args: --release -o dist --interpreter python${{ matrix.python-version }}
@@ -53,6 +54,7 @@ jobs:
         echo "PYTHON_PATH=$python_path" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
     - uses: messense/maturin-action@v1
       with:
+        rust-toolchain: 1.61
         command: build
         args: --release --no-sdist -o dist --interpreter ${{ env.PYTHON_PATH }}
     - name: Run tests
@@ -80,6 +82,7 @@ jobs:
         architecture: x64
     - uses: messense/maturin-action@v1
       with:
+        rust-toolchain: 1.61
         command: build
         args: --release --no-sdist -o dist --universal2 --interpreter python${{ matrix.python-version }}
     - name: Run tests

--- a/examples/translator.py
+++ b/examples/translator.py
@@ -4,9 +4,12 @@ import bytewax
 from bytewax import Dataflow, inputs, parse, run_cluster
 
 
-def predict(en):
-    de = translator(en)[0]["translation_text"]
-    return (en, de)
+def build_predict(translator):
+    def predict(en):
+        de = translator(en)[0]["translation_text"]
+        return (en, de)
+
+    return predict
 
 
 def inspector(en_de):
@@ -14,14 +17,13 @@ def inspector(en_de):
     print(f"{en} -> {de}")
 
 
-flow = Dataflow()
-flow.map(str.strip)
-flow.map(predict)
-flow.capture()
-
-
 if __name__ == "__main__":
     translator = pipeline("translation_en_to_de")
+
+    flow = Dataflow()
+    flow.map(str.strip)
+    flow.map(build_predict(translator))
+    flow.capture()
 
     for epoch, item in run_cluster(
         flow,

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -6,14 +6,13 @@
 //! See [`build_dataflow()`] and [`worker_main()`] for the main parts
 //! of this.
 
-use crate::recovery::build_state_caches;
 use crate::operators::Backup;
 use crate::operators::DataflowFrontier;
 use crate::operators::GarbageCollector;
+use crate::recovery::build_state_caches;
 use crate::recovery::RecoveryConfig;
 use send_wrapper::SendWrapper;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -246,7 +245,6 @@ where
         }
     })
 }
-
 
 /// Advance to the supplied epoch.
 ///
@@ -598,11 +596,6 @@ pub(crate) fn cluster_main(
         let should_shutdown = Arc::new(AtomicBool::new(false));
         let should_shutdown_w = should_shutdown.clone();
         let should_shutdown_p = should_shutdown.clone();
-        // We can drop these if we want to use nightly
-        // Thread::is_running
-        // https://github.com/rust-lang/rust/issues/90470
-        let shutdown_worker_count = Arc::new(AtomicUsize::new(0));
-        let shutdown_worker_count_w = shutdown_worker_count.clone();
 
         // Panic hook is per-process, so this won't work if you call
         // `cluster_main()` twice concurrently.
@@ -630,10 +623,6 @@ pub(crate) fn cluster_main(
             other,
             timely::WorkerConfig::default(),
             move |worker| {
-                defer! {
-                    shutdown_worker_count_w.fetch_add(1, Ordering::Relaxed);
-                }
-
                 let (pump, probe) = Python::with_gil(|py| {
                     let flow = &flow.as_ref(py).borrow();
                     let input_builder = input_builder.clone_ref(py);
@@ -662,8 +651,11 @@ pub(crate) fn cluster_main(
         // Recreating what Python does in Thread.join() to "block"
         // but also check interrupt handlers.
         // https://github.com/python/cpython/blob/204946986feee7bc80b233350377d24d20fcb1b8/Modules/_threadmodule.c#L81
-        let workers_in_proc_count = guards.guards().len();
-        while shutdown_worker_count.load(Ordering::Relaxed) < workers_in_proc_count {
+        while guards
+            .guards()
+            .iter()
+            .any(|worker_thread| !worker_thread.is_finished())
+        {
             thread::sleep(Duration::from_millis(1));
             Python::with_gil(|py| Python::check_signals(py)).map_err(|err| {
                 should_shutdown.store(true, Ordering::Relaxed);


### PR DESCRIPTION
- Uses new `JoinHandle::is_finished` in Rust 1.61 instead of atomic count
- Fixes up translator and wikistream examples

Since we're still having problems running our ctrl-C tests, I tested
this manually on the fixed up examples and it works.
