### PR TITLE
Stateful windowing operators

### DIFF
--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -217,12 +217,10 @@ impl Dataflow {
     fn tumbling_window(
         &mut self,
         step_id: String,
-        datetime_getter_fn: TdPyCallable,
         window_time: TdPyAny,
     ) {
         self.steps.push(Step::TumblingWindow {
             step_id: StepId(step_id),
-            datetime_getter_fn,
             window_time,
         });
     }
@@ -529,7 +527,6 @@ pub(crate) enum Step {
     },
     TumblingWindow {
         step_id: StepId,
-        datetime_getter_fn: TdPyCallable,
         window_time: TdPyAny,
     },
     Capture {},
@@ -577,10 +574,9 @@ impl<'source> FromPyObject<'source> for Step {
                 mapper,
             });
         }
-        if let Ok(("TumblingWindow", step_id, datetime_getter_fn, window_time)) = tuple.extract() {
+        if let Ok(("TumblingWindow", step_id, window_time)) = tuple.extract() {
             return Ok(Self::TumblingWindow {
                 step_id: StepId(step_id),
-                datetime_getter_fn,
                 window_time,
             });
         }
@@ -619,12 +615,10 @@ impl ToPyObject for Step {
             } => ("StatefulMap", step_id.0.clone(), builder, mapper).to_object(py),
             Self::TumblingWindow {
                 step_id,
-                datetime_getter_fn,
                 window_time,
             } => (
                 "TumblingWindow",
                 step_id.0.clone(),
-                datetime_getter_fn,
                 window_time,
             )
                 .to_object(py),

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -234,6 +234,7 @@ where
                 Step::TumblingWindow {
                     step_id,
                     datetime_getter_fn,
+                    window_time
                 } => {
                     let time_getter_fn = datetime_getter_fn.clone_ref(py);
                     let state_cache = state_caches.remove(step_id).unwrap_or_default();
@@ -259,6 +260,7 @@ where
                             move |key, current_window, value| {
                                 aggregate_window(key, current_window, value)
                             },
+                            window_time,
                             StateKey::route,
                         );
 

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -244,14 +244,15 @@ where
                         move |output| {
                             if let Some(cap) = cap.as_mut() {
                                 output.session(&cap).give(());
-                                cap.downgrade(&(cap.time() + 10));
-                                debug!("Setting activation after 10s");
-                                activator.activate_after(Duration::new(10, 0));                                                  }
+                                cap.downgrade(&(cap.time() + 1));
+                                debug!("Setting activation");
+                                activator.activate_after(Duration::new(1, 0));
+                            }
                         }
                     });
 
                     // TODO: Handle state update stream
-                    let (downstream, _state_update_stream) =
+                    let (downstream, state_update_stream) =
                         stream.map(extract_state_pair).tumbling_window(
                             window_source_stream,
                             state_cache,

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -232,11 +232,9 @@ where
                 }
                 Step::TumblingWindow {
                     step_id,
-                    datetime_getter_fn,
                     window_time,
                 } => {
                     let step_id = step_id.clone();
-                    let time_getter_fn = datetime_getter_fn.clone_ref(py);
                     let state_cache = state_caches.remove(&step_id).unwrap_or_default();
                     let window_source_stream = source(scope, "Source", |capability, info| {
                         // Create an activator to provide a heartbeat for this window function

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -9,6 +9,8 @@
 //!     2. Shim functions that totally encapsulate PyO3 and Python
 //!     calling boilerplate to easily pass into Timely operators.
 
+pub mod window;
+
 use crate::dataflow::StepId;
 use crate::pyo3_extensions::StateKey;
 use crate::recovery::RecoveryStore;

--- a/src/operators/window.rs
+++ b/src/operators/window.rs
@@ -1,0 +1,190 @@
+//! Code implementing Bytewax's windowing operators on top of Timely's
+//! operators.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::hash::Hash;
+
+use log::debug;
+use timely::dataflow::channels::pact;
+use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use timely::dataflow::operators::generic::FrontieredInputHandle;
+use timely::dataflow::operators::FrontierNotificator;
+use timely::dataflow::Scope;
+use timely::dataflow::Stream;
+use timely::ExchangeData;
+
+use pyo3::prelude::*;
+use timely::progress::Antichain;
+
+use crate::pyo3_extensions::StateKey;
+use crate::pyo3_extensions::TdPyAny;
+
+// Based on the good work in
+// https://github.com/TimelyDataflow/timely-dataflow/blob/0d0d84885672d6369a78cd9aff7beb2048390d3b/timely/src/dataflow/operators/aggregation/state_machine.rs#L57
+pub(crate) trait TumblingWindow<S: Scope, K: ExchangeData + Hash + Eq, V: ExchangeData> {
+    /// First return stream is window output, second is
+    /// updates for recovery you'll probably pass into a [`Backup`]
+    /// operator.
+    fn tumbling_window<
+        W: Fn(&K, Option<V>, &V) -> V + 'static, // Windowing function
+        H: Fn(&K) -> u64 + 'static,              // Hash function of key to worker
+    >(
+        &self,
+        windowing_stream: Stream<S, ()>,
+        state_cache: HashMap<K, V>,
+        window_fn: W,
+        hasher: H,
+    ) -> (Stream<S, (K, V)>, Stream<S, (K, Option<V>)>)
+    where
+        S: Scope<Timestamp = u64>;
+}
+
+impl<S: Scope, K: ExchangeData + Hash + Eq, V: ExchangeData> TumblingWindow<S, K, V>
+    for Stream<S, (K, V)>
+{
+    fn tumbling_window<
+        W: Fn(&K, Option<V>, &V) -> V + 'static, // Windowing function
+        H: Fn(&K) -> u64 + 'static,              // Hash function of key to worker
+    >(
+        &self,
+        windowing_stream: Stream<S, ()>,
+        mut state_cache: HashMap<K, V>,
+        window_fn: W,
+        hasher: H,
+    ) -> (Stream<S, (K, V)>, Stream<S, (K, Option<V>)>) {
+        let mut op_builder = OperatorBuilder::new("TumblingWindow".to_owned(), self.scope());
+
+        let mut input = op_builder.new_input(
+            self,
+            pact::Exchange::new(move |&(ref key, ref _value)| hasher(key)),
+        );
+
+        let (mut downstream_output_wrapper, downstream_stream) = op_builder.new_output();
+        let (mut state_update_output_wrapper, state_update_stream) = op_builder.new_output();
+
+        let mut windowing_input = op_builder.new_input_connection(
+            &windowing_stream,
+            pact::Pipeline,
+            vec![Antichain::new(), Antichain::new()],
+        );
+
+        op_builder.build(move |_init_capabilities| {
+            let mut tmp_key_values = Vec::new();
+            let mut incoming_epoch_to_key_values_buffer = HashMap::new();
+
+            let mut tmp_updated_keys = HashSet::new();
+            let mut outgoing_epoch_to_state_updates_buffer = HashMap::new();
+
+            let mut downstream_fncater = FrontierNotificator::new();
+            let mut state_update_fncater = FrontierNotificator::new();
+            move |input_frontiers| {
+                let mut input_handle = FrontieredInputHandle::new(&mut input, &input_frontiers[0]);
+                let mut downstream_output_handle = downstream_output_wrapper.activate();
+                let mut state_update_output_handle = state_update_output_wrapper.activate();
+
+                windowing_input.for_each(|cap, _value| {
+                    debug!("Window input received: {cap:?}");
+                    let epoch = cap.time();
+                    downstream_fncater.notify_at(cap.delayed_for_output(epoch, 0));
+                });
+
+                input_handle.for_each(|cap, key_values| {
+                    key_values.swap(&mut tmp_key_values);
+
+                    let epoch = cap.time();
+                    incoming_epoch_to_key_values_buffer
+                        .entry(epoch.clone())
+                        .or_insert_with(Vec::new)
+                        .extend(tmp_key_values.drain(..));
+
+                    state_update_fncater.notify_at(cap.delayed_for_output(epoch, 1));
+                });
+
+                // This runs once per epoch that will be no longer be
+                // seen in the input of this operator (not the whole
+                // dataflow, though).
+                downstream_fncater.for_each(
+                    &[input_handle.frontier()],
+                    |downstream_cap, _ncater| {
+                        let epoch = downstream_cap.time();
+                        if let Some(key_values) = incoming_epoch_to_key_values_buffer.remove(epoch)
+                        {
+                            for (key, value) in key_values {
+                                let current_window = state_cache.remove(&key);
+                                let updated_window_for_key =
+                                    window_fn(&key, current_window, &value);
+                                // Save the window so we can use
+                                // it if there are multiple values
+                                // within this epoch. We do not save
+                                // to the recovery store here because
+                                // we don't have finalized state for
+                                // the epoch.
+                                debug!("Window complete");
+                                let mut downstream_output_session =
+                                    downstream_output_handle.session(&downstream_cap);
+                                downstream_output_session
+                                    .give((key.clone(), updated_window_for_key));
+                                state_cache.remove(&key);
+                            }
+
+                            // Now that this epoch is over, find the final
+                            // updated state for all keys that were
+                            // touched and save that to be emitted
+                            // downstream for the second output.
+                            for key in tmp_updated_keys.drain() {
+                                let updated_state = state_cache.get(&key).cloned();
+                                outgoing_epoch_to_state_updates_buffer
+                                    .entry(epoch.clone())
+                                    .or_insert_with(Vec::new)
+                                    .push((key, updated_state));
+                            }
+                        } else {
+                            todo!()
+                        }
+                    },
+                );
+
+                state_update_fncater.for_each(
+                    &[input_handle.frontier()],
+                    |state_update_cap, _ncater| {
+                        let epoch = state_update_cap.time();
+                        let mut state_update_output_session =
+                            state_update_output_handle.session(&state_update_cap);
+                        // Now that this epoch is complete, write out any
+                        // modified state. `remove()` will ensure we
+                        // slowly drain the buffer.
+                        if let Some(state_updates) =
+                            outgoing_epoch_to_state_updates_buffer.remove(epoch)
+                        {
+                            for (key, updated_state) in state_updates {
+                                state_update_output_session.give((key, updated_state));
+                            }
+                        }
+                    },
+                );
+            }
+        });
+
+        (downstream_stream, state_update_stream)
+    }
+}
+
+pub(crate) fn aggregate_window(
+    key: &StateKey,
+    current_window: Option<&TdPyAny>,
+    value: &TdPyAny,
+) -> TdPyAny {
+    Python::with_gil(|py| {
+        let updated_window = if let Some(current_window) = current_window {
+            let mut current_window: Vec<TdPyAny> = current_window.extract(py).unwrap();
+            current_window.push(value.clone_ref(py));
+            current_window
+        } else {
+            vec![value.clone_ref(py)]
+        };
+
+        debug!("aggregate_window for key={key:?}: current_window={current_window:?} {value:?}) -> updated_window={updated_window:?}");
+        updated_window.into_py(py).clone_ref(py).into()
+    })
+}


### PR DESCRIPTION
## Stateful windowing operators

This PR begins the work of providing stateful windowing operators in Bytewax.

I'm opening this PR in draft form to solicit feedback before I continue working on other implementations of windows.

## Overview

I am starting this PR with a basic tumbling window operator that interoperates with our current recovery store. `tumbling_window` is very similar in shape to operators like `stateful_map` and `reduce`, but differs in that it uses [activate_after](https://docs.rs/timely/0.12.0/timely/scheduling/activate/struct.Activator.html#method.activate_after) to re-activate itself periodically. Being able to re-schedule the operator to run allows us to yield completed windows downstream even in the absence of new input.

## Processing time vs event time windows

Processing time windows specify that operators determine the current time of the data stream according to the system clock of the machine where they are being executed. In this implementation, the window starts from when the worker has started. In other stream processing frameworks, the windows are aligned to wall clock boundaries like `00:00:00`.

I started with processing-time windows, as they are conceptually simpler to implement. The difficulty with processing time windows is that they are non-deterministic, as they are based on the speed at which events arrive. The goal of processing-time windows is to provide the lowest latency, as they do not wait for late arriving data before emitting windows.

I believe that implementing event-time tumbling windows is the next logical step for this work, and once I have had some :eyes: on this implementation, I'll start work there.

## Notes

- In the current implementation, processing time windows will also not yield elements after the input handle is closed. I'm not sure how, or if I should modify this implementation to emit remaining records if the clock time has not passed.
- It's also unclear to me what the recovery semantics should be for processing-time windows. If you collect a window for a minute, crash after 30 seconds, and resume a minute later, presumably the window should be empty.
- I have a TODO to investigate how to calculate the optimal time to re-schedule the operator for that will produce correct windows, while not activating the operator to run an excessive number of times.
- Testing windows means adding some code to wait in our tests for the window to accumulate some state. Should we consider adding a pytest [marker](https://docs.pytest.org/en/7.1.x/example/markers.html) for these?
- I chose an arbitrary lower-bound on the frequency of windowing to be 1 second.
 
