### PR TITLE
Kafka recovery store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cmake"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1100,7 @@ version = "4.2.0+1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e542c6863b04ce0fa0c5719bc6b7b348cf8dd21af1bb03c9db5f9805b2a6473"
 dependencies = [
+ "cmake",
  "libc",
  "libz-sys",
  "num_enum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,13 +160,16 @@ name = "bytewax"
 version = "0.9.0"
 dependencies = [
  "axum",
+ "bincode",
  "log",
  "pyo3",
  "pyo3-log",
+ "rdkafka",
  "retry",
  "scopeguard",
  "send_wrapper",
  "serde",
+ "serde_test",
  "sqlx",
  "timely",
  "tokio",
@@ -318,6 +321,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +374,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
 name = "futures-macro"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,10 +408,13 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -645,6 +672,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e7e15d7610cce1d9752e137625f14e61a28cd45929b6e12e47b50fe154ee2e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +803,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +934,16 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -999,6 +1069,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdkafka"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de127f294f2dba488ed46760b129d5ecbeabbd337ccbf3739cb29d50db2161c"
+dependencies = [
+ "futures",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.2.0+1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e542c6863b04ce0fa0c5719bc6b7b348cf8dd21af1bb03c9db5f9805b2a6473"
+dependencies = [
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,12 +1204,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe196827aea34242c314d2f0dd49ed00a129225e80dda71b0dbf65d54d25628d"
+dependencies = [
  "serde",
 ]
 
@@ -1496,6 +1604,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,9 +1661,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if",
  "log",
@@ -1557,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1568,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ bincode = { version = "1.3.3" }
 log = { version = "0.4" }
 pyo3 = { version = "0.15.1" }
 pyo3-log = { version = "0.5.0" }
-rdkafka = { version = "0.28.0" }
+rdkafka = { version = "0.28.0", features = [ "cmake-build" ] }
 retry = { version = "1.3.1" }
 scopeguard = { version = "1.1.0" }
 send_wrapper = { version = "0.5.0" }
 serde = { version = "1.0.134" }
 serde_test = { version = "1.0.134" }
 sqlx = { version = "0.5.11", features = [ "runtime-tokio-rustls", "postgres", "sqlite" ] }
-timely = { version = "0.12.0", features = ["bincode"] }
-tokio = { version = "1.15.0", features = ["full"] }
+timely = { version = "0.12.0", features = [ "bincode" ] }
+tokio = { version = "1.15.0", features = [ "full" ] }
 
 [dev-dependencies]
 pyo3 = { version = "0.15.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,16 @@ python-source = "pysrc"
 
 [dependencies]
 axum = { version = "0.4.3" }
+bincode = { version = "1.3.3" }
 log = { version = "0.4" }
 pyo3 = { version = "0.15.1" }
 pyo3-log = { version = "0.5.0" }
+rdkafka = { version = "0.28.0" }
 retry = { version = "1.3.1" }
 scopeguard = { version = "1.1.0" }
 send_wrapper = { version = "0.5.0" }
 serde = { version = "1.0.134" }
+serde_test = { version = "1.0.134" }
 sqlx = { version = "0.5.11", features = [ "runtime-tokio-rustls", "postgres", "sqlite" ] }
 timely = { version = "0.12.0", features = ["bincode"] }
 tokio = { version = "1.15.0", features = ["full"] }

--- a/docs/examples/cart-join.md
+++ b/docs/examples/cart-join.md
@@ -61,8 +61,8 @@ present in every event.
 ```python
 def key_off_user_id(event):
     return event["user_id"], event
-    
-    
+
+
 flow.map(key_off_user_id)
 ```
 
@@ -243,16 +243,15 @@ def input_builder(worker_index, worker_count, resume_epoch):
 ```
 
 Running the dataflow again will pickup very close to where we
-started. In this case, even though the failure happend with an input
-on epoch `4`, the system detected that we were not done processing
-input from epoch `1` yet, so it resumes from there.
+failed. In this case, the failure happened with an input on epoch `5`,
+so it resumes from there. As the `FAIL HERE` string is ignored,
+there's no output during epoch `5`.
 
 ```python
 run_main(flow, input_builder, output_builder, recovery_config=recovery_config)
 ```
 
 ```{testoutput}
-4 {"user_id": "b", "paid_order_ids": [], "unpaid_order_ids": [3, 4]}
 6 {"user_id": "a", "paid_order_ids": [2, 1], "unpaid_order_ids": []}
 7 {"user_id": "b", "paid_order_ids": [4], "unpaid_order_ids": [3]}
 ```

--- a/examples/wordcount.py
+++ b/examples/wordcount.py
@@ -1,11 +1,24 @@
 import re
 
-from bytewax import Dataflow, parse, run_cluster
+from bytewax import AdvanceTo, Dataflow, Emit, parse, spawn_cluster
+from bytewax.recovery import KafkaRecoveryConfig
 
 
-def file_input():
-    for line in open("examples/sample_data/wordcount.txt"):
-        yield 1, line
+def input_builder(worker_index, worker_count, resume_epoch):
+    with open("examples/sample_data/wordcount.txt") as lines:
+        for epoch, line in enumerate(lines):
+            if epoch < resume_epoch:
+                continue
+            if epoch % worker_count != worker_index:
+                continue
+            # if epoch == 12:
+            #     raise RuntimeError("boom")
+            yield AdvanceTo(epoch)
+            yield Emit(line)
+
+
+def output_builder(worker_index, worker_count):
+    return print
 
 
 def lower(line):
@@ -20,8 +33,13 @@ def initial_count(word):
     return word, 1
 
 
-def add(count1, count2):
-    return count1 + count2
+def count_builder(word):
+    return 0
+
+
+def add(running_count, new_count):
+    running_count += new_count
+    return running_count, running_count
 
 
 flow = Dataflow()
@@ -32,11 +50,19 @@ flow.flat_map(tokenize)
 # "words"
 flow.map(initial_count)
 # ("word", 1)
-flow.reduce_epoch(add)
-# ("word", count)
+flow.stateful_map("running_count", count_builder, add)
+# ("word", running_count)
 flow.capture()
 
 
 if __name__ == "__main__":
-    for epoch, item in run_cluster(flow, file_input(), **parse.cluster_args()):
-        print(epoch, item)
+    recovery_config = KafkaRecoveryConfig(
+        ["localhost:9092"], "bytewax-state", create=True
+    )
+    spawn_cluster(
+        flow,
+        input_builder,
+        output_builder,
+        recovery_config=recovery_config,
+        **parse.cluster_args()
+    )

--- a/pysrc/bytewax/recovery.py
+++ b/pysrc/bytewax/recovery.py
@@ -48,4 +48,4 @@ you either have to create a recovery config that points at a new
 datastore or delete the recovery data in the datastore.
 
 """
-from .bytewax import RecoveryConfig, SqliteRecoveryConfig  # noqa
+from .bytewax import KafkaRecoveryConfig, RecoveryConfig, SqliteRecoveryConfig  # noqa

--- a/recovery_wordcount.py
+++ b/recovery_wordcount.py
@@ -1,0 +1,68 @@
+import re
+
+from bytewax import AdvanceTo, Dataflow, Emit, parse, spawn_cluster
+from bytewax.recovery import KafkaRecoveryConfig
+
+
+def input_builder(worker_index, worker_count, resume_epoch):
+    with open("examples/sample_data/wordcount.txt") as lines:
+        for epoch, line in enumerate(lines):
+            if epoch < resume_epoch:
+                continue
+            if epoch % worker_count != worker_index:
+                continue
+            # if epoch == 12:
+            #     raise RuntimeError("boom")
+            yield AdvanceTo(epoch)
+            yield Emit(line)
+
+
+def output_builder(worker_index, worker_count):
+    return print
+
+
+def lower(line):
+    return line.lower()
+
+
+def tokenize(line):
+    return re.findall(r'[^\s!,.?":;0-9]+', line)
+
+
+def initial_count(word):
+    return word, 1
+
+
+def count_builder(word):
+    return 0
+
+
+def add(running_count, new_count):
+    running_count += new_count
+    return running_count, running_count
+
+
+flow = Dataflow()
+# "Here, we have FULL sentences."
+flow.map(lower)
+# "here, we have lowercase sentences."
+flow.flat_map(tokenize)
+# "words"
+flow.map(initial_count)
+# ("word", 1)
+flow.stateful_map("running_count", count_builder, add)
+# ("word", running_count)
+flow.capture()
+
+
+if __name__ == "__main__":
+    recovery_config = KafkaRecoveryConfig(
+        ["localhost:9092"], "bytewax-state", create=True
+    )
+    spawn_cluster(
+        flow,
+        input_builder,
+        output_builder,
+        recovery_config=recovery_config,
+        **parse.cluster_args()
+    )

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -2,9 +2,18 @@ use crate::pyo3_extensions::TdPyCallable;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::*;
+use serde::Deserialize;
+use serde::Serialize;
+use std::fmt::Display;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub(crate) struct StepId(String);
+
+impl Display for StepId {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        fmt.write_str(&self.0)
+    }
+}
 
 impl From<String> for StepId {
     fn from(s: String) -> Self {

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -635,12 +635,10 @@ impl<K: ExchangeData + Hash + Eq, T: Timestamp> RecoveryStoreSummary<K, T> {
             let (step_id, key) = map_key;
 
             // TODO: The following becomes way cleaner once
-            // [`std::collections::BTreeMap::drain_filter`] hits
+            // [`std::collections::BTreeMap::drain_filter`] and
+            // [`std::collections::BTreeMap::first_entry`] hits
             // stable.
 
-            // [`std::collections::BTreeMap::split_off`] looks at all
-            // the keys (epochs) in order, keeps every epoch <
-            // finalized_epoch, returns epoch >= finalized_epoch.
             let (mut map_key_garbage, mut map_key_non_garbage): (Vec<_>, Vec<_>) = epoch_updates
                 .drain()
                 .partition(|(epoch, _update_type)| epoch <= finalized_epoch);

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -12,19 +12,18 @@
 use crate::dataflow::StepId;
 use crate::recovery::RecoveryStore;
 use crate::recovery::UpdateType;
-use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::rc::Rc;
 use timely::dataflow::channels::pact;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::FrontieredInputHandle;
 use timely::dataflow::operators::FrontierNotificator;
-use timely::dataflow::operators::Operator;
 use timely::dataflow::Scope;
 use timely::dataflow::Stream;
+use timely::progress::Antichain;
+use timely::progress::Timestamp;
 use timely::Data;
 use timely::ExchangeData;
 
@@ -175,10 +174,9 @@ impl<S: Scope, K: ExchangeData + Hash + Eq, V: ExchangeData> Reduce<S, K, V> for
 
                                 // Save the aggregator so we can use
                                 // it if there are multiple values
-                                // within this epoch. We do not save
-                                // to the recovery store here because
-                                // we don't have finalized state for
-                                // the epoch.
+                                // within this epoch. We do not emit
+                                // updated state here because we don't
+                                // have finalized state for the epoch.
                                 if is_complete(&key, &updated_aggregator_for_key) {
                                     let mut downstream_output_session =
                                         downstream_output_handle.session(&downstream_cap);
@@ -452,10 +450,9 @@ impl<S: Scope, K: ExchangeData + Hash + Eq, V: ExchangeData> StatefulMap<S, K, V
 
                                 // Save the state so we can use it if
                                 // there are multiple values within
-                                // this epoch. We do not save to the
-                                // recovery store here because we
-                                // don't have finalized state for the
-                                // epoch.
+                                // this epoch. We do not emit updated
+                                // state here because we don't have
+                                // finalized state for the epoch.
                                 if let Some(updated_state) = updated_state_for_key {
                                     state_cache.insert(key.clone(), updated_state);
                                 } else {
@@ -537,72 +534,35 @@ pub(crate) fn capture(captor: &TdPyCallable, epoch: &u64, item: &TdPyAny) {
     Python::with_gil(|py| with_traceback!(py, captor.call1(py, ((*epoch, item.clone_ref(py)),))));
 }
 
-/// Utility operator which persists state changes coming out of the
-/// stateful operators to the recovery store.
-///
-/// Emits a stream of update summaries for use in garbage collection.
-pub(crate) trait Backup<S: Scope, K: ExchangeData + Hash + Eq, D: ExchangeData> {
-    fn backup(
-        &self,
-        step_id: StepId,
-        recovery_writer: Rc<Box<dyn RecoveryStore<S::Timestamp, K, D>>>,
-    ) -> Stream<S, (StepId, K, UpdateType)>
-    where
-        S::Timestamp: Hash + Eq;
-}
-
-impl<S: Scope, K: ExchangeData + Hash + Eq, D: ExchangeData> Backup<S, K, D>
-    for Stream<S, (K, Option<D>)>
-{
-    fn backup(
-        &self,
-        step_id: StepId,
-        recovery_writer: Rc<Box<dyn RecoveryStore<S::Timestamp, K, D>>>,
-    ) -> Stream<S, (StepId, K, UpdateType)> {
-        self.unary(pact::Pipeline, "Backup", |_init_capability, _info| {
-            let mut items_buffer = Vec::new();
-            move |input, output| {
-                input.for_each(|cap, data| {
-                    data.swap(&mut items_buffer);
-                    let epoch = cap.time();
-
-                    let mut output_session = output.session(&cap);
-                    for (key, updated_state) in items_buffer.drain(..) {
-                        recovery_writer.save_state(&step_id, &key, epoch, &updated_state);
-                        output_session.give((step_id.clone(), key, updated_state.into()));
-                    }
-                });
-            }
-        })
-    }
-}
-
 /// Utility operator which calculates the dataflow frontier.
 ///
-/// Connect to all backups and captures in the dataflow during
-/// building.
+/// Connect to the backup output of the [`Recovery`] operator and all
+/// captures in the dataflow during building.
 ///
 /// It outputs a kind of "heartbeat" `()` but the epochs attached to
 /// that will be the dataflow frontiers.
 pub(crate) trait DataflowFrontier<S: Scope, K: ExchangeData + Hash + Eq> {
-    fn dataflow_frontier<IB, IC>(&self, backups: IB, captures: IC) -> Stream<S, ()>
+    fn dataflow_frontier<IC>(
+        &self,
+        backup: Stream<S, (StepId, K, UpdateType)>,
+        captures: IC,
+    ) -> Stream<S, ()>
     where
-        IB: IntoIterator<Item = Stream<S, (StepId, K, UpdateType)>>,
         IC: IntoIterator<Item = Stream<S, TdPyAny>>;
 }
 
 impl<S: Scope, K: ExchangeData + Hash + Eq> DataflowFrontier<S, K> for S {
-    fn dataflow_frontier<IB, IC>(&self, backups: IB, captures: IC) -> Stream<S, ()>
+    fn dataflow_frontier<IC>(
+        &self,
+        backup: Stream<S, (StepId, K, UpdateType)>,
+        captures: IC,
+    ) -> Stream<S, ()>
     where
-        IB: IntoIterator<Item = Stream<S, (StepId, K, UpdateType)>>,
         IC: IntoIterator<Item = Stream<S, TdPyAny>>,
     {
         let mut op_builder = OperatorBuilder::new("DataflowFrontier".to_string(), self.clone());
 
-        let mut backup_inputs = backups
-            .into_iter()
-            .map(|s| op_builder.new_input(&s, pact::Pipeline))
-            .collect::<Vec<_>>();
+        let mut backup_input = op_builder.new_input(&backup, pact::Pipeline);
         let mut capture_inputs = captures
             .into_iter()
             .map(|s| op_builder.new_input(&s, pact::Pipeline))
@@ -615,11 +575,9 @@ impl<S: Scope, K: ExchangeData + Hash + Eq> DataflowFrontier<S, K> for S {
             move |input_frontiers| {
                 let mut output_handle = output_wrapper.activate();
 
-                for input in backup_inputs.iter_mut() {
-                    input.for_each(|cap, _data| {
-                        fncater.notify_at(cap.retain());
-                    });
-                }
+                backup_input.for_each(|cap, _data| {
+                    fncater.notify_at(cap.retain());
+                });
                 for input in capture_inputs.iter_mut() {
                     input.for_each(|cap, _data| {
                         fncater.notify_at(cap.retain());
@@ -639,152 +597,255 @@ impl<S: Scope, K: ExchangeData + Hash + Eq> DataflowFrontier<S, K> for S {
     }
 }
 
-/// Utility operator which listens to the dataflow frontier and
-/// streams of backup summaries and will coordinate with the recovery
-/// store to garbage collect old state.
+/// In-memory summary of all keys this worker's recovery store knows
+/// about.
 ///
-/// It also records the dataflow frontier.
-///
-/// This should be called on the dataflow frontier stream itself.
-pub(crate) trait GarbageCollector<S: Scope, K: ExchangeData + Hash + Eq> {
-    fn garbage_collector<IB, D: 'static>(
-        &self,
-        recovery_store_summary: Vec<(StepId, K, S::Timestamp, UpdateType)>,
-        backups: IB,
-        recovery_collector: Rc<Box<dyn RecoveryStore<S::Timestamp, K, D>>>,
-    ) where
-        IB: IntoIterator<Item = Stream<S, (StepId, K, UpdateType)>>;
+/// This is used to quickly find garbage state without needing to
+/// query the recovery store itself.
+struct RecoveryStoreSummary<K, T> {
+    db: HashMap<(StepId, K), HashMap<T, UpdateType>>,
 }
 
-impl<S, K: ExchangeData + Hash + Eq + Debug> GarbageCollector<S, K> for Stream<S, ()>
+impl<K: ExchangeData + Hash + Eq, T: Timestamp> RecoveryStoreSummary<K, T> {
+    fn new() -> Self {
+        Self { db: HashMap::new() }
+    }
+
+    /// Mark that state for this step ID, key, and epoch was saved.
+    ///
+    /// We don't store the state itself in-memory, just the update
+    /// type (for GC reasons).
+    fn insert_saved(&mut self, step_id: StepId, key: K, epoch: T, state: UpdateType) {
+        self.db
+            .entry((step_id, key))
+            .or_default()
+            .insert(epoch, state);
+    }
+
+    /// Find and remove all garbage given a finalized epoch.
+    ///
+    /// Garbage is any state data before or during a finalized epoch,
+    /// other than the last upsert for a key (since that's still
+    /// relevant since it hasn't been overwritten yet).
+    fn drain_garbage(&mut self, finalized_epoch: &T) -> Vec<(StepId, K, T)> {
+        let mut garbage = Vec::new();
+
+        let mut empty_map_keys = Vec::new();
+        for (map_key, epoch_updates) in self.db.iter_mut() {
+            let (step_id, key) = map_key;
+
+            // TODO: The following becomes way cleaner once
+            // [`std::collections::BTreeMap::drain_filter`] hits
+            // stable.
+
+            // [`std::collections::BTreeMap::split_off`] looks at all
+            // the keys (epochs) in order, keeps every epoch <
+            // finalized_epoch, returns epoch >= finalized_epoch.
+            let (mut map_key_garbage, mut map_key_non_garbage): (Vec<_>, Vec<_>) = epoch_updates
+                .drain()
+                .partition(|(epoch, _update_type)| epoch <= finalized_epoch);
+            map_key_garbage.sort();
+
+            // If the final bit of "garbage" is an upsert, keep it,
+            // since it's the state we'd use to recover.
+            if let Some(epoch_update) = map_key_garbage.pop() {
+                let (_epoch, update_type) = &epoch_update;
+                if update_type == &UpdateType::Upsert {
+                    map_key_non_garbage.push(epoch_update);
+                } else {
+                    map_key_garbage.push(epoch_update);
+                }
+            }
+
+            for (epoch, _update_type) in map_key_garbage {
+                garbage.push((step_id.clone(), key.clone(), epoch.clone()));
+            }
+
+            // Non-garbage should remain in the in-mem DB.
+            *epoch_updates = map_key_non_garbage.into_iter().collect::<HashMap<_, _>>();
+
+            if epoch_updates.is_empty() {
+                empty_map_keys.push(map_key.clone());
+            }
+        }
+
+        // Clean up any keys that aren't seen again.
+        for map_key in empty_map_keys {
+            self.db.remove(&map_key);
+        }
+
+        garbage
+    }
+}
+
+/// Utility operator which deals with all recovery store coordination.
+///
+/// Does three things:
+///
+/// 1. Listens to the streams of all state updates from stateful
+/// operators and backs them up to the recovery store. It then outputs
+/// a summary of backed up state.
+///
+/// 2. Listens to the dataflow frontier, determines if any previously
+/// backed-up state is garbage and GCs it.
+///
+/// 3. Writes out the current dataflow frontier as the recovery epoch.
+pub(crate) trait Recovery<S: Scope, K: ExchangeData + Hash + Eq, D: Data> {
+    fn recovery<IB>(
+        &self,
+        state_updates: IB,
+        dataflow_frontier_loop: Stream<S, ()>,
+        recovery_store: Box<dyn RecoveryStore<S::Timestamp, K, D>>,
+        recovery_store_summary: Vec<(StepId, K, S::Timestamp, UpdateType)>,
+    ) -> (
+        Stream<S, (StepId, K, UpdateType)>,
+        Stream<S, (StepId, K, S::Timestamp)>,
+    )
+    where
+        IB: IntoIterator<Item = Stream<S, (StepId, K, Option<D>)>>;
+}
+
+impl<S: Scope, K: ExchangeData + Hash + Eq + Debug, D: Data> Recovery<S, K, D> for S
+// TODO: Drop the Timestamp = u64 requirement. The only thing
+// preventing that is some way of specifying a generic path summary
+// that means "timestamp not incremented" like
+// `Antichain::from_elem(0)`.
 where
     S: Scope<Timestamp = u64>,
 {
-    fn garbage_collector<IB, D: 'static>(
+    fn recovery<IB>(
         &self,
+        state_updates: IB,
+        dataflow_frontier_loop: Stream<S, ()>,
+        mut recovery_store: Box<dyn RecoveryStore<S::Timestamp, K, D>>,
         recovery_store_log: Vec<(StepId, K, S::Timestamp, UpdateType)>,
-        backups: IB,
-        recovery_collector: Rc<Box<dyn RecoveryStore<S::Timestamp, K, D>>>,
-    ) where
-        IB: IntoIterator<Item = Stream<S, (StepId, K, UpdateType)>>,
+    ) -> (
+        Stream<S, (StepId, K, UpdateType)>,
+        Stream<S, (StepId, K, S::Timestamp)>,
+    )
+    where
+        IB: IntoIterator<Item = Stream<S, (StepId, K, Option<D>)>>,
     {
-        let mut op_builder = OperatorBuilder::new("GarbageCollector".to_string(), self.scope());
+        let mut op_builder = OperatorBuilder::new("Recovery".to_string(), self.clone());
 
-        let mut dataflow_frontier_input = op_builder.new_input(self, pact::Pipeline);
-        let mut backup_inputs = backups
+        let (mut backup_output_wrapper, backup_output_stream) = op_builder.new_output();
+        let (mut gc_output_wrapper, gc_output_stream) = op_builder.new_output();
+
+        // We have to use these complicated sigatures to ensure the
+        // path summaries are correct because not every input results
+        // in output on every output.
+        let mut dataflow_frontier_input = op_builder.new_input_connection(
+            &dataflow_frontier_loop,
+            pact::Pipeline,
+            // This is saying this input only produces output on the
+            // second / GC output.
+            vec![Antichain::new(), Antichain::from_elem(0)],
+        );
+        let mut state_inputs = state_updates
             .into_iter()
-            .map(|s| op_builder.new_input(&s, pact::Pipeline))
+            .map(|s| {
+                op_builder.new_input_connection(
+                    &s,
+                    pact::Pipeline,
+                    // This is saying this input only produces output
+                    // on the first / backup output.
+                    vec![Antichain::from_elem(0), Antichain::new()],
+                )
+            })
             .collect::<Vec<_>>();
 
+        let mut gc_fncater = FrontierNotificator::new();
         op_builder.build(move |_init_capabilities| {
-            let mut tmp_recovery_keys = Vec::new();
-            let mut garbage_key_buffer = Vec::new();
-            let mut recovery_store_summary: HashMap<
-                (StepId, K),
-                BTreeSet<(S::Timestamp, UpdateType)>,
-            > = HashMap::new();
+            let mut tmp_state_updates = Vec::new();
+            let mut tmp_dataflow_frontier_pings = Vec::new();
+            let mut recovery_store_summary = RecoveryStoreSummary::new();
 
             // Load the initial summary of the recovery store into
             // this special query structure in memory.
             for (step_id, key, epoch, update_type) in recovery_store_log {
-                recovery_store_summary
-                    .entry((step_id, key))
-                    .or_default()
-                    .insert((epoch, update_type));
+                recovery_store_summary.insert_saved(step_id, key, epoch, update_type);
             }
 
             move |input_frontiers| {
-                let mut dataflow_frontier_input_handle =
-                    FrontieredInputHandle::new(&mut dataflow_frontier_input, &input_frontiers[0]);
-
-                // Gotta drain the data on this input to advance its
-                // frontier, even if we do nothing with it.
-                dataflow_frontier_input_handle.for_each(|_cap, _data| {});
-
-                for input in backup_inputs.iter_mut() {
+                // Backup section: continuously backup state updates
+                // to the recovery store and then emit downstream a
+                // summary of what happened.
+                let mut backup_output_handler = backup_output_wrapper.activate();
+                for input in state_inputs.iter_mut() {
                     input.for_each(|cap, data| {
-                        data.swap(&mut tmp_recovery_keys);
+                        data.swap(&mut tmp_state_updates);
+                        let cap = cap.retain_for_output(0);
+                        let mut backup_output_session = backup_output_handler.session(&cap);
                         let epoch = cap.time();
 
                         // Drain items so we don't have to re-allocate.
-                        for (step_id, key, update_type) in tmp_recovery_keys.drain(..) {
-                            recovery_store_summary
-                                .entry((step_id, key))
-                                .or_default()
-                                .insert((epoch.clone(), update_type));
+                        for (step_id, key, state) in tmp_state_updates.drain(..) {
+                            recovery_store.save_state(&step_id, &key, epoch, &state);
+                            let update_type: UpdateType = state.into();
+                            recovery_store_summary.insert_saved(
+                                step_id.clone(),
+                                key.clone(),
+                                *epoch,
+                                update_type.clone(),
+                            );
+                            backup_output_session.give((step_id, key, update_type));
                         }
                     });
                 }
 
-                // TODO: This runs on every operator activation. We
-                // only need to run when the dataflow frontier has
-                // actually updated, though.
-                let dataflow_frontier = dataflow_frontier_input_handle.frontier().frontier();
-                let is_collectable =
-                // Why +2? The dataflow frontier is the oldest
-                // in-progress epoch. Thus -1 is the epoch who's state
-                // we need to fully recreate during recovery and we
-                // shouldn't GC it. Thus -2 is the first GC-able
-                // epoch. We'd like to be able to write
-                // `dataflow_frontier - 2 >= epoch` but since there's
-                // no [`Anitchain::greater_than()`], we use
-                // `!less_than()` and since you can't do math on the
-                // frontier set, we move the `-2` to the other side
-                // and it becomes `+2`.
+                // Store in the notificator what epochs have resulted
+                // in backup data.
+                dataflow_frontier_input.for_each(|cap, data| {
+                    // Drain the input so the frontier advances.
+                    data.swap(&mut tmp_dataflow_frontier_pings);
+                    tmp_dataflow_frontier_pings.drain(..);
+                    gc_fncater.notify_at(cap.retain_for_output(1));
+                });
 
-                // TODO: Is there a way to do this without a fixed
-                // offset? It feels kinda hacky and would be cool to
-                // support arbitrary timestamp types.
+                // Find epochs that are now older than the dataflow
+                // frontier. These are now finalized and might be able
+                // to result in garbage.
+                let mut gc_output_handler = gc_output_wrapper.activate();
+                // 0th is the first defined input.
+                let dataflow_frontier = &input_frontiers[0];
+                gc_fncater.for_each(&[dataflow_frontier], |cap, _ncater| {
+                    let mut gc_output_session = gc_output_handler.session(&cap);
+                    // If the dataflow frontier has passed a
+                    // notificator-retained epoch, it means it is
+                    // fully output and backed up.
+                    let finalized_epoch = cap.time();
 
-                    |epoch: &u64| -> bool { !dataflow_frontier.less_than(&(epoch + 2)) };
-                // We save the dataflow frontier here in the garbage
-                // collector and not in the dataflow frontier operator
-                // because we are downstream of broadcast() which
-                // ensures we'll be getting the true cluster dataflow
-                // frontier, not local to any worker.
-                recovery_collector.save_frontier(dataflow_frontier);
+                    // Resume from the beginning of the dataflow
+                    // frontier; it's the oldest in-progress epoch.
+                    // We save the resume epoch here in the garbage
+                    // collector and not in the dataflow frontier
+                    // operator because we are downstream of
+                    // broadcast() which ensures we'll be getting the
+                    // true cluster dataflow frontier, not local to
+                    // any worker.
+                    recovery_store.save_frontier(dataflow_frontier.frontier());
 
-                for ((step_id, key), epoch_updates) in recovery_store_summary.iter() {
-                    // [`BTreeSet::iter()`] is in asc order.
-                    let mut collectable_updates = epoch_updates
-                        .range(..)
-                        .filter(|(epoch, _update_type)| is_collectable(epoch))
-                        .map(|(epoch, update_type)| {
-                            (step_id.clone(), key.clone(), *epoch, update_type.clone())
-                        })
-                        .collect::<Vec<_>>();
-
-                    // Never collect the last upsert; that's the most
-                    // recent recovery data! If the final update is a
-                    // delete, though then collect that so abandoned
-                    // keys are GCd.
-                    if let Some((_step_id, _key, _epoch, UpdateType::Upsert)) =
-                        collectable_updates.last()
+                    // Now remove all GCd items from the recovery
+                    // store and the local copy of the keyspace.
+                    for (step_id, key, epoch) in
+                        recovery_store_summary.drain_garbage(finalized_epoch)
                     {
-                        collectable_updates.pop();
+                        recovery_store.delete_state(&step_id, &key, &epoch);
+                        // Output that we deleted this previous state
+                        // in the finalized epoch.
+                        gc_output_session.give((step_id, key, epoch));
                     }
+                });
 
-                    garbage_key_buffer.append(&mut collectable_updates);
-                }
-
-                // Now remove all GCd items from the recovery store
-                // and the local copy of the keyspace.
-                for (step_id, key, epoch, update_type) in garbage_key_buffer.drain(..) {
-                    recovery_collector.delete_state(&step_id, &key, &epoch);
-
-                    // Do this multi-step process so we don't have
-                    // empty BTreeSets in the summary.
-                    let recovery_key = (step_id, key);
-                    let mut epochs_remaining = recovery_store_summary
-                        .remove(&recovery_key)
-                        .unwrap_or_default();
-                    let recovery_value = (epoch, update_type);
-                    epochs_remaining.remove(&recovery_value);
-                    if !epochs_remaining.is_empty() {
-                        recovery_store_summary.insert(recovery_key, epochs_remaining);
-                    }
-                }
+                // NOTE: We won't call this GC code when the dataflow
+                // frontier closes / input is complete. This makes
+                // sense to me: It's not correct to say last_epoch+1
+                // has been "finalized" as it never happened. And it
+                // supports the use case of "continuing" a completed
+                // dataflow by starting back up at that epoch.
             }
         });
+
+        (backup_output_stream, gc_output_stream)
     }
 }

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -820,9 +820,10 @@ impl RecoveryStore<u64, TdPyAny, TdPyAny> for KafkaRecoveryStore {
                     let msg_payload = msg.payload().map(KafkaPayload::from_bytes);
                     match msg_key {
                         KafkaKey::DataflowFrontier => match msg_payload {
-                            Some(KafkaPayload::DataflowFrontier(dataflow_frontier)) => {
-                                resume_epoch = dataflow_frontier;
-                            },
+                            Some(KafkaPayload::DataflowFrontier(dataflow_frontier)) => resume_epoch = dataflow_frontier,
+                            // TODO: Figure out better semantics when
+                            // resuming a completed dataflow.
+                            None => resume_epoch = 0,
                             unexpected_payload => panic!("Unexpected dataflow frontier Kafka message payload: {unexpected_payload:?}"),
                         },
                         KafkaKey::State { step_id, key, epoch } => {

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -751,9 +751,8 @@ impl RecoveryStore<u64, TdPyAny, TdPyAny> for KafkaRecoveryStore {
 
         let consumer: StreamConsumer = self.rt.block_on(async {
             ClientConfig::new()
-                // TODO: Should we be generating a new consumer group
-                // per cluster execution? Or will the group offset
-                // reset?
+                // TODO: Do away with a consumer group here and
+                // instead do per-worker recovery loading.
                 .set("group.id", "bytewax-loader")
                 .set("bootstrap.servers", self.hosts.join(","))
                 .set("auto.offset.reset", "earliest")


### PR DESCRIPTION
We've got a few things going on that are all connected together:

New Recovery Operators
======================

Refactors the recovery machinery so that all writing to the recovery
store happens in just the `Recovery` operator. This is so we don't
have to have `Rc<>` around the recovery store and can use underlying
libraries that require `&mut` to the writer.

New setup:

```mermaid
graph TD
DB{{Dataflow Builder}} -. Recovered State .-> S1
DB -. Recovered State .-> S2
DB -. Resume Epoch .-> I
I(Input) --> X1([... More Dataflow ...])
X1 --> S1(Stateful Operator)
S1 -. Updated State .-> R{{Recovery}}
S1 -- Logic Output --> X2([... More Dataflow ...]) --> C1(Capture)
X1 --> S2(Stateful Operator)
S2 -. Updated State .-> R
S2 -- Logic Output --> X3([... More Dataflow ...]) --> C2(Capture)
R -. Backup Frontier .-> DF{{Dataflow Frontier}}
C1 -. Frontier .-> DF
C2 -. Frontier .-> DF
DF -. Dataflow Frontier .-> R
```

Previously there was a `Backup` operator attached to each stateful
operator (e.g. `StatefulMap`). Now each stateful operator writes out a
stream of state updates, and we use a little `map` to apply the step
ID to the state updates. All those updates are funneled into
`Recovery` which actually does the writing.

`Recovery` now outputs a stream of backup updates. The
`DataflowFrontier` operator listens to that and all the `Capture`s,
and still outputs heartbeat events whenever the dataflow frontier
advances. (As a reminder the **dataflow frontier** is the oldest
in-progress epoch that is still being output or backed-up.)

Previously there was a `GarbageCollector` operator which listened to
these heartbeats and GCd old state data. This has been moved into the
`Recovery` operator itself, listening on a second input stream. This
required using the fancy `feedback` operator and telling the operator
builder in `Recovery` what inputs would result in cycles on which
outputs. Whenever a dataflow frontier has been GCd, it emits an output
event. There are comments in the code explaining these advanced
things.

One minor change here is renaming our `probe` to `execution_frontier`
and making sure it watches both outputs and GCs. We need to make sure
that the `worker_main` doesn't stop just after all output is complete,
it must _also_ wait for all GC / state writing to be
complete. Otherwise you'll restart further behind than the end of the
dataflow. I want to make sure if the dataflow finishes without error,
and you attempt to recover it, it does no work (as there's nothing to
do). In the future, this might be useful for "adding" new data onto a
computation and continuing it.

Recovery Store
==============

The `RecoveryStore` trait has been modified a little to take `&mut
self` so you can use a wider range of underlying interfaces. The Kafka
producers required mut references to write. This is made possible by
centralizing all writes into that `Recovery` operator.

Kafka Bits
==========

Adds a `KafkaRecoveryConfig` PyO3 object which is analagous to the
`SqliteRecoveryConfig`: it stores the connection information and tells
Bytewax to use Kafka as the recovery store.

Then adds a new `RecoveryStore` impl `KafkaRecoveryStore` which
actually does the reading and writing. The rustdocs describe how the
data is formatted in the topic. tl;dr use the topic as a change log on
a key-value store and write out `(state_id, key, epoch)` key changes.

One slightly tricky thing here is Kafka messages are just bags of
bytes: bytes as the keys and bytes as the values / payloads. In order
to not have to write my own marshalling code, I use `serde` and create
some key and payload enums and use the `bincode` format to write
them. I picked that just because that's what Timely uses for
serialization, but we might want to pick something more human readable
for debugging the topic.

TODO
====

This currently doesn't resume properly with multiple workers. I want
to do a deeper dive into that process in another PR and do the whole
thing of using a mini-dataflow to help with loading.

Also if you do use this to resume, it's kinda slow when the consumer
group is figuring out who is reading what. Sometimes it takes a min or
two to resume.
