### PR TITLE
Updates release steps

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -72,7 +72,7 @@ jobs:
             echo "You should check if the last CI Workflow ends successfully."
             echo "https://github.com/bytewax/bytewax/actions/workflows/CI.yml"
             exit 1
-          fi 
+          fi
           EOF
           chmod +x ./check_versions.sh
           ./check_versions.sh
@@ -85,7 +85,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           pip install --upgrade twine
-          twine upload --skip-existing *
+          twine upload --skip-existing *.whl
 
   check-pypi:
     name: Check PyPI

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@ Make a PR which commits the following:
    -version = "0.1.0"
    +version = "1.2.3"
    ```
-   
+
 2. Commits updated API docs
 
    ```sh
@@ -20,34 +20,38 @@ Make a PR which commits the following:
    (.venv) bytewax/apidocs $ rm -rf html/
    (.venv) bytewax/apidocs $ ./build.sh
    ```
-   
+
    You'll get a warning about `Couldn't read PEP-224 variable
    docstrings`, but ignore that as our PyO3 Rust pyclasses don't have
    Python source `pdoc` can read.
-   
+
    If we've been committing these as we go, there might not be any
    changes to commit here. That's fine.
-   
+
 3. Labels the latest changelog entries with the version number
 
    Look in `CHANGELOG.md` for the latest batch of hand-written
    changelog notes and add a new headings with the version number.
-   
+
    ```diff
    *** CHANGELOG.md
     ## Latest
-    
+
     __Add any extra change notes here and we'll put them in the release
     notes on GitHub when we make a new release.__
-   
+
    +## 1.2.3
    +
     * Example note here. Describe any super important changes that you
       wouldn't glean from PR names which will be added by GitHub
       automatically.
    ```
-   
+
 Approve and merge that PR.
+
+4. Check that the CI run completed for the just updated `main` branch
+   on [our CI actions
+   page](https://github.com/bytewax/bytewax/actions/workflows/CI.yml).
 
 ## 2. Create Release on GitHub
 
@@ -60,12 +64,12 @@ repo](https://github.com/bytewax/bytewax/releases/new).
 
    This will pre-populate the GitHub release notes with a list of
    changes via PRs.
-   
+
 3. Copy and paste any hand-written notes from the section of
    [`CHANGELOG.md`](https://raw.githubusercontent.com/bytewax/bytewax/main/CHANGELOG.md)
    with this version into a new section of the GitHub release
    description at the top.
-   
+
    ```diff
    +## Overview
    +* Paste in the stuff in `CHANGELOG.md` here.
@@ -74,13 +78,16 @@ repo](https://github.com/bytewax/bytewax/releases/new).
     * List of PRs that were merged, but sometimes the names aren't helpful.
    ```
 
-4. *Press "Publish release"!*
+4. Wait until the CI run above for the `main` branch completes. The
+   next CD step needs the wheel packages that are built during CI. It
+   looks like this usually takes ~20 min.
 
-   This should create a tag in our repo named `v1.2.3` and CI will
-   kick off building, running tests, and pushing the final package to
-   PyPI.
-   
-   Check that the CI run completed on [our CI actions
+5. *Press "Publish release"!*
+
+   This should create a tag in our repo named `v1.2.3` and CD will
+   kick off, pushing the final package to PyPI.
+
+   Check that the CD run completed on [our CD actions
    page](https://github.com/bytewax/bytewax/actions/workflows/CI.yml).
 
 ## 3. Double check PyPI


### PR DESCRIPTION
Added a comment about waiting for the merge CI to finish before
cutting a release.

Also CD was failing because `twine` was trying to upload the `check_versions.sh` script since it's also in the CWD. Make it only upload wheels.