### PR TITLE
Fold window operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Added the `fold_window` operator, works like `reduce_window` but allows
+  the user to build the initial accumulator for each key in a `builder` function.
+
 - Output is no longer specified using an `output_builder` for the
   entire dataflow, but you supply an "output config" per capture. See
   `bytewax.outputs` for more info.

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -33,8 +33,7 @@ def test_tumbling_window():
 
 
 def test_fold_window():
-    def gen(i, n, r):
-        assert r == 0
+    def gen():
         yield from [
             {"user": "a", "type": "login"},
             {"user": "a", "type": "post"},
@@ -44,11 +43,6 @@ def test_fold_window():
             {"user": "b", "type": "post"},
             {"user": "b", "type": "post"},
         ]
-
-    out = []
-
-    def ob(i, n):
-        return out.append
 
     def extract_id(event):
         return (event["user"], event)
@@ -75,6 +69,6 @@ def test_fold_window():
     run_main(flow)
 
     assert len(out) == 3
-    assert (0, ("a", {"login": 1, "post": 2})) in out
-    assert (0, ("a", {"post": 1})) in out
-    assert (0, ("b", {"login": 1, "post": 2})) in out
+    assert ("a", {"login": 1, "post": 2}) in out
+    assert ("a", {"post": 1}) in out
+    assert ("b", {"login": 1, "post": 2}) in out

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import timedelta
 
 from bytewax.dataflow import Dataflow
@@ -29,3 +30,51 @@ def test_tumbling_window():
     run_main(flow)
 
     assert sorted(out) == sorted([("ALL", 3), ("ALL", 1)])
+
+
+def test_fold_window():
+    def gen(i, n, r):
+        assert r == 0
+        yield from [
+            {"user": "a", "type": "login"},
+            {"user": "a", "type": "post"},
+            {"user": "a", "type": "post"},
+            {"user": "b", "type": "login"},
+            {"user": "a", "type": "post"},
+            {"user": "b", "type": "post"},
+            {"user": "b", "type": "post"},
+        ]
+
+    out = []
+
+    def ob(i, n):
+        return out.append
+
+    def extract_id(event):
+        return (event["user"], event)
+
+    def build(key):
+        return defaultdict(lambda: 0)
+
+    def count(results, event):
+        results[event["type"]] += 1
+        return results
+
+    # This will result in times for events of +0, +4, +8, +12.
+    clock_config = TestingClockConfig(item_incr=timedelta(seconds=4))
+    # And since the window is +10, we should get a window with value
+    # of 3 and then 1.
+    window_config = TumblingWindowConfig(length=timedelta(seconds=10))
+
+    flow = Dataflow(TestingInputConfig(gen()))
+    flow.map(extract_id)
+    flow.fold_window("sum", clock_config, window_config, build, count)
+    out = []
+    flow.capture(TestingOutputConfig(out))
+
+    run_main(flow)
+
+    assert len(out) == 3
+    assert (0, ("a", {"login": 1, "post": 2})) in out
+    assert (0, ("a", {"post": 1})) in out
+    assert (0, ("b", {"login": 1, "post": 2})) in out

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -389,7 +389,26 @@ impl Dataflow {
         });
     }
 
-    /// TODO
+    /// Fold window lets you combine all items for a key within a
+    /// window into an accumulator, using a function to build its initial value.
+    ///
+    /// It is like `bytewax.Dataflow.reduce_window()` but uses a function to
+    /// build the initial value.
+    ///
+    /// See reduce_window's documentation and the `test_fold_window` test in
+    /// `bytewax/pytests/test_window.py file for more details.
+    ///
+    /// Args:
+    ///
+    ///     step_id: Uniquely identifies this step for recovery.
+    ///
+    ///     clock_config: Clock config to use. See `bytewax.window`.
+    ///
+    ///     window_config: Windower config to use. See `bytewax.window`.
+    ///
+    ///     builder: `builder(key: Any) => initial_accumulator: Any`
+    ///
+    ///     folder: `folder(accumulator: Any, value: Any) => updated_accumulator: Any`
     #[pyo3(text_signature = "(self, step_id, clock_config, window_config, builder, folder)")]
     fn fold_window(
         &mut self,

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -396,7 +396,7 @@ impl Dataflow {
     /// build the initial value.
     ///
     /// See reduce_window's documentation and the `test_fold_window` test in
-    /// `bytewax/pytests/test_window.py file for more details.
+    /// `bytewax/pytests/test_window.py` file for more details.
     ///
     /// Args:
     ///

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -775,12 +775,14 @@ pub(crate) fn fold_window(
 ) -> (Option<TdPyAny>, impl IntoIterator<Item = TdPyAny>) {
     match next_value {
         Some(value) => Python::with_gil(|py| {
-            let initial_acc = acc
-                .unwrap_or_else(|| with_traceback!(py, builder.call1(py, (key.clone(),))).into());
             // Save the value's debug string here first, because its ownership
             // will be moved to the `folder` function.
             let value_dbg = format!("{value:?}");
-            let updated_acc = with_traceback!(py, folder.call1(py, (initial_acc, value))).into();
+            // Either take acc's value or build the initial one with the builder,
+            // then update it with the folder.
+            let acc = acc
+                .unwrap_or_else(|| with_traceback!(py, builder.call1(py, (key.clone(),))).into());
+            let updated_acc = with_traceback!(py, folder.call1(py, (acc, value))).into();
             debug!("fold_window for key={key:?}: builder={builder:?}, value={value_dbg}) -> updated_acc={updated_acc:?}",);
             (Some(updated_acc), None)
         }),

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -777,12 +777,11 @@ pub(crate) fn fold_window(
         Some(value) => Python::with_gil(|py| {
             let initial_acc = acc
                 .unwrap_or_else(|| with_traceback!(py, builder.call1(py, (key.clone(),))).into());
-            // I have to start building the debug message here first, because ownership
-            // of `value` will be moved to the `folder` function.
-            let msg =
-                format!("fold_window for key={key:?}: builder={builder:?}, value={value:?}) -> ");
+            // Save the value's debug string here first, because its ownership
+            // will be moved to the `folder` function.
+            let value_dbg = format!("{value:?}");
             let updated_acc = with_traceback!(py, folder.call1(py, (initial_acc, value))).into();
-            debug!("{msg} updated_acc={updated_acc:?}",);
+            debug!("fold_window for key={key:?}: builder={builder:?}, value={value_dbg}) -> updated_acc={updated_acc:?}",);
             (Some(updated_acc), None)
         }),
         None => (None, acc),


### PR DESCRIPTION
# Fold Window Operator
This PR introduces the `fold_window` operator.

`fold_window`, like `reduce_window`, lets you combine all the items for a key within a given epoch into an accumulator.

The main difference is that `fold_window` accepts a `builder` function as first parameter, which is called the first time a new key appears in the configured window.

The second parameter is the `folder` function, which acts just like the `reducer` in `reduce_window`, takes the `accumulator` as first parameter and `current_value` as second one, and returns the updated `accumulator`.

The `builder` function takes the first key as parameter, and it should be used to build the empty accumulator.

This is an example usage (from the test for the python side):

```python
    def gen():
        yield from [
            {"user": "a", "type": "login"},
            {"user": "a", "type": "post"},
            {"user": "a", "type": "post"},
            {"user": "b", "type": "login"},
            {"user": "a", "type": "post"},
            {"user": "b", "type": "post"},
            {"user": "b", "type": "post"},
        ]

    def extract_id(event):
        return (event["user"], event)

    def build(key):
        return defaultdict(lambda: 0)

    def count(results, event):
        results[event["type"]] += 1
        return results

    clock_config = TestingClockConfig(item_incr=timedelta(seconds=4))
    window_config = TumblingWindowConfig(length=timedelta(seconds=10))

    out = []
    flow = Dataflow(TestingInputConfig(gen()))
    flow.map(extract_id)
    flow.fold_window("sum", clock_config, window_config, build, count)
    flow.capture(TestingOutputConfig(out))

    run_main(flow)

    assert len(out) == 3
    assert ("a", {"login": 1, "post": 2}) in out
    assert ("a", {"post": 1}) in out
    assert ("b", {"login": 1, "post": 2}) in out
```

## TODO
- [x] Write the docstring
- [x] Move from fold_epoch to fold_window
- [x] User the new input operators