### PR TITLE
Require state keys to be strings

### DIFF
--- a/docs/articles/getting-started/design-patterns.md
+++ b/docs/articles/getting-started/design-patterns.md
@@ -230,12 +230,12 @@ flow.capture()
 
 
 inp = [
-    (0, {"user_id": 1, "type": "login"}),
-    (0, {"user_id": 1, "type": "logout"}),
+    (0, {"user_id": "1", "type": "login"}),
+    (0, {"user_id": "1", "type": "logout"}),
 ]
 print(run(flow, inp))
 ```
 
 ```{testoutput}
-[(0, [{'user_id': 1, 'type': 'login'}, {'user_id': 1, 'type': 'logout'}])]
+[(0, [{'user_id': '1', 'type': 'login'}, {'user_id': '1', 'type': 'logout'}])]
 ```

--- a/docs/articles/getting-started/operators.md
+++ b/docs/articles/getting-started/operators.md
@@ -18,9 +18,15 @@ Operators generally do not modify the epoch of the data that is passing through 
 
 ## Stateful Operators
 
-Any operator which carries state between processing items is a **stateful operator**.
+Any operator which carries state between processing items is a
+**stateful operator**.
 
-In order to coordinate this state in a multiple-worker execution, all stateful operators require that their input are make up of **keys** and **values** in a `(key, value)` two-tuple. Bytewax can then route the value to the worker that has the relevant state. Any output from these operators will also be `(key, output_item)` two-tuples as well.
+In order to coordinate this state in a multiple-worker execution, all
+stateful operators require that their input are make up of **keys**
+and **values** in a `(key, value)` two-tuple. Keys must be
+strings. Bytewax can then route the value to the worker that has the
+relevant state. Any output from these operators will also be `(key,
+output_item)` two-tuples as well.
 
 ## Recoverable Operators
 

--- a/docs/examples/search-session.md
+++ b/docs/examples/search-session.md
@@ -141,16 +141,16 @@ Our first task is to make sure to group incoming events by user since
 no session deals with multiple users.
 
 All Bytewax operators that perform grouping require that their input
-be in the form of a `(key, value)` tuple, where `key` is the value the
-dataflow will group by before passing to the operator logic.
+be in the form of a `(key, value)` tuple, where `key` is the string
+the dataflow will group by before passing to the operator logic.
 
 The operator which modifies all data flowing through it is
-[map](/apidocs#bytewax.Dataflow.map). Let's use that and pull each event's user into
-that key position.
+[map](/apidocs#bytewax.Dataflow.map). Let's use that and pull each
+event's user ID as a string into that key position.
 
 ```python
 def initial_session(event):
-    return event.user, [event]
+    return str(event.user), [event]
 
 flow.map(initial_session)
 ```
@@ -173,7 +173,7 @@ Reduce requires two bits of logic:
 - When is a session complete? In this case, a session is complete when
   the last item in the session is the app closing. We'll write a
   `session_has_closed` function to answer that.
-  
+
 Reduce also takes a unique **step ID** to help organize the state
 saved internally.
 

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -215,8 +215,9 @@ impl Dataflow {
     /// epoch order.
     ///
     /// It is a stateful operator. It requires the the input stream
-    /// has items that are `(key, value)` tuples so we can ensure that
-    /// all relevant values are routed to the relevant aggregator.
+    /// has items that are `(key: str, value)` tuples so we can ensure
+    /// that all relevant values are routed to the relevant
+    /// aggregator.
     ///
     /// It is a recoverable operator. It requires a step ID to recover
     /// the correct state.
@@ -292,8 +293,9 @@ impl Dataflow {
     /// aggregator as complete automatically at the end of each epoch.
     ///
     /// It is a stateful operator. it requires the the input stream
-    /// has items that are `(key, value)` tuples so we can ensure that
-    /// all relevant values are routed to the relevant aggregator.
+    /// has items that are `(key: str, value)` tuples so we can ensure
+    /// that all relevant values are routed to the relevant
+    /// aggregator.
     ///
     /// It calls a **reducer** function which combines two values. The
     /// aggregator is initially the first value seen for a key. Values
@@ -370,8 +372,8 @@ impl Dataflow {
     /// state for each key when doing the transformation.
     ///
     /// It is a stateful operator. It requires the the input stream
-    /// has items that are `(key, value)` tuples so we can ensure that
-    /// all relevant values are routed to the relevant state.
+    /// has items that are `(key: str, value)` tuples so we can ensure
+    /// that all relevant values are routed to the relevant state.
     ///
     /// It is a recoverable operator. It requires a step ID to recover
     /// the correct state.


### PR DESCRIPTION
I think it's going to be important to require the `key` in the `(key,
value)` 2-tuples to be a string. We / Timely do a lot with those keys
that we don't do with the values: shove them in hash maps (so they
need to properly be `Hash` and `PartialEq` and `Eq`), serialize them
and hope that the bytes are equal if the keys are equal (for recovery
DB lookup), print them for debugging. I'm worried that either folks
are going to use some Python types that don't obey equality correctly,
or there's going to be some issue with Pickling, and I think forcing
keys to be strings will make things easier to debug and write.

Adds a `StateKey` newtype wrapper around `String` and swaps out all
the `TdPyAny`s that represented the key with that type. Fills in some
shim traits.

Renames / cleans up `lift_2tuple` and `wrap_2tuple` into
`extract_state_pair` and `wrap_state_pair` with better error
reporting. Fixes https://github.com/bytewax/bytewax/issues/80

Tests the error messages and fixes docs to say the key has to be a
string.
