### PR TITLE
Multi-worker recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Recovery format has been changed for all recovery stores. You cannot
+  resume from recovery data written with an older version.
+
+- Slight changes to `bytewax.recovery.RecoveryConfig` config options
+  due to recovery system changes.
+
+- `bytewax.run()` and `bytewax.run_cluster()` no longer take
+  `recovery_config` as they don't support recovery.
+
 
 ## 0.9.0
 
@@ -13,13 +22,13 @@ notes on GitHub when we make a new release.__
 
 - Adds `bytewax.run_main()` as a way to test input and output builders
   without starting a cluster.
-  
+
 - Adds a `bytewax.testing` module with helpers for testing.
 
 - `bytewax.run_cluster()` and `bytewax.spawn_cluster()` now take a
   `mp_ctx` argument to allow you to change the multiprocessing
   behavior. E.g. from "fork" to "spawn". Defaults now to "spawn".
-  
+
 - Adds dataflow recovery capabilities. See `bytewax.recovery`.
 
 - Stateful operators `bytewax.Dataflow.reduce()` and
@@ -37,25 +46,25 @@ notes on GitHub when we make a new release.__
 
 - `Executor.build_and_run()` is replaced with four entry points for
   specific use cases:
-  
+
   - `run()` for exeuction in the current process. It returns all
     captured items to the calling process for you. Use this for
     prototyping in notebooks and basic tests.
-  
+
   - `run_cluster()` for execution on a temporary machine-local cluster
     that Bytewax coordinates for you. It returns all captured items to
     the calling process for you. Use this for notebook analysis where
     you need parallelism.
-    
+
   - `spawn_cluster()` for starting a machine-local cluster with more
     control over input and output. Use this for standalone scripts
     where you might need partitioned input and output.
-  
+
   - `cluster_main()` for starting a process that will participate in a
     cluster you are coordinating manually. Use this when starting a
     Kubernetes cluster.
-  
+
 - Adds `bytewax.parse` module to help with reading command line
   arguments and environment variables for the above entrypoints.
-  
+
 - Renames `bytewax.inp` to `bytewax.inputs`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,11 +161,11 @@ version = "0.9.0"
 dependencies = [
  "axum",
  "bincode",
+ "futures",
  "log",
  "pyo3",
  "pyo3-log",
  "rdkafka",
- "retry",
  "scopeguard",
  "send_wrapper",
  "serde",
@@ -222,9 +222,9 @@ checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -356,15 +356,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -390,9 +390,9 @@ checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -401,21 +401,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1128,15 +1128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "retry"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac95c60a949a63fd2822f4964939662d8f2c16c4fa0624fd954bc6e703b9a3f6"
-dependencies = [
- "rand",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ python-source = "pysrc"
 [dependencies]
 axum = { version = "0.4.3" }
 bincode = { version = "1.3.3" }
+futures = { version = "0.3.21" }
 log = { version = "0.4" }
 pyo3 = { version = "0.15.1" }
 pyo3-log = { version = "0.5.0" }
 rdkafka = { version = "0.28.0", features = [ "cmake-build" ] }
-retry = { version = "1.3.1" }
 scopeguard = { version = "1.1.0" }
 send_wrapper = { version = "0.5.0" }
 serde = { version = "1.0.134" }

--- a/docs/examples/cart-join.md
+++ b/docs/examples/cart-join.md
@@ -190,17 +190,17 @@ def input_builder(worker_index, worker_count, resume_epoch):
 ```
 
 
-We need a **recovery store**. For this example we'll use a local
+We need a **recovery config** that describes where to store the state
+and progress data for this worker. For this example we'll use a local
 [SQLite](https://sqlite.org/index.html) database because we're running
 on a single machine.
-
 
 ```python
 from tempfile import TemporaryDirectory
 from bytewax.recovery import SqliteRecoveryConfig
 
 recovery_dir = TemporaryDirectory()  # We'll store this somewhere temporary for this test.
-recovery_config = SqliteRecoveryConfig(recovery_dir.name + "/state-recovery.sqlite3", create=True)
+recovery_config = SqliteRecoveryConfig(recovery_dir.name)
 ```
 
 Now if we run the dataflow, the internal state will be persisted at
@@ -209,7 +209,12 @@ run with any of the recovery systems activated last time, let's run
 the dataflow again with them enabled.
 
 ```python doctest:IGNORE_EXCEPTION_DETAIL doctest:ELLIPSIS
-run_main(flow, ManualInputConfig(input_builder), output_builder, recovery_config=recovery_config)
+run_main(
+    flow,
+    ManualInputConfig(input_builder),
+    output_builder,
+    recovery_config=recovery_config,
+)
 ```
 
 As expected, we have the same error.
@@ -250,7 +255,12 @@ so it resumes from there. As the `FAIL HERE` string is ignored,
 there's no output during epoch `5`.
 
 ```python
-run_main(flow, ManualInputConfig(input_builder), output_builder, recovery_config=recovery_config)
+run_main(
+    flow,
+    ManualInputConfig(input_builder),
+    output_builder,
+    recovery_config=recovery_config,
+)
 ```
 
 ```{testoutput}

--- a/examples/recovery_wordcount.py
+++ b/examples/recovery_wordcount.py
@@ -13,8 +13,8 @@ def input_builder(worker_index, worker_count, resume_epoch):
             if epoch % worker_count != worker_index:
                 continue
             yield AdvanceTo(epoch)
-            # if epoch == 3:
-            #     raise RuntimeError("boom")
+            if epoch == 3:
+                raise RuntimeError("boom")
             yield Emit(line)
 
 
@@ -56,13 +56,13 @@ flow.stateful_map("running_count", count_builder, add)
 flow.capture()
 
 
-# recovery_config = KafkaRecoveryConfig(
-#     ["localhost:9092"],
-#     "wordcount",
-# )
-recovery_config = SqliteRecoveryConfig(
-    ".",
+recovery_config = KafkaRecoveryConfig(
+    ["127.0.0.1:9092"],
+    "wordcount",
 )
+# recovery_config = SqliteRecoveryConfig(
+#     ".",
+# )
 
 if __name__ == "__main__":
     spawn_cluster(

--- a/pysrc/bytewax/execution.py
+++ b/pysrc/bytewax/execution.py
@@ -1,25 +1,19 @@
 """Entry point functions to execute `bytewax.Dataflow`s.
 
 """
-from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Iterable, List, Optional, Tuple
 
 from multiprocess import get_context
 
+from bytewax.inputs import AdvanceTo, Emit, InputConfig, ManualInputConfig
 from bytewax.recovery import RecoveryConfig
-from bytewax.inputs import AdvanceTo, Emit, ManualInputConfig, InputConfig
 
-from .bytewax import (
-    cluster_main,
-    Dataflow,
-    run_main,
-)
+from .bytewax import cluster_main, Dataflow, run_main
 
 
 def run(
     flow: Dataflow,
     inp: Iterable[Tuple[int, Any]],
-    *,
-    recovery_config: Optional[RecoveryConfig] = None,
 ) -> List[Tuple[int, Any]]:
     """Pass data through a dataflow running in the current thread.
 
@@ -45,10 +39,6 @@ def run(
         inp: Input data. If you are recovering a stateful dataflow,
             your input should resume from the last finalized epoch.
 
-        recovery_config: State recovery config. See
-            `bytewax.recovery`. If `None`, state will not be
-            persisted.
-
     Returns:
 
         List of `(epoch, item)` tuples seen by capture operators.
@@ -73,7 +63,6 @@ def run(
         flow,
         ManualInputConfig(input_builder),
         output_builder,
-        recovery_config=recovery_config,
     )
 
     return out
@@ -185,7 +174,6 @@ def run_cluster(
     flow: Dataflow,
     inp: Iterable[Tuple[int, Any]],
     *,
-    recovery_config: Optional[RecoveryConfig] = None,
     proc_count: int = 1,
     worker_count_per_proc: int = 1,
     mp_ctx=get_context("spawn"),
@@ -230,10 +218,6 @@ def run_cluster(
             you are recovering a stateful dataflow, you must ensure
             your input resumes from the last finalized epoch.
 
-        recovery_config: State recovery config. See
-            `bytewax.recovery`. If `None`, state will not be
-            persisted.
-
         proc_count: Number of processes to start.
 
         worker_count_per_proc: Number of worker threads to start on
@@ -268,7 +252,6 @@ def run_cluster(
             flow,
             ManualInputConfig(input_builder),
             output_builder,
-            recovery_config=recovery_config,
             proc_count=proc_count,
             worker_count_per_proc=worker_count_per_proc,
             mp_ctx=mp_ctx,

--- a/pysrc/bytewax/recovery.py
+++ b/pysrc/bytewax/recovery.py
@@ -4,14 +4,17 @@ Bytewax allows you to **recover** a stateful dataflow; it will let you
 resume processing and output due to a failure without re-processing
 all initial data to re-calculate all internal state.
 
+It does this by storing state and progress information for a single
+dataflow instance in a **recovery store** backed by a durable state
+storage system of your choosing, e.g. Sqlite or Kafka. See the
+subclasses of `RecoveryConfig` in this module for the supported
+datastores, the specifics of how each is utilized, and tradeoffs.
+
 Preparation
 -----------
 
-1. Create a **recovery config** for describing how to connect to a
-**recovery store** which is where Bytewax will store state and
-progress data for this dataflow. See the classes in this module for
-the supported datastores, the specifics of how each is utilized, and
-tradeoffs.
+1. Create a **recovery config** for describing how to connect to the
+recovery store of your choosing.
 
 2. Pass that recovery config as the `recovery_config` argument to the
 entry point running your dataflow (e.g. `bytewax.cluster_main()`).
@@ -34,8 +37,8 @@ boundaries.
 See comments on input configuration types in `bytewax.inputs` for any
 limitations each might have regarding recovery.
 
-It is possible that your output systems will see duplicate data right
-during the resume epoch; design your systems to support at-least-once
+It is possible that your output systems will see duplicate data during
+the resume epoch; design your systems to support at-least-once
 processing.
 
 Currently it is not possible to recover a dataflow with a different
@@ -52,7 +55,8 @@ Once that is done, re-run the dataflow using the _same recovery
 config_ and thus re-connect to the _same recovery store_. Bytewax will
 automatically read the progress of the previous dataflow execution and
 determine the most recent epoch that processing can resume at, called
-the **resume epoch**. Output should resume during the resume epoch.
+the **resume epoch**. Output should resume from the beginning of the
+resume epoch.
 
 If you want to fully restart a dataflow and ignore previous state,
 delete the data in the recovery store using whatever operational tools

--- a/pysrc/bytewax/recovery.py
+++ b/pysrc/bytewax/recovery.py
@@ -22,8 +22,11 @@ automatically.
 Caveats
 -------
 
-Recovery data for multiple dataflows can not be mixed together. Use a
-different recovery config for each dataflow.
+Recovery data for multiple dataflows _must not_ be mixed together. See
+the docs for each `RecoveryConfig` subclass for what this means
+depending on the recovery store. E.g. when using a
+`KafkaRecoveryConfig`, each dataflow must have a distinct topic
+prefix.
 
 The epoch is the unit of recovery: dataflows will only resume on epoch
 boundaries.

--- a/pysrc/bytewax/recovery.py
+++ b/pysrc/bytewax/recovery.py
@@ -1,51 +1,59 @@
 """Bytewax's state recovery machinery.
 
-Preparation
------------
-
-This allows you to **recover** a stateful dataflow; it will let you
+Bytewax allows you to **recover** a stateful dataflow; it will let you
 resume processing and output due to a failure without re-processing
 all initial data to re-calculate all internal state.
 
-0. Pick a **recovery store** in which internal state and progress will
-be continuously backed up. Different storage systems will have
-different performance and reconfiguration trade-offs.
+Preparation
+-----------
 
-1. Create a **recovery config** for connecting to your recovery
-store. See the class types in this module for the datstores supported.
+1. Create a **recovery config** for describing how to connect to a
+**recovery store** which is where Bytewax will store state and
+progress data for this dataflow. See the classes in this module for
+the supported datastores, the specifics of how each is utilized, and
+tradeoffs.
 
-2. Pass that created config as the `recovery_config` argument to the
+2. Pass that recovery config as the `recovery_config` argument to the
 entry point running your dataflow (e.g. `bytewax.cluster_main()`).
 
-3. Run your dataflow! It will start backing up state data
+3. Run your dataflow! It will start backing up recovery data
 automatically.
 
-The epoch is the unit of recovery. It is your responsibility to design
-your input handlers in such a way that it jumps to the point in the
-input that corresponds to the `resume_epoch` argument; if it can't
-(because the input is ephemeral) you can still recover the dataflow,
-but the lost input is unable to be replayed so the output will be
-different.
+Caveats
+-------
+
+Recovery data for multiple dataflows can not be mixed together. Use a
+different recovery config for each dataflow.
+
+The epoch is the unit of recovery: dataflows will only resume on epoch
+boundaries.
+
+See comments on input configuration types in `bytewax.inputs` for any
+limitations each might have regarding recovery.
 
 It is possible that your output systems will see duplicate data right
-around the resume epoch; design your systems to support at-least-once
+during the resume epoch; design your systems to support at-least-once
 processing.
 
-Recovery
---------
+Currently it is not possible to recover a dataflow with a different
+number of workers than when it failed.
+
+On Failure
+----------
 
 If the dataflow fails, first you must fix whatever underlying fault
 caused the issue. That might mean deploying new code which fixes a bug
 or resolving an issue with a connected system.
 
 Once that is done, re-run the dataflow using the _same recovery
-config_. Bytewax will automatically recover state from the recovery
-store and tell your input handlers to fast forward to the resume
-epoch. Output should resume.
+config_ and thus re-connect to the _same recovery store_. Bytewax will
+automatically read the progress of the previous dataflow execution and
+determine the most recent epoch that processing can resume at, called
+the **resume epoch**. Output should resume during the resume epoch.
 
-If you want to fully _restart_ a dataflow and ignore previous state,
-you either have to create a recovery config that points at a new
-datastore or delete the recovery data in the datastore.
+If you want to fully restart a dataflow and ignore previous state,
+delete the data in the recovery store using whatever operational tools
+you have for that storage type.
 
 """
 from .bytewax import KafkaRecoveryConfig, RecoveryConfig, SqliteRecoveryConfig  # noqa

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -40,7 +40,7 @@ use timely::progress::Timestamp;
 use timely::worker::Worker;
 
 /// Compile a dataflow which reads the progress data from the previous
-/// execution calculates the resume epoch.
+/// execution and calculates the resume epoch.
 fn build_resume_epoch_calc_dataflow<A: Allocate>(
     timely_worker: &mut Worker<A>,
     // TODO: Allow multiple (or none) FrontierReaders so you can recover a

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -3,44 +3,98 @@
 //! For a user-centric version of how to execute dataflows, read the
 //! the `bytewax.execution` Python module docstring. Read that first.
 //!
-//! See [`build_dataflow()`] and [`worker_main()`] for the main parts
-//! of this.
+//! [`worker_main()`] for the root of all the internal action here.
 
+use crate::dataflow::{Dataflow, Step};
 use crate::inputs::pump_from_config;
 use crate::inputs::InputConfig;
 use crate::inputs::Pump;
-use crate::operators::DataflowFrontier;
-use crate::operators::Recovery;
-use crate::recovery::build_state_caches;
+use crate::operators::CollectGarbage;
+use crate::operators::*;
+use crate::pyo3_extensions::{extract_state_pair, wrap_state_pair, StateKey};
+use crate::pyo3_extensions::{TdPyAny, TdPyCallable};
 use crate::recovery::RecoveryConfig;
-use send_wrapper::SendWrapper;
+use crate::recovery::RecoveryKey;
+use crate::recovery::StateBackup;
+use crate::recovery::StateReader;
+use crate::recovery::StateWriter;
+use crate::recovery::{build_recovery_readers, build_recovery_writers, FrontierUpdate};
+use crate::recovery::{default_recovery_config, ProgressWriter};
+use crate::recovery::{ProgressReader, StateCollector};
+use log::debug;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-
 use std::thread;
 use std::time::Duration;
-
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
-use pyo3::prelude::*;
-
-use crate::dataflow::{Dataflow, Step};
-use crate::operators::build;
-use crate::operators::check_complete;
-use crate::operators::stateful_map;
-use crate::operators::Reduce;
-use crate::operators::{
-    capture, filter, flat_map, inspect, inspect_epoch, map, reduce, reduce_epoch,
-    reduce_epoch_local, StatefulMap,
-};
-use crate::pyo3_extensions::{extract_state_pair, wrap_state_pair, StateKey};
-use crate::pyo3_extensions::{TdPyAny, TdPyCallable};
-use crate::recovery::build_recovery_store;
-use std::collections::HashMap;
+use timely::communication::Allocate;
 use timely::dataflow::operators::aggregation::*;
 use timely::dataflow::operators::*;
 use timely::dataflow::InputHandle;
 use timely::dataflow::ProbeHandle;
+use timely::progress::Antichain;
+use timely::progress::Timestamp;
+use timely::worker::Worker;
+
+/// Compile a dataflow which reads the progress data from the previous
+/// execution calculates the resume epoch.
+fn build_resume_epoch_calc_dataflow<A: Allocate>(
+    timely_worker: &mut Worker<A>,
+    // TODO: Allow multiple (or none) FrontierReaders so you can recover a
+    // different-sized cluster.
+    progress_reader: Box<dyn ProgressReader<u64>>,
+    resume_epoch_tx: std::sync::mpsc::Sender<u64>,
+) -> Result<ProbeHandle<()>, String> {
+    timely_worker.dataflow(|scope| {
+        let mut probe = ProbeHandle::new();
+
+        progress_source(scope, progress_reader, &probe)
+            .accumulate(
+                // A frontier of [0] is the "earliest", not the empty
+                // frontier. (Empty is "complete" or "last", which is
+                // used below).
+                Antichain::from_elem(Default::default()),
+                |worker_frontier, frontier_updates| {
+                    for FrontierUpdate(antichain) in frontier_updates.iter() {
+                        // For each worker in the failed cluster, find the
+                        // latest frontier.
+                        if timely::PartialOrder::less_than(worker_frontier, &antichain) {
+                            *worker_frontier = antichain.clone();
+                        }
+                    }
+                },
+            )
+            // Each worker in the recovery cluster reads only some of
+            // the frontier data of workers in the failed cluster.
+            .broadcast()
+            .accumulate(Antichain::new(), |dataflow_frontier, worker_frontiers| {
+                for worker_frontier in worker_frontiers.iter() {
+                    // The slowest of the workers in the failed
+                    // cluster is the resume epoch.
+                    if timely::PartialOrder::less_than(worker_frontier, dataflow_frontier) {
+                        *dataflow_frontier = worker_frontier.clone();
+                    }
+                }
+            })
+            .map(|dataflow_frontier| {
+                // TODO: Is this the right way to transform a frontier
+                // back into a recovery epoch?
+                dataflow_frontier
+                    .elements()
+                    .iter()
+                    .cloned()
+                    .min()
+                    .unwrap_or_default()
+            })
+            .inspect(move |resume_epoch| resume_epoch_tx.send(*resume_epoch).unwrap())
+            .probe_with(&mut probe);
+
+        Ok(probe)
+    })
+}
 
 /// Turn the abstract blueprint for a dataflow into a Timely dataflow
 /// so it can be executed.
@@ -49,101 +103,53 @@ use timely::dataflow::ProbeHandle;
 /// concepts to Timely, as we are using Timely as a basis to implement
 /// more-complicated Bytewax features like input builders and
 /// recovery.
-///
-/// The main steps here are:
-///
-/// 1. Load up relevant state from the recovery store and transform
-/// that into what the stateful operators and garbage collector need.
-///
-/// 2. Call the input and output builders to get our callbacks for the
-/// [`Pump`] and capture operator.
-///
-/// 3. "Compile" the Bytewax [`crate::dataflow::Dataflow`] into a
-/// Timely dataflow. This involves re-using some Timely operators
-/// (e.g. [`timely::dataflow::operators::map::Map`]), abusing some
-/// Timely operators with different names but the correct
-/// functionality
-/// (e.g. [`timely::dataflow::operators::inspect::Inspect`]), using
-/// our own custom operators (e.g. [`crate::operators::Reduce`]).
-///
-/// 4. Put in utility recovery
-/// machinery. (C.f. [`crate::operators::Recovery`] and
-/// [`crate::recovery`]).
-///
-/// 5. Return the [`Pump`] and execution frontier probe for execution.
-pub(crate) fn build_dataflow<A>(
-    timely_worker: &mut timely::worker::Worker<A>,
+fn build_production_dataflow<A: Allocate>(
     py: Python,
-    flow: &Dataflow,
+    worker: &mut Worker<A>,
+    resume_epoch: u64,
+    flow: Py<Dataflow>,
     input_config: Py<InputConfig>,
     output_builder: TdPyCallable,
-    recovery_config: Option<Py<RecoveryConfig>>,
-) -> Result<(Box<dyn Pump>, ProbeHandle<u64>), String>
-where
-    A: timely::communication::Allocate,
-{
-    let worker_index = timely_worker.index();
-    let worker_count = timely_worker.peers();
+    state_reader: Box<dyn StateReader<u64, TdPyAny>>,
+    progress_writer: Box<dyn ProgressWriter<u64>>,
+    state_writer: Box<dyn StateWriter<u64, TdPyAny>>,
+    state_collector: Box<dyn StateCollector<u64>>,
+) -> Result<(Box<dyn Pump>, ProbeHandle<u64>), String> {
+    let worker_index = worker.index();
+    let worker_count = worker.peers();
 
-    timely_worker.dataflow(|scope| {
-        let mut timely_input = InputHandle::new();
-        let mut execution_frontier = ProbeHandle::new();
-        let mut stream = timely_input.to_stream(scope);
-        let mut state_updates = Vec::new();
-        let mut captures = Vec::new();
+    worker.dataflow(|scope| {
+        let mut root_input = InputHandle::new();
+        let mut probe = ProbeHandle::new();
 
-        let recovery_store = build_recovery_store(py, recovery_config)?;
+        let state_loading_stream = state_source(scope, state_reader, resume_epoch, &probe);
+        let mut stream = scope.input_from(&mut root_input);
+        root_input.advance_to(resume_epoch);
 
-        // SAFETY: Avoid PyO3 Send overloading.
-        let wrapped_recovery_store = SendWrapper::new(recovery_store);
-        // All RecoveryStore methods require not holding the GIL. They
-        // might spawn background threads.
-        let (recovery_data, resume_epoch) = py.allow_threads(|| wrapped_recovery_store.load());
+        let mut state_backup_streams = Vec::new();
+        let mut capture_streams = Vec::new();
 
-        // Lock in that we're at the recovery epoch. Timely will error
-        // if the input handler does not start here.
-        timely_input.advance_to(resume_epoch);
-        // Yes this is a clone of a giant Vec, but I think this'll be
-        // fine (at least from a memory perspective) because we're
-        // dropping all the actual state data and just noting if it's
-        // an upsert or delete.
-        let recovery_store_log = recovery_data
-            .clone()
-            .into_iter()
-            .map(|(step_id, key, epoch, state)| (step_id, key, epoch, state.into()))
-            .collect();
-        let mut state_caches = build_state_caches(recovery_data);
-
-        let worker_output: TdPyCallable = output_builder
-            .call1(py, (worker_index, worker_count))
-            .unwrap()
-            .extract(py)
-            .unwrap();
-
+        let flow = flow.as_ref(py).borrow();
         for step in &flow.steps {
+            // All these closure lifetimes are static, so tell
+            // Python's GC that there's another pointer to the
+            // mapping function that's going to hang around
+            // for a while when it's moved into the closure.
+            let step = step.clone();
             match step {
                 Step::Map { mapper } => {
-                    // All these closure lifetimes are static, so tell
-                    // Python's GC that there's another pointer to the
-                    // mapping function that's going to hang around
-                    // for a while when it's moved into the closure.
-                    let mapper = mapper.clone_ref(py);
                     stream = stream.map(move |item| map(&mapper, item));
                 }
                 Step::FlatMap { mapper } => {
-                    let mapper = mapper.clone_ref(py);
                     stream = stream.flat_map(move |item| flat_map(&mapper, item));
                 }
                 Step::Filter { predicate } => {
-                    let predicate = predicate.clone_ref(py);
                     stream = stream.filter(move |item| filter(&predicate, item));
                 }
                 Step::Inspect { inspector } => {
-                    let inspector = inspector.clone_ref(py);
                     stream = stream.inspect(move |item| inspect(&inspector, item));
                 }
                 Step::InspectEpoch { inspector } => {
-                    let inspector = inspector.clone_ref(py);
                     stream = stream
                         .inspect_time(move |epoch, item| inspect_epoch(&inspector, epoch, item));
                 }
@@ -152,141 +158,140 @@ where
                     reducer,
                     is_complete,
                 } => {
-                    let step_id = step_id.clone();
-                    let reducer = reducer.clone_ref(py);
-                    let is_complete = is_complete.clone_ref(py);
-
-                    let state_cache = state_caches.remove(&step_id).unwrap_or_default();
-
-                    let (downstream, state_update_stream) = stream.map(extract_state_pair).reduce(
-                        state_cache,
-                        move |key, aggregator, value| reduce(&reducer, key, aggregator, value),
-                        move |key, aggregator| check_complete(&is_complete, key, aggregator),
-                        StateKey::route,
+                    let filter_step_id = step_id.clone();
+                    let state_loading_stream = state_loading_stream.filter(
+                        move |StateBackup(
+                            RecoveryKey(loading_step_id, _key, _epoch),
+                            _state_update,
+                        )| { &filter_step_id == loading_step_id },
                     );
 
-                    let state_update_stream =
-                        state_update_stream.map(move |(key, state)| (step_id.clone(), key, state));
-                    state_updates.push(state_update_stream);
+                    let (downstream, state_backup_stream) =
+                        // Reduce is implemented using stateful map so
+                        // we only have to implement state interacting
+                        // with recovery once.
+                        stream.map(extract_state_pair).stateful_map(
+                            step_id,
+                            state_loading_stream,
+                            move |_key| build_none(),
+                            move |key, acc, value| {
+                                reduce(&reducer, &is_complete, key, acc, value)
+                            },
+                            StateKey::route,
+                        );
 
+                    state_backup_streams.push(state_backup_stream);
                     stream = downstream.map(wrap_state_pair);
                 }
                 Step::ReduceEpoch { reducer } => {
-                    let reducer = reducer.clone_ref(py);
                     stream = stream.map(extract_state_pair).aggregate(
-                        move |key, value, aggregator: &mut Option<TdPyAny>| {
-                            reduce_epoch(&reducer, aggregator, key, value);
+                        move |key, value, acc: &mut Option<TdPyAny>| {
+                            reduce_epoch(&reducer, acc, key, value);
                         },
-                        move |key, aggregator: Option<TdPyAny>| {
-                            // Aggregator will only exist for keys
+                        move |key, acc: Option<TdPyAny>| {
+                            // Accumulator will only exist for keys
                             // that exist, so it will have been filled
                             // into Some(value) above.
-                            wrap_state_pair((key, aggregator.unwrap()))
+                            wrap_state_pair((key, acc.unwrap()))
                         },
                         StateKey::route,
                     );
                 }
                 Step::ReduceEpochLocal { reducer } => {
-                    let reducer = reducer.clone_ref(py);
                     stream = stream
                         .map(extract_state_pair)
-                        .accumulate(
-                            HashMap::new(),
-                            move |aggregators, all_key_value_in_epoch| {
-                                reduce_epoch_local(&reducer, aggregators, &all_key_value_in_epoch);
-                            },
-                        )
-                        .flat_map(|aggregators| aggregators.into_iter().map(wrap_state_pair));
+                        .accumulate(HashMap::new(), move |accs, all_key_value_in_epoch| {
+                            reduce_epoch_local(&reducer, accs, &all_key_value_in_epoch);
+                        })
+                        .flat_map(|accs| accs.into_iter().map(wrap_state_pair));
                 }
                 Step::StatefulMap {
                     step_id,
                     builder,
                     mapper,
                 } => {
-                    let step_id = step_id.clone();
-                    let builder = builder.clone_ref(py);
-                    let mapper = mapper.clone_ref(py);
+                    let filter_step_id = step_id.clone();
+                    let state_loading_stream = state_loading_stream.filter(
+                        move |StateBackup(
+                            RecoveryKey(loading_step_id, _key, _epoch),
+                            _state_update,
+                        )| { &filter_step_id == loading_step_id },
+                    );
 
-                    let state_cache = state_caches.remove(&step_id).unwrap_or_default();
-
-                    let (downstream, state_update_stream) =
+                    let (downstream, state_backup_stream) =
                         stream.map(extract_state_pair).stateful_map(
-                            state_cache,
+                            step_id,
+                            state_loading_stream,
                             move |key| build(&builder, key),
                             move |key, state, value| stateful_map(&mapper, key, state, value),
                             StateKey::route,
                         );
 
-                    let state_update_stream =
-                        state_update_stream.map(move |(key, state)| (step_id.clone(), key, state));
-                    state_updates.push(state_update_stream);
-
+                    state_backup_streams.push(state_backup_stream);
                     stream = downstream.map(wrap_state_pair);
                 }
                 Step::Capture {} => {
-                    let worker_output = worker_output.clone_ref(py);
-                    let capture = stream
-                        .inspect_time(move |epoch, item| capture(&worker_output, epoch, item))
-                        .probe_with(&mut execution_frontier);
+                    let capture = stream;
 
-                    captures.push(capture.clone());
-
+                    capture_streams.push(capture.clone());
                     stream = capture;
                 }
             }
         }
 
-        if captures.len() < 1 {
+        if capture_streams.is_empty() {
             return Err("Dataflow needs to contain at least one capture".into());
         }
 
-        let (dataflow_frontier_handle, dataflow_frontier_stream) =
-            scope.feedback(Default::default());
-        let (backup, gc) = scope.recovery(
-            state_updates,
-            dataflow_frontier_stream,
-            wrapped_recovery_store.take(),
-            recovery_store_log,
-        );
-        scope
-            .dataflow_frontier(backup, captures)
-            // No worker can GC until all workers have backed up and
-            // output an epoch.
-            .broadcast()
-            .connect_loop(dataflow_frontier_handle);
-        // Execution should not complete until GC is complete since we
-        // record the dataflow frontier there.
-        gc.probe_with(&mut execution_frontier);
+        let state_backup_stream = scope
+            .concatenate(state_backup_streams)
+            .write_state_with(state_writer);
+
+        let worker_output: TdPyCallable = output_builder
+            .call1(py, (worker_index, worker_count))
+            .unwrap()
+            .extract(py)
+            .unwrap();
+
+        let capture_stream = scope
+            .concatenate(capture_streams)
+            .inspect_time(move |epoch, item| capture(&worker_output, epoch, item));
+
+        let dataflow_frontier_stream = capture_stream
+            // TODO: Can we only downstream progress messages? Doing this
+            // flat_map trick results in nothing (not even progress)
+            // downstream.
+            //.flat_map(|_| Option::<()>::None)
+            //.concat(&state_backup_stream.flat_map(|_| Option::<()>::None))
+            .map(|_| ())
+            .concat(&state_backup_stream.map(|_| ()))
+            .write_progress_with(progress_writer)
+            .broadcast();
+
+        state_backup_stream
+            .concat(&state_loading_stream)
+            .collect_garbage(state_collector, dataflow_frontier_stream)
+            .probe_with(&mut probe);
 
         let pump = pump_from_config(
             py,
             input_config,
-            timely_input,
+            root_input,
             worker_index,
             worker_count,
             resume_epoch,
         );
-        Ok((pump, execution_frontier))
+        Ok((pump, probe))
     })
 }
 
-/// "Main loop" of a Timely worker thread.
-///
-/// 1. Pump [`Pump`]s (get input data from Python into Timely).
-///
-/// 2. Dispose of empty [`Pump`]s and Probes which indicate there's no
-/// data left to process in that dataflow.
-///
-/// 3. Call [timely::worker::Worker::step] to tell Timely to do
-/// whatever work it can.
-pub(crate) fn worker_main<A>(
+/// Run a dataflow which uses a [`Pump`] until complete.
+fn pump_until_done<A: Allocate>(
+    worker: &mut Worker<A>,
+    interrupt_flag: &AtomicBool,
     mut pumps_with_input_remaining: Vec<Box<dyn Pump>>,
     probe: ProbeHandle<u64>,
-    interrupt_flag: &AtomicBool,
-    worker: &mut timely::worker::Worker<A>,
-) where
-    A: timely::communication::Allocate,
-{
+) {
     while !interrupt_flag.load(Ordering::Relaxed) && !probe.done() {
         if !pumps_with_input_remaining.is_empty() {
             // We have input remaining, pump the pumps, and step the workers while
@@ -307,13 +312,126 @@ pub(crate) fn worker_main<A>(
     }
 }
 
-pub(crate) fn shutdown_worker<A>(worker: &mut timely::worker::Worker<A>)
-where
-    A: timely::communication::Allocate,
-{
+/// Run a dataflow which uses sources until complete.
+fn run_until_done<A: Allocate, T: Timestamp>(
+    worker: &mut Worker<A>,
+    interrupt_flag: &AtomicBool,
+    probe: ProbeHandle<T>,
+) {
+    while !interrupt_flag.load(Ordering::Relaxed) && !probe.done() {
+        worker.step();
+    }
+}
+
+fn build_and_run_resume_epoch_calc_dataflow<A: Allocate>(
+    worker: &mut Worker<A>,
+    interrupt_flag: &AtomicBool,
+    recovery_config: Py<RecoveryConfig>,
+) -> Result<u64, String> {
+    let worker_index = worker.index();
+    let worker_count = worker.peers();
+
+    let (progress_reader, _state_reader) = Python::with_gil(|py| {
+        build_recovery_readers(py, worker_index, worker_count, recovery_config)
+    })?;
+
+    let (resume_epoch_tx, resume_epoch_rx) = std::sync::mpsc::channel();
+    let probe = build_resume_epoch_calc_dataflow(worker, progress_reader, resume_epoch_tx)?;
+
+    run_until_done(worker, &interrupt_flag, probe);
+
+    let resume_epoch = match resume_epoch_rx.recv() {
+        Ok(resume_epoch) => {
+            debug!("Loaded resume epoch {resume_epoch}");
+            resume_epoch
+        }
+        Err(_) => {
+            let default_epoch = Default::default();
+            debug!("No resume epoch calculated; probably empty recovery store; starting at default epoch {default_epoch}");
+            default_epoch
+        }
+    };
+
+    Ok(resume_epoch)
+}
+
+fn build_and_run_production_dataflow<A: Allocate>(
+    worker: &mut Worker<A>,
+    interrupt_flag: &AtomicBool,
+    flow: Py<Dataflow>,
+    input_config: Py<InputConfig>,
+    output_builder: TdPyCallable,
+    recovery_config: Py<RecoveryConfig>,
+    resume_epoch: u64,
+) -> Result<(), String> {
+    let worker_index = worker.index();
+    let worker_count = worker.peers();
+
+    let (_progress_reader, state_reader) = Python::with_gil(|py| {
+        build_recovery_readers(py, worker_index, worker_count, recovery_config.clone())
+    })?;
+    let (progress_writer, state_writer, state_collector) = Python::with_gil(|py| {
+        build_recovery_writers(py, worker_index, worker_count, recovery_config)
+    })?;
+
+    let (pump, probe) = Python::with_gil(|py| {
+        build_production_dataflow(
+            py,
+            worker,
+            resume_epoch,
+            flow,
+            input_config,
+            output_builder,
+            state_reader,
+            progress_writer,
+            state_writer,
+            state_collector,
+        )
+    })?;
+
+    pump_until_done(worker, &interrupt_flag, vec![pump], probe);
+
+    Ok(())
+}
+
+/// Terminate all dataflows in this worker.
+///
+/// We need this because otherwise all of Timely's entry points
+/// (e.g. [`timely::execute::execute_from`]) wait until all work is
+/// complete and we will hang.
+fn shutdown_worker<A: Allocate>(worker: &mut Worker<A>) {
     for dataflow_id in worker.installed_dataflows() {
         worker.drop_dataflow(dataflow_id);
     }
+}
+
+/// What a worker thread should do during its lifetime.
+fn worker_main<A: Allocate>(
+    worker: &mut Worker<A>,
+    interrupt_flag: &AtomicBool,
+    flow: Py<Dataflow>,
+    input_config: Py<InputConfig>,
+    output_builder: TdPyCallable,
+    recovery_config: Option<Py<RecoveryConfig>>,
+) -> Result<(), String> {
+    let recovery_config = recovery_config.unwrap_or_else(default_recovery_config);
+
+    let resume_epoch =
+        build_and_run_resume_epoch_calc_dataflow(worker, interrupt_flag, recovery_config.clone())?;
+
+    build_and_run_production_dataflow(
+        worker,
+        interrupt_flag,
+        flow,
+        input_config,
+        output_builder,
+        recovery_config,
+        resume_epoch,
+    )?;
+
+    shutdown_worker(worker);
+
+    Ok(())
 }
 
 // TODO: pytest --doctest-modules does not find doctests in PyO3 code.
@@ -353,7 +471,8 @@ where
 ///         passes by a capture operator on this process.
 ///
 ///     recovery_config: State recovery config. See
-///         `bytewax.recovery`. If `None`, state will not be persisted.
+///         `bytewax.recovery`. If `None`, state will not be
+///         persisted.
 ///
 #[pyfunction(flow, input_config, output_builder, "*", recovery_config = "None")]
 #[pyo3(text_signature = "(flow, input_config, output_builder, *, recovery_config)")]
@@ -371,24 +490,16 @@ pub(crate) fn run_main(
             // the builder directly. Probably also as part of the
             // panic recast issue below.
             timely::execute::execute_directly::<Result<(), String>, _>(move |worker| {
-                let (pump, probe) = Python::with_gil(|py| {
-                    let flow = &flow.as_ref(py).borrow();
+                let interrupt_flag = AtomicBool::new(false);
 
-                    build_dataflow(
-                        worker,
-                        py,
-                        flow,
-                        input_config,
-                        output_builder,
-                        recovery_config,
-                    )
-                })?;
-
-                worker_main(vec![pump], probe, &AtomicBool::new(false), worker);
-
-                shutdown_worker(worker);
-
-                Ok(())
+                worker_main(
+                    worker,
+                    &interrupt_flag,
+                    flow,
+                    input_config,
+                    output_builder,
+                    recovery_config,
+                )
             })
         })
     });
@@ -451,7 +562,8 @@ pub(crate) fn run_main(
 ///     proc_id: Index of this process in cluster; starts from 0.
 ///
 ///     recovery_config: State recovery config. See
-///         `bytewax.recovery`. If `None`, state will not be persisted.
+///         `bytewax.recovery`. If `None`, state will not be
+///         persisted.
 ///
 ///     worker_count_per_proc: Number of worker threads to start on
 ///         each process.
@@ -524,27 +636,14 @@ pub(crate) fn cluster_main(
             other,
             timely::WorkerConfig::default(),
             move |worker| {
-                let (pump, probe) = Python::with_gil(|py| {
-                    let flow = &flow.as_ref(py).borrow();
-                    let input_config = input_config.clone_ref(py);
-                    let output_builder = output_builder.clone_ref(py);
-                    let recovery_config = recovery_config.clone();
-
-                    build_dataflow(
-                        worker,
-                        py,
-                        flow,
-                        input_config,
-                        output_builder,
-                        recovery_config,
-                    )
-                })?;
-
-                worker_main(vec![pump], probe, &should_shutdown_w, worker);
-
-                shutdown_worker(worker);
-
-                Ok(())
+                worker_main(
+                    worker,
+                    &should_shutdown_w,
+                    flow.clone(),
+                    input_config.clone(),
+                    output_builder.clone(),
+                    recovery_config.clone(),
+                )
             },
         )
         .map_err(PyRuntimeError::new_err)?;

--- a/src/inputs/mod.rs
+++ b/src/inputs/mod.rs
@@ -1,5 +1,4 @@
 use crate::pyo3_extensions::{TdPyAny, TdPyIterator};
-
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -98,6 +97,7 @@ pub(crate) struct InputConfig;
 /// does not support recovery. Kafka messages will be passed through the dataflow
 /// as byte two-tuples of Kafka key and payload.
 ///
+/// Currently Kafka input does not support recovery.
 ///
 /// Args:
 ///
@@ -219,6 +219,11 @@ impl KafkaInputConfig {
 
 /// Use a user-defined function that returns an iterable as the input source.
 ///
+/// It is your responsibility to design your input handlers in such a
+/// way that it jumps to the point in the input that corresponds to
+/// the `resume_epoch` argument; if it can't (because the input is
+/// ephemeral) you can still recover the dataflow, but the lost input
+/// is unable to be replayed so the output will be different.
 ///
 /// Args:
 ///
@@ -287,6 +292,8 @@ struct KafkaPump {
 }
 
 impl KafkaPump {
+    // TODO: Support recovery epoch on Kafka input. That'll require
+    // figuring out windowing.
     fn new(config: PyRef<KafkaInputConfig>, push_to_timely: InputHandle<u64, TdPyAny>) -> Self {
         let context = CustomContext;
 

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -177,7 +177,7 @@
 //!
 //! The production dataflow also has a second **state loading input**
 //! [`crate::operators::state_source`] in which each resume worker is
-//! assigned to read all state _before_ the recovery epoch. This state
+//! assigned to read all state _before_ the resume epoch. This state
 //! is routed to the correct stateful operators (filtering on step ID)
 //! so that state is loaded and ready for when normal execution
 //! resumes. This state data is also sent to the
@@ -682,7 +682,7 @@ pub(crate) fn build_recovery_readers(
     String,
 > {
     // See comment about the GIL in
-    // [`build_recovery_writer_components`].
+    // [`build_recovery_writers`].
     let recovery_config = recovery_config.as_ref(py);
 
     if let Ok(_noop_recovery_config) = recovery_config.downcast::<PyCell<NoopRecoveryConfig>>() {

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -298,6 +298,9 @@ pub(crate) fn default_recovery_config() -> Py<RecoveryConfig> {
 /// Creates a SQLite DB per-worker in a given directory. Multiple DBs
 /// are used to allow workers to write without contention.
 ///
+/// Use a distinct directory per dataflow so recovery data is not
+/// mixed.
+///
 /// >>> flow = Dataflow()
 /// >>> flow.capture()
 /// >>> def input_builder(worker_index, worker_count, resume_epoch):
@@ -321,9 +324,10 @@ pub(crate) fn default_recovery_config() -> Py<RecoveryConfig> {
 ///
 /// Args:
 ///
-///     db_dir: Existing directory to store per-worker DBs in. DB
-///     files will have names like `"worker0.sqlite3"`. You can use
-///     `"."` for the current directory.
+///     db_dir: Existing directory to store per-worker DBs in. Must be
+///     distinct per-dataflow. DB files will have names like
+///     `"worker0.sqlite3"`. You can use `"."` for the current
+///     directory.
 ///
 /// Returns:
 ///
@@ -386,6 +390,9 @@ impl SqliteRecoveryConfig {
 /// log compaction so that topic size is proportional to state size,
 /// not epoch count.
 ///
+/// Use a distinct topic prefix per dataflow so recovery data is not
+/// mixed.
+//
 /// >>> flow = Dataflow()
 /// >>> flow.capture()
 /// >>> def input_builder(worker_index, worker_count, resume_epoch):
@@ -414,10 +421,9 @@ impl SqliteRecoveryConfig {
 ///
 ///     hosts: List of `host:port` strings of Kafka brokers.
 ///
-///     topic_prefix: Prefix used for naming topics. Two topics will
-///         be created using this prefix:
-///         e.g. `"sample-dataflow-progress"` and
-///         `"sample-dataflow-state"`.
+///     topic_prefix: Prefix used for naming topics. Must be distinct
+///     per-dataflow. Two topics will be created using this prefix
+///     `"topic_prefix-progress"` and `"topic_prefix-state"`.
 ///
 /// Returns:
 ///


### PR DESCRIPTION
There's a lot going on here, but the module rustdoc in `crate::recovery` explains the architecture and moving parts and is where you should start. The external facing API is basically unchanged: pass in a `recovery_config`.

Biggest conceptual changes:

- Two dataflows. One calculates resume epoch, one is the production dataflow.
- More fine-grained recovery traits because each recovery store type needs different kinds of connector shapes.
- Implemented `Reduce` in terms of `StatefulMap` because all the state loading stuff is hairy and I didn't want to do it twice.

I'm happy and expecting to do an in-person walk through of the moving parts here.