### PR TITLE
Windowing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,11 @@ version = "0.10.0"
 dependencies = [
  "axum",
  "bincode",
+ "chrono",
  "futures",
  "log",
  "pyo3",
+ "pyo3-chrono",
  "pyo3-log",
  "rdkafka",
  "scopeguard",
@@ -186,6 +188,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "cmake"
@@ -597,26 +613,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "0.3.6"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47741a8bc60fb26eb8d6e0238bbb26d8575ff623fdc97b1a2c00c050b9684ed8"
-dependencies = [
- "indoc-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "indoc-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce046d161f000fffde5f432a0d034d0341dc152643b2598ed5bfce44c4f3a8f0"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
- "unindent",
-]
+checksum = "05a0bd019339e5d968b37855180087b7b9d512c5046fbd244cf8c95687927d6e"
 
 [[package]]
 name = "instant"
@@ -793,6 +792,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,28 +880,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
-dependencies = [
- "paste-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "paste"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
-
-[[package]]
-name = "paste-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
-dependencies = [
- "proc-macro-hack",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -955,12 +945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,34 +955,55 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.15.1"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf01dbf1c05af0a14c7779ed6f3aa9deac9c3419606ac9de537a2d649005720"
+checksum = "1e6302e85060011447471887705bb7838f14aba43fcb06957d823739a496b3dc"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "parking_lot",
- "paste 0.1.18",
  "pyo3-build-config",
+ "pyo3-ffi",
  "pyo3-macros",
  "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.15.1"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf9e4d128bfbddc898ad3409900080d8d5095c379632fbbfbb9c8cfb1fb852b"
+checksum = "b5b65b546c35d8a3b1b2f0ddbac7c6a569d759f357f2b9df884f5d6b719152c8"
 dependencies = [
  "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-chrono"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf262a150bf60208502d7cd03c68a12ca408122bb41ace6c0b221dd2157b4b4"
+dependencies = [
+ "chrono",
+ "pyo3",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c275a07127c1aca33031a563e384ffdd485aee34ef131116fcd58e3430d1742b"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
 ]
 
 [[package]]
 name = "pyo3-log"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d43bb6bf4460e400696a4c8b4b647362e1eddc4ac31b993998692e4c2a9a5f"
+checksum = "d84f1cb4bfeb767e1913b5e79fb86c1db083404296a650a7689a96371f7d30ea"
 dependencies = [
  "arc-swap",
  "log",
@@ -1007,10 +1012,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.15.1"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67701eb32b1f9a9722b4bc54b548ff9d7ebfded011c12daece7b9063be1fd755"
+checksum = "284fc4485bfbcc9850a6d661d627783f18d19c2ab55880b021671c4ba83e90f7"
 dependencies = [
+ "proc-macro2",
  "pyo3-macros-backend",
  "quote",
  "syn",
@@ -1018,12 +1024,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.15.1"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44f09e825ee49a105f2c7b23ebee50886a9aee0746f4dd5a704138a64b0218a"
+checksum = "53bda0f58f73f5c5429693c96ed57f7abdb38fdfc28ae06da4101a257adb7faf"
 dependencies = [
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -1361,7 +1366,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "paste 1.0.7",
+ "paste",
  "percent-encoding",
  "rand",
  "rustls",
@@ -1457,6 +1462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1485,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,12 @@ python-source = "pysrc"
 [dependencies]
 axum = { version = "0.4.3" }
 bincode = { version = "1.3.3" }
+chrono = { version = "0.4", features = [ "serde" ] }
 futures = { version = "0.3.21" }
 log = { version = "0.4" }
-pyo3 = { version = "0.15.1" }
-pyo3-log = { version = "0.5.0" }
+pyo3 = { version = "0.16" }
+pyo3-chrono = { version = "0.4" }
+pyo3-log = { version = "0.6" }
 rdkafka = { version = "0.28.0", features = [ "cmake-build" ] }
 scopeguard = { version = "1.1.0" }
 send_wrapper = { version = "0.5.0" }
@@ -27,7 +29,7 @@ timely = { version = "0.12.0", features = [ "bincode" ] }
 tokio = { version = "1.15.0", features = [ "full" ] }
 
 [dev-dependencies]
-pyo3 = { version = "0.15.1", default-features = false }
+pyo3 = { version = "0.16", default-features = false }
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,10 @@ doctest_optionflags = "NORMALIZE_WHITESPACE"
 testpaths = [
     "pytests",
     # TODO: Add back in doctests when we can figure out how to run them without import problems.
-    "docs",
+
+    # "pysrc",
+
+    # TODO: Turn back on markdown tests once we stabilize inputs.
+
+    # "docs",
 ]

--- a/pysrc/bytewax/recovery.py
+++ b/pysrc/bytewax/recovery.py
@@ -1,4 +1,4 @@
-"""Bytewax's state recovery machinery.
+"""Recovering from failures.
 
 Bytewax allows you to **recover** a stateful dataflow; it will let you
 resume processing and output due to a failure without re-processing
@@ -63,4 +63,8 @@ delete the data in the recovery store using whatever operational tools
 you have for that storage type.
 
 """
-from .bytewax import KafkaRecoveryConfig, RecoveryConfig, SqliteRecoveryConfig  # noqa
+from .bytewax import (  # noqa: F401
+    KafkaRecoveryConfig,
+    RecoveryConfig,
+    SqliteRecoveryConfig,
+)

--- a/pysrc/bytewax/window.py
+++ b/pysrc/bytewax/window.py
@@ -30,7 +30,7 @@ stateful operators, so you can read more on their methods on
 `bytewax.Dataflow`.
 
 4. Pass both these configs to the windowing operator of your
-choice. The **windowing operators** decided what kind of logic you
+choice. The **windowing operators** decide what kind of logic you
 should apply to values within a window and what should be the output
 of the window. E.g. `bytewax.Dataflow.reduce_window` combines all
 values in a window into a single output and sends that downstream.

--- a/pysrc/bytewax/window.py
+++ b/pysrc/bytewax/window.py
@@ -1,0 +1,75 @@
+"""Time-based windows.
+
+Bytewax provides some operators and pre-built configurations for
+easily grouping data into buckets called **windows** and running code
+on just the values in those windows.
+
+See the operator methods on `bytewax.Dataflow` with `_window` in the
+name for simple example use cases of each.
+
+Use
+---
+
+1. Pick a clock and create a config for it. A **clock** determines the
+time of each element and the current time used for closing each
+window. E.g. use the current system time. See the docs for each
+subclass of `ClockConfig` for options.
+
+2. Pick a windower and create a config for it. A **windower** defines
+how to take the values and their times and bucket them into
+windows. E.g. have tumbling windows every 30 seconds. See the docs for
+each subclass of `WindowConfig` for options.
+
+3. Pick a **key** to route the values for the window and make sure the
+input to the windowing operator you choose is a 2-tuple of `(key: str,
+value)`. Windows are managed independently for each key. If you need
+all data to be processed into the same window state, you can use a
+constant key like `("ALL", value)` but this will reduce the
+parallelism possible in the dataflow. This is similar to all the other
+stateful operators, so you can read more on their methods on
+`bytewax.Dataflow`.
+
+4. Pass both these configs to the windowing operator of your
+choice. The **windowing operators** decided what kind of logic you
+should apply to values within a window and what should be the output
+of the window. E.g. `bytewax.Dataflow.reduce_window` combines all
+values in a window into a single output and sends that downstream.
+
+You are allowed and encouraged to have as many different clocks and
+windowers as you need in a single dataflow. Just instantiate more of
+them and pass the ones you need for each situation to each windowing
+operator.
+
+Order
+-----
+
+Because Bytewax can be run as a distributed system with multiple
+worker processes and threads all reading relevant data simultaneously,
+you have to specifically collect and manually sort data that you need
+to process in strict time order.
+
+Recovery
+--------
+
+Bytewax's windowing system is built on top of its recovery system (see
+`bytewax.recovery` for more info), so failure in the middle of a
+window will be handled as gracefully as possible.
+
+Some clocks don't have a single correct answer on what to do during
+recovery. E.g. if you use `SystemClockConfig` with 10 minute windows,
+but then recover on a 15 minute mark, the system will immediately
+close out the half-completed window stored during recovery. See the
+docs for each `ClockConfig` subclass for specific notes on recovery.
+
+Recovery happens on the granularity of the _epochs_ of the dataflow,
+not the windows. See `bytewax.inputs` for more information on ways to
+adjust epochs.
+
+"""
+
+from .bytewax import (  # noqa: F401
+    ClockConfig,
+    SystemClockConfig,
+    TumblingWindowConfig,
+    WindowConfig,
+)

--- a/pysrc/bytewax/window.py
+++ b/pysrc/bytewax/window.py
@@ -70,6 +70,7 @@ adjust epochs.
 from .bytewax import (  # noqa: F401
     ClockConfig,
     SystemClockConfig,
+    TestingClockConfig,
     TumblingWindowConfig,
     WindowConfig,
 )

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -1,0 +1,44 @@
+from datetime import timedelta
+from time import sleep
+
+from bytewax import Dataflow
+from bytewax.execution import run_main
+from bytewax.inputs import AdvanceTo, Emit, ManualInputConfig
+from bytewax.window import SystemClockConfig, TumblingWindowConfig
+
+
+def test_system_clock_tumbling_window():
+    def ib(i, n, r):
+        assert r == 0
+        for e in range(4):
+            yield Emit(("ALL", 1))
+            # Remember currently the input handle buffers unless the
+            # epoch is advanced and windowing happens _inside_ the
+            # reduce_window operator. So we have to kick the epoch to
+            # get things to work.
+            yield AdvanceTo(e + 1)
+            sleep(0.2)
+
+    out = []
+
+    def ob(i, n):
+        return out.append
+
+    def add(acc, x):
+        return acc + x
+
+    clock_config = SystemClockConfig()
+    window_config = TumblingWindowConfig(length=timedelta(seconds=0.5))
+
+    flow = Dataflow()
+    flow.reduce_window("sum", clock_config, window_config, add)
+    flow.capture()
+
+    run_main(flow, ManualInputConfig(ib), ob)
+
+    assert sorted(out) == sorted(
+        [
+            (3, ("ALL", 3)),
+            (4, ("ALL", 1)),
+        ]
+    )

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -17,7 +17,7 @@ def test_system_clock_tumbling_window():
             # reduce_window operator. So we have to kick the epoch to
             # get things to work.
             yield AdvanceTo(e + 1)
-            sleep(0.2)
+            sleep(0.4)
 
     out = []
 
@@ -28,7 +28,7 @@ def test_system_clock_tumbling_window():
         return acc + x
 
     clock_config = SystemClockConfig()
-    window_config = TumblingWindowConfig(length=timedelta(seconds=0.5))
+    window_config = TumblingWindowConfig(length=timedelta(seconds=1))
 
     flow = Dataflow()
     flow.reduce_window("sum", clock_config, window_config, add)

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -1,4 +1,6 @@
 use crate::pyo3_extensions::TdPyCallable;
+use crate::window::ClockConfig;
+use crate::window::WindowConfig;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::*;
@@ -18,6 +20,24 @@ use std::fmt::Display;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub(crate) struct StepId(String);
+
+impl<'source> FromPyObject<'source> for StepId {
+    fn extract(ob: &'source PyAny) -> PyResult<Self> {
+        Ok(StepId(ob.extract()?))
+    }
+}
+
+impl IntoPy<PyObject> for StepId {
+    fn into_py(self, py: Python) -> Py<PyAny> {
+        PyString::new(py, &self.0).into()
+    }
+}
+
+impl ToPyObject for StepId {
+    fn to_object(&self, py: Python) -> PyObject {
+        self.0.to_object(py)
+    }
+}
 
 impl Display for StepId {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
@@ -251,11 +271,8 @@ impl Dataflow {
     ///
     /// It is a stateful operator. It requires the the input stream
     /// has items that are `(key: str, value)` tuples so we can ensure
-    /// that all relevant values are routed to the relevant
-    /// accumulator.
-    ///
-    /// It is a recoverable operator. It requires a step ID to recover
-    /// the correct state.
+    /// that all relevant values are routed to the relevant state. It
+    /// also requires a step ID to recover the correct state.
     ///
     /// It calls two functions:
     ///
@@ -313,38 +330,41 @@ impl Dataflow {
     ///     is_complete: `is_complete(updated_accumulator: Any) =>
     ///         should_emit: bool`
     #[pyo3(text_signature = "(self, step_id, reducer, is_complete)")]
-    fn reduce(&mut self, step_id: String, reducer: TdPyCallable, is_complete: TdPyCallable) {
+    fn reduce(&mut self, step_id: StepId, reducer: TdPyCallable, is_complete: TdPyCallable) {
         self.steps.push(Step::Reduce {
-            step_id: StepId(step_id),
+            step_id,
             reducer,
             is_complete,
         });
     }
 
-    /// Reduce epoch lets you combine all items for a key within an
-    /// epoch into an accumulator.
+    // TODO: Update this example once we have a better idea about
+    // input.
+    /// Reduce window lets you combine all items for a key within an
+    /// window into an accumulator.
     ///
     /// It is like `bytewax.Dataflow.reduce()` but marks the
-    /// accumulator as complete automatically at the end of each epoch.
+    /// accumulator as complete automatically at the end of each
+    /// window.
     ///
-    /// It is a stateful operator. it requires the the input stream
+    /// It is a stateful operator. It requires the the input stream
     /// has items that are `(key: str, value)` tuples so we can ensure
-    /// that all relevant values are routed to the relevant
-    /// accumulator.
+    /// that all relevant values are routed to the relevant state. It
+    /// also requires a step ID to recover the correct state.
     ///
     /// It calls a **reducer** function which combines two values. The
     /// accumulator is initially the first value seen for a key. Values
     /// will be passed in arbitrary order. If there is only a single
-    /// value for a key in this epoch, this function will not be
+    /// value for a key in this window, this function will not be
     /// called.
     ///
     /// It emits `(key, accumulator)` tuples downstream at the end of
-    /// each epoch.
+    /// each window.
     ///
     /// It is commonly used for:
     ///
-    /// - Counting within epochs
-    /// - Accumulation within epochs
+    /// - Counting within windows
+    /// - Accumulation within windows
     ///
     /// >>> def add_initial_count(event):
     /// ...     return event["user"], 1
@@ -373,33 +393,29 @@ impl Dataflow {
     ///
     /// Args:
     ///
-    ///     reducer: `reducer(accumulator: Any, value: Any) =>
-    ///         updated_accumulator: Any`
-    #[pyo3(text_signature = "(self, reducer)")]
-    fn reduce_epoch(&mut self, reducer: TdPyCallable) {
-        self.steps.push(Step::ReduceEpoch { reducer });
-    }
-
-    /// Reduce epoch local lets you combine all items for a key within
-    /// an epoch _on a single worker._
+    ///     step_id: Uniquely identifies this step for recovery.
     ///
-    /// It is exactly like `bytewax.Dataflow.reduce_epoch()` but does
-    /// _not_ ensure all values for a key are routed to the same
-    /// worker and thus there is only one output accumulator per key.
+    ///     clock_config: Clock config to use. See `bytewax.window`.
     ///
-    /// You should use `bytewax.Dataflow.reduce_epoch()` unless you
-    /// need a network-overhead optimization and some later step does
-    /// full accumulation.
-    ///
-    /// It is only used for performance optimziation.
-    ///
-    /// Args:
+    ///     window_config: Windower config to use. See
+    ///         `bytewax.window`.
     ///
     ///     reducer: `reducer(accumulator: Any, value: Any) =>
     ///         updated_accumulator: Any`
-    #[pyo3(text_signature = "(self, reducer)")]
-    fn reduce_epoch_local(&mut self, reducer: TdPyCallable) {
-        self.steps.push(Step::ReduceEpochLocal { reducer });
+    #[pyo3(text_signature = "(self, step_id, clock_config, window_config, reducer)")]
+    fn reduce_window(
+        &mut self,
+        step_id: StepId,
+        clock_config: Py<ClockConfig>,
+        window_config: Py<WindowConfig>,
+        reducer: TdPyCallable,
+    ) {
+        self.steps.push(Step::ReduceWindow {
+            step_id,
+            clock_config,
+            window_config,
+            reducer,
+        });
     }
 
     /// Stateful map is a one-to-one transformation of values, but
@@ -408,10 +424,8 @@ impl Dataflow {
     ///
     /// It is a stateful operator. It requires the the input stream
     /// has items that are `(key: str, value)` tuples so we can ensure
-    /// that all relevant values are routed to the relevant state.
-    ///
-    /// It is a recoverable operator. It requires a step ID to recover
-    /// the correct state.
+    /// that all relevant values are routed to the relevant state. It
+    /// also requires a step ID to recover the correct state.
     ///
     /// It calls two functions:
     ///
@@ -472,9 +486,9 @@ impl Dataflow {
     ///     mapper: `mapper(state: Any, value: Any) => (updated_state:
     ///         Any, updated_value: Any)`
     #[pyo3(text_signature = "(self, step_id, builder, mapper)")]
-    fn stateful_map(&mut self, step_id: String, builder: TdPyCallable, mapper: TdPyCallable) {
+    fn stateful_map(&mut self, step_id: StepId, builder: TdPyCallable, mapper: TdPyCallable) {
         self.steps.push(Step::StatefulMap {
-            step_id: StepId(step_id),
+            step_id,
             builder,
             mapper,
         });
@@ -536,10 +550,10 @@ pub(crate) enum Step {
         reducer: TdPyCallable,
         is_complete: TdPyCallable,
     },
-    ReduceEpoch {
-        reducer: TdPyCallable,
-    },
-    ReduceEpochLocal {
+    ReduceWindow {
+        step_id: StepId,
+        clock_config: Py<ClockConfig>,
+        window_config: Py<WindowConfig>,
         reducer: TdPyCallable,
     },
     StatefulMap {
@@ -574,20 +588,23 @@ impl<'source> FromPyObject<'source> for Step {
         }
         if let Ok(("Reduce", step_id, reducer, is_complete)) = tuple.extract() {
             return Ok(Self::Reduce {
-                step_id: StepId(step_id),
+                step_id,
                 reducer,
                 is_complete,
             });
         }
-        if let Ok(("ReduceEpoch", reducer)) = tuple.extract() {
-            return Ok(Self::ReduceEpoch { reducer });
-        }
-        if let Ok(("ReduceEpochLocal", reducer)) = tuple.extract() {
-            return Ok(Self::ReduceEpochLocal { reducer });
+        if let Ok(("ReduceWindow", step_id, clock_config, window_config, reducer)) = tuple.extract()
+        {
+            return Ok(Self::ReduceWindow {
+                step_id,
+                clock_config,
+                window_config,
+                reducer,
+            });
         }
         if let Ok(("StatefulMap", step_id, builder, mapper)) = tuple.extract() {
             return Ok(Self::StatefulMap {
-                step_id: StepId(step_id),
+                step_id,
                 builder,
                 mapper,
             });
@@ -617,14 +634,25 @@ impl ToPyObject for Step {
                 step_id,
                 reducer,
                 is_complete,
-            } => ("Reduce", step_id.0.clone(), reducer, is_complete).to_object(py),
-            Self::ReduceEpoch { reducer } => ("ReduceEpoch", reducer).to_object(py),
-            Self::ReduceEpochLocal { reducer } => ("ReduceEpochLocal", reducer).to_object(py),
+            } => ("Reduce", step_id.clone(), reducer, is_complete).to_object(py),
+            Self::ReduceWindow {
+                step_id,
+                clock_config,
+                window_config,
+                reducer,
+            } => (
+                "ReduceWindow",
+                step_id.clone(),
+                clock_config,
+                window_config,
+                reducer,
+            )
+                .to_object(py),
             Self::StatefulMap {
                 step_id,
                 builder,
                 mapper,
-            } => ("StatefulMap", step_id.0.clone(), builder, mapper).to_object(py),
+            } => ("StatefulMap", step_id.clone(), builder, mapper).to_object(py),
             Self::Capture {} => ("Capture",).to_object(py),
         }
         .into()

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -340,7 +340,7 @@ impl Dataflow {
 
     // TODO: Update this example once we have a better idea about
     // input.
-    /// Reduce window lets you combine all items for a key within an
+    /// Reduce window lets you combine all items for a key within a
     /// window into an accumulator.
     ///
     /// It is like `bytewax.Dataflow.reduce()` but marks the

--- a/src/inputs/mod.rs
+++ b/src/inputs/mod.rs
@@ -1,16 +1,18 @@
+//!
+
 use crate::pyo3_extensions::{TdPyAny, TdPyIterator};
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
-use rdkafka::client::ClientContext;
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
 use rdkafka::consumer::base_consumer::BaseConsumer;
-use rdkafka::consumer::{Consumer, ConsumerContext};
+use rdkafka::consumer::Consumer;
+use rdkafka::error::KafkaError;
 use rdkafka::message::Message;
-use std::time::Duration;
+use send_wrapper::SendWrapper;
+use std::time::{Duration, Instant};
 use timely::dataflow::InputHandle;
-use tokio::runtime::Runtime;
 
 /// Advance to the supplied epoch.
 ///
@@ -100,12 +102,11 @@ pub(crate) struct InputConfig;
 ///
 /// Args:
 ///
-///     brokers: Comma-separated of broker addresses.
-///         E.g. "localhost:9092,localhost:9093"
+///     hosts: Broker addresses. E.g. "localhost:9092,localhost:9093"
 ///
 ///     group_id: Group id as a string.
 ///
-///     topic: Topic to which consumer will subscribe.
+///     topics: Topics to which consumer will subscribe.
 ///
 ///     offset_reset: Can be "earliest" or "latest". Delegates where
 ///         to resume if auto_commit is not enabled. Defaults to
@@ -116,100 +117,134 @@ pub(crate) struct InputConfig;
 ///         when the process restarts to pick up where it left
 ///         off. Defaults to false.
 ///
-///     messages_per_epoch: (integer) Defines maximum number of
-///         messages per epoch.  Defaults to `1`. If the consumer
-///         times out waiting, the system will increment to the next
-///         epoch, and fewer (or no) messages may be assigned to the
-///         preceding epoch.
+///     epoch_length: (timedelta)
 ///
 /// Returns:
 ///
 ///     Config object. Pass this as the `input_config` argument to
 ///     your execution entry point.
 #[pyclass(module = "bytewax.inputs", extends = InputConfig)]
-#[pyo3(
-    text_signature = "(brokers, group_id, topics, offset_reset, auto_commit, messages_per_epoch)"
-)]
+#[pyo3(text_signature = "(hosts, group_id, topics, tail, offset_reset, auto_commit, epoch_length)")]
 pub(crate) struct KafkaInputConfig {
     #[pyo3(get)]
-    pub brokers: String,
+    pub hosts: Vec<String>,
     #[pyo3(get)]
     pub group_id: String,
     #[pyo3(get)]
-    pub topics: String,
+    pub topics: Vec<String>,
+    #[pyo3(get)]
+    pub tail: bool,
     #[pyo3(get)]
     pub offset_reset: String,
     #[pyo3(get)]
     pub auto_commit: bool,
     #[pyo3(get)]
-    pub messages_per_epoch: u64,
+    epoch_length: pyo3_chrono::Duration,
 }
 
 #[pymethods]
 impl KafkaInputConfig {
     #[new]
     #[args(
-        brokers,
+        hosts,
         group_id,
         topics,
+        tail = true,
         offset_reset = "\"earliest\".to_string()",
         auto_commit = false,
-        messages_per_epoch = 1
+        epoch_length = "pyo3_chrono::Duration(chrono::Duration::seconds(5))"
     )]
     fn new(
-        brokers: String,
+        hosts: Vec<String>,
         group_id: String,
-        topics: String,
+        topics: Vec<String>,
+        tail: bool,
         offset_reset: String,
         auto_commit: bool,
-        messages_per_epoch: u64,
+        epoch_length: pyo3_chrono::Duration,
     ) -> (Self, InputConfig) {
         (
             Self {
-                brokers,
+                hosts,
                 group_id,
                 topics,
+                tail,
                 offset_reset,
                 auto_commit,
-                messages_per_epoch,
+                epoch_length,
             },
             InputConfig {},
         )
     }
 
-    fn __getstate__(&self) -> (&str, String, String, String, String, u64) {
+    fn __getstate__(
+        &self,
+    ) -> (
+        &str,
+        Vec<String>,
+        String,
+        Vec<String>,
+        bool,
+        String,
+        bool,
+        pyo3_chrono::Duration,
+    ) {
         (
             "KafkaInputConfig",
-            self.brokers.clone(),
+            self.hosts.clone(),
             self.group_id.clone(),
             self.topics.clone(),
+            self.tail,
             self.offset_reset.clone(),
-            self.messages_per_epoch,
+            self.auto_commit,
+            self.epoch_length,
         )
     }
 
     /// Egregious hack see [`SqliteRecoveryConfig::__getnewargs__`].
-    fn __getnewargs__(&self) -> (&str, &str, &str, &str, u64) {
+    fn __getnewargs__(
+        &self,
+    ) -> (
+        Vec<String>,
+        &str,
+        Vec<String>,
+        bool,
+        &str,
+        bool,
+        pyo3_chrono::Duration,
+    ) {
         let s = "UNINIT_PICKLED_STRING";
-        (s, s, s, s, 0)
+        (
+            Vec::new(),
+            s,
+            Vec::new(),
+            false,
+            s,
+            false,
+            pyo3_chrono::Duration(chrono::Duration::zero()),
+        )
     }
 
     /// Unpickle from tuple of arguments.
     fn __setstate__(&mut self, state: &PyAny) -> PyResult<()> {
         if let Ok((
             "KafkaInputConfig",
-            brokers,
+            hosts,
             group_id,
             topics,
+            tail,
             offset_reset,
-            messages_per_epoch,
+            auto_commit,
+            epoch_length,
         )) = state.extract()
         {
-            self.brokers = brokers;
+            self.hosts = hosts;
             self.group_id = group_id;
             self.topics = topics;
+            self.tail = tail;
             self.offset_reset = offset_reset;
-            self.messages_per_epoch = messages_per_epoch;
+            self.auto_commit = auto_commit;
+            self.epoch_length = epoch_length;
             Ok(())
         } else {
             Err(PyValueError::new_err(format!(
@@ -284,50 +319,49 @@ pub trait Pump {
 /// Encapsulates the process of pulling data out of a Kafka
 /// stream and feeding it into Timely.
 struct KafkaPump {
-    consumer: BaseConsumer<CustomContext>,
-    rt: Runtime,
+    consumer: BaseConsumer,
     push_to_timely: InputHandle<u64, TdPyAny>,
-    desired_messages_per_epoch: u64,
-    current_messages_per_epoch: u64,
-    current_epoch: u64,
+    epoch_length: Duration,
+    epoch_start: Instant,
     empty: bool,
 }
 
 impl KafkaPump {
     // TODO: Support recovery epoch on Kafka input. That'll require
-    // figuring out windowing.
-    fn new(config: PyRef<KafkaInputConfig>, push_to_timely: InputHandle<u64, TdPyAny>) -> Self {
-        let context = CustomContext;
+    // storing epoch to offset mappings.
+    fn new(
+        hosts: &[String],
+        group_id: &str,
+        topics: &[String],
+        tail: bool,
+        offset_reset: &str,
+        auto_commit: bool,
+        epoch_length: Duration,
+        push_to_timely: InputHandle<u64, TdPyAny>,
+    ) -> Self {
+        let eof = !tail;
 
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
+        let consumer: BaseConsumer = ClientConfig::new()
+            .set("group.id", group_id)
+            .set("bootstrap.servers", hosts.join(","))
+            .set("enable.partition.eof", format!("{eof}"))
+            .set("session.timeout.ms", "6000")
+            .set("enable.auto.commit", format!("{auto_commit}"))
+            .set("auto.offset.reset", offset_reset)
+            .set_log_level(RDKafkaLogLevel::Debug)
+            .create()
+            .expect("Consumer creation failed");
 
-        let consumer: BaseConsumer<CustomContext> = rt.block_on(async {
-            ClientConfig::new()
-                .set("group.id", config.group_id.clone())
-                .set("bootstrap.servers", config.brokers.clone())
-                .set("enable.partition.eof", "false")
-                .set("session.timeout.ms", "6000")
-                .set("enable.auto.commit", config.auto_commit.to_string())
-                .set("auto.offset.reset", config.offset_reset.clone())
-                .set_log_level(RDKafkaLogLevel::Debug)
-                .create_with_context(context)
-                .expect("Consumer creation failed")
-        });
-
+        let topics: Vec<_> = topics.iter().map(|s| s.as_str()).collect();
         consumer
-            .subscribe(&[&config.topics])
+            .subscribe(&topics)
             .expect("Can't subscribe to specified topics");
 
         Self {
             consumer,
-            rt,
             push_to_timely,
-            current_epoch: 0,
-            desired_messages_per_epoch: config.messages_per_epoch,
-            current_messages_per_epoch: 0,
+            epoch_length,
+            epoch_start: Instant::now(),
             empty: false,
         }
     }
@@ -335,37 +369,32 @@ impl KafkaPump {
 
 impl Pump for KafkaPump {
     fn pump(&mut self) {
-        if self.current_messages_per_epoch == self.desired_messages_per_epoch {
-            self.current_messages_per_epoch = 0;
-            self.current_epoch += 1;
-            self.push_to_timely.advance_to(self.current_epoch);
-        } else {
-            self.rt.block_on(async {
-                match self.consumer.poll(Duration::from_millis(1000)) {
-                    None => {
-                        dbg!("No messages available, incrementing epoch");
-                        self.current_messages_per_epoch = 0;
-                        self.current_epoch += 1;
-                        self.push_to_timely.advance_to(self.current_epoch);
-                    }
-                    Some(r) => match r {
-                        Err(e) => panic!("Kafka error! {}", e),
-                        Ok(s) => {
-                            self.current_messages_per_epoch += 1;
-                            Python::with_gil(|py| {
-                                let key: Py<PyAny> =
-                                    s.key().map_or(py.None(), |k| PyBytes::new(py, k).into());
-                                let payload: Py<PyAny> = s
-                                    .payload()
-                                    .map_or(py.None(), |k| PyBytes::new(py, k).into());
-                                let key_payload: Py<PyAny> = (key, payload).into_py(py);
+        let now = Instant::now();
+        if now > self.epoch_start + self.epoch_length {
+            self.push_to_timely
+                .advance_to(self.push_to_timely.time() + 1);
+            self.epoch_start = now;
+        }
 
-                                self.push_to_timely.send(key_payload.into())
-                            })
-                        }
-                    },
-                }
-            })
+        // TODO: Figure out how we're going to rate limit all
+        // inputs. I think we could do something like "activate_delay"
+        // on the input source itself once we move from Pumps to
+        // sources.
+        match self.consumer.poll(Duration::from_millis(100)) {
+            Some(Err(KafkaError::PartitionEOF(_))) => {
+                self.empty = true;
+            }
+            Some(Err(err)) => panic!("Error reading input from Kafka topic: {err:?}"),
+            None => {}
+            Some(Ok(s)) => Python::with_gil(|py| {
+                let key: Py<PyAny> = s.key().map_or(py.None(), |k| PyBytes::new(py, k).into());
+                let payload: Py<PyAny> = s
+                    .payload()
+                    .map_or(py.None(), |k| PyBytes::new(py, k).into());
+                let key_payload: Py<PyAny> = (key, payload).into_py(py);
+
+                self.push_to_timely.send(key_payload.into())
+            }),
         }
     }
 
@@ -373,7 +402,6 @@ impl Pump for KafkaPump {
         self.push_to_timely.time()
     }
 
-    // Always true right now
     fn input_remains(&mut self) -> bool {
         !self.empty
     }
@@ -420,9 +448,15 @@ impl Pump for ManualPump {
                         if let Ok(send) = item.downcast::<PyCell<Emit>>() {
                             self.push_to_timely.send(send.borrow().item.clone());
                         } else if let Ok(advance_to) = item.downcast::<PyCell<AdvanceTo>>() {
-                            self.push_to_timely.advance_to(advance_to.borrow().epoch);
+                            let epoch = advance_to.borrow().epoch;
+                            let input_epoch = self.push_to_timely.time();
+                            if &epoch >= input_epoch {
+                                self.push_to_timely.advance_to(epoch)
+                            } else {
+                                panic!("The epoch on `AdvanceTo` must never decrease; got an epoch of `{epoch:?}` while current input epoch is `{input_epoch:?}`; are you respecting `resume_epoch`?");
+                            }
                         } else {
-                            panic!("{}", format!("Input must be an instance of either `AdvanceTo` or `Emit`. Got: {item:?}. See https://docs.bytewax.io/apidocs#bytewax.AdvanceTo for more information."))
+                            panic!("Input must be an instance of either `AdvanceTo` or `Emit`; got `{item:?}` instead. See https://docs.bytewax.io/apidocs#bytewax.AdvanceTo for more information.");
                         }
                     }
                     Err(err) => {
@@ -446,40 +480,66 @@ impl Pump for ManualPump {
 
 pub(crate) fn pump_from_config(
     py: Python,
-    config: Py<InputConfig>,
+    input_config: Py<InputConfig>,
     input_handle: InputHandle<u64, TdPyAny>,
     worker_index: usize,
     worker_count: usize,
     resume_epoch: u64,
 ) -> Box<dyn Pump> {
-    let input_config = config.as_ref(py);
+    // See comment in [`crate::recovery::build_recovery_writers`]
+    // about releasing the GIL during IO class building.
+    let input_config = input_config.as_ref(py);
+
     if let Ok(kafka_config) = input_config.downcast::<PyCell<KafkaInputConfig>>() {
         let kafka_config = kafka_config.borrow();
-        Box::new(KafkaPump::new(kafka_config, input_handle))
+
+        let hosts = &kafka_config.hosts;
+        let group_id = &kafka_config.group_id;
+        let topics = &kafka_config.topics;
+        let tail = kafka_config.tail;
+        let offset_reset = &kafka_config.offset_reset;
+        let auto_commit = kafka_config.auto_commit;
+        let epoch_length = kafka_config
+            .epoch_length
+            .0
+            .to_std()
+            .expect("Can't convert epoch_length into std::time::Duration; negative length?");
+
+        let input_handle = SendWrapper::new(input_handle);
+        let kafka_pump = py.allow_threads(|| {
+            SendWrapper::new(KafkaPump::new(
+                hosts,
+                group_id,
+                topics,
+                tail,
+                offset_reset,
+                auto_commit,
+                epoch_length,
+                input_handle.take(),
+            ))
+        });
+
+        Box::new(kafka_pump.take())
     } else if let Ok(manual_config) = input_config.downcast::<PyCell<ManualInputConfig>>() {
         let manual_config = manual_config.borrow();
-        Box::new(ManualPump::new(
+
+        // This one can't release the GIL because we're calling Python
+        // to construct it.
+        let manual_pump = ManualPump::new(
             py,
             worker_index,
             worker_count,
             resume_epoch,
             manual_config,
             input_handle,
-        ))
+        );
+
+        Box::new(manual_pump)
     } else {
         let pytype = input_config.get_type();
         panic!("Unknown input_config type: {pytype}")
     }
 }
-
-//  // A context can be used to change the behavior of producers and consumers by adding callbacks
-// that will be executed by librdkafka.
-// We're not using this yet, but seems like it will be helpful with recovery callbacks
-struct CustomContext;
-
-impl ClientContext for CustomContext {}
-
-impl ConsumerContext for CustomContext {}
 
 pub(crate) fn register(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Emit>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub(crate) mod operators;
 pub(crate) mod pyo3_extensions;
 pub(crate) mod recovery;
 pub(crate) mod webserver;
+pub(crate) mod window;
 
 #[macro_use]
 pub(crate) mod macros;
@@ -35,10 +36,11 @@ fn sleep_release_gil(py: Python, secs: u64) {
 fn mod_bytewax(py: Python, m: &PyModule) -> PyResult<()> {
     pyo3_log::init();
 
-    execution::register(py, m)?;
     dataflow::register(py, m)?;
+    execution::register(py, m)?;
     inputs::register(py, m)?;
     recovery::register(py, m)?;
+    window::register(py, m)?;
 
     m.add_function(wrap_pyfunction!(sleep_keep_gil, m)?)?;
     m.add_function(wrap_pyfunction!(sleep_release_gil, m)?)?;

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -414,7 +414,7 @@ where
                     // frontier might have already progressed and it
                     // would be stranded.
                     activate_epochs_buffer.extend(outgoing_epoch_to_key_updates_buffer.keys().cloned().filter(is_closed));
-                    // Eagarly execute the frontier.
+                    // Eagerly execute the frontier.
                     activate_epochs_buffer.push(frontier_epoch);
                     activate_epochs_buffer.dedup();
                     activate_epochs_buffer.sort();
@@ -473,7 +473,7 @@ where
                                     key_values_buffer.extend(keys_buffer.drain(..).map(|k| (k.clone(), Poll::Ready(None))));
                                 } else {
                                     // Otherwise, wake up any keys
-                                    // that are passed their requested
+                                    // that are past their requested
                                     // activation time.
                                     key_values_buffer.extend(key_to_next_activate_at_buffer.iter().filter(|(_k, a)| a.elapsed() >= Duration::ZERO).map(|(k, _a)| (k.clone(), Poll::Pending)));
                                 }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -13,9 +13,11 @@ use crate::dataflow::StepId;
 use crate::log_func;
 use crate::pyo3_extensions::StateKey;
 use crate::pyo3_extensions::{TdPyAny, TdPyCallable, TdPyIterator};
+use crate::recovery::DeserializeBackup;
 use crate::recovery::ProgressReader;
 use crate::recovery::ProgressWriter;
 use crate::recovery::RecoveryKey;
+use crate::recovery::SerializeBackup;
 use crate::recovery::StateBackup;
 use crate::recovery::StateReader;
 use crate::recovery::StateUpdate;
@@ -23,19 +25,23 @@ use crate::recovery::StateWriter;
 use crate::recovery::{FrontierUpdate, StateCollector};
 use crate::with_traceback;
 use log::debug;
+use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::hash::Hash;
 use std::marker::PhantomData;
 use std::rc::Rc;
-use std::thread;
+use std::task::Poll;
+use std::time::{Duration, Instant};
 use timely::dataflow::channels::pact;
 use timely::dataflow::operators::flow_controlled::iterator_source;
 use timely::dataflow::operators::flow_controlled::IteratorSourceInput;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::FrontieredInputHandle;
-use timely::dataflow::operators::FrontierNotificator;
 use timely::dataflow::operators::Operator;
+use timely::dataflow::operators::{Filter, FrontierNotificator};
 use timely::dataflow::ProbeHandle;
 use timely::dataflow::Scope;
 use timely::dataflow::Stream;
@@ -62,7 +68,12 @@ pub(crate) fn filter(predicate: &TdPyCallable, item: &TdPyAny) -> bool {
         predicate,
         item
     );
-    Python::with_gil(|py| with_traceback!(py, predicate.call1(py, (item,))?.extract(py)))
+    Python::with_gil(|py| {
+        with_traceback!(py, {
+            let should_emit_pybool: TdPyAny = predicate.call1(py, (item,))?.into();
+            should_emit_pybool.extract(py).map_err(|_err| PyTypeError::new_err(format!("return value of `predicate` in filter operator must be a bool; got `{should_emit_pybool:?}` instead")))
+        })
+    })
 }
 
 pub(crate) fn inspect(inspector: &TdPyCallable, item: &TdPyAny) {
@@ -89,138 +100,142 @@ pub(crate) fn inspect_epoch(inspector: &TdPyCallable, epoch: &u64, item: &TdPyAn
     });
 }
 
-pub(crate) fn build_none() -> TdPyAny {
-    Python::with_gil(|py| py.None()).into()
-}
-
 pub(crate) fn reduce(
     reducer: &TdPyCallable,
     is_complete: &TdPyCallable,
     key: &StateKey,
-    acc: TdPyAny,
-    value: TdPyAny,
-) -> (Option<TdPyAny>, impl IntoIterator<Item = TdPyAny>) {
-    Python::with_gil(|py| {
-        let updated_acc: TdPyAny = if acc.is_none(py) {
-            value
-        } else {
-            let updated_acc = with_traceback!(
-                py,
-                reducer.call1(py, (acc.clone_ref(py), value.clone_ref(py)))
-            )
-            .into();
-            debug!("reduce for key={key:?}: reducer={reducer:?}(acc={acc:?}, value={value:?}) -> updated_acc={updated_acc:?}",);
-            updated_acc
-        };
-
-        let should_emit_and_discard_acc: bool = with_traceback!(
-            py,
-            is_complete
-                .call1(py, (updated_acc.clone_ref(py),))?
-                .extract(py)
-        );
-        debug!("reduce for key={key:?}: is_complete={is_complete:?}(updated_acc={updated_acc:?}) -> should_emit_and_discard_acc={should_emit_and_discard_acc:?}");
-
-        if should_emit_and_discard_acc {
-            (None, Some(updated_acc))
-        } else {
-            (Some(updated_acc), None)
-        }
-    })
-}
-
-pub(crate) fn reduce_epoch(
-    reducer: &TdPyCallable,
-    acc: &mut Option<TdPyAny>,
-    _key: &StateKey,
-    value: TdPyAny,
+    acc: Option<TdPyAny>,
+    next_value: Poll<Option<TdPyAny>>,
+) -> (
+    Option<TdPyAny>,
+    impl IntoIterator<Item = TdPyAny>,
+    Option<Duration>,
 ) {
-    debug!(
-        "{}, reducer:{:?}, key:{:?}, value:{:?}, acc:{:?}",
-        log_func!(),
-        reducer,
-        _key,
-        value,
-        acc
-    );
-    Python::with_gil(|py| {
-        let updated_acc = match acc {
-            Some(acc) => with_traceback!(py, reducer.call1(py, (acc.clone_ref(py), value))).into(),
-            None => value,
-        };
-        *acc = Some(updated_acc);
-        debug!(
-            "{}, reducer:{:?}, key:{:?}, updated_acc:{:?}",
-            log_func!(),
-            reducer,
-            _key,
-            acc
-        );
-    });
-}
+    if let Poll::Ready(Some(value)) = next_value {
+        Python::with_gil(|py| {
+            let updated_acc: TdPyAny = match acc {
+                // If there's no previous state for this key, use the
+                // current value.
+                None => value,
+                Some(acc) => {
+                    let updated_acc = with_traceback!(
+                        py,
+                        reducer.call1(py, (acc.clone_ref(py), value.clone_ref(py)))
+                    )
+                    .into();
+                    debug!("reduce for key={key:?}: reducer={reducer:?}(acc={acc:?}, value={value:?}) -> updated_acc={updated_acc:?}",);
+                    updated_acc
+                }
+            };
 
-pub(crate) fn reduce_epoch_local(
-    reducer: &TdPyCallable,
-    accs: &mut HashMap<StateKey, TdPyAny>,
-    all_key_value_in_epoch: &Vec<(StateKey, TdPyAny)>,
-) {
-    Python::with_gil(|py| {
-        let _current = thread::current();
-        let id = _current.id();
-        for (key, value) in all_key_value_in_epoch {
-            let acc = accs.entry(key.clone());
-            debug!(
-                "thread:{:?}, {}, reducer:{:?}, key:{:?}, value:{:?}, acc:{:?}",
-                id,
-                log_func!(),
-                reducer,
-                key,
-                value,
-                acc
-            );
-            acc.and_modify(|acc| {
-                *acc = with_traceback!(py, reducer.call1(py, (acc.clone_ref(py), value))).into();
-                debug!(
-                    "{}, reducer:{:?}, key:{:?}, value:{:?}, updated_acc:{:?}",
-                    log_func!(),
-                    reducer,
-                    key,
-                    value,
-                    *acc
-                );
-            })
-            .or_insert(value.clone_ref(py));
-        }
-    });
+            let should_emit_and_discard_acc: bool = with_traceback!(py, {
+                let should_emit_and_discard_acc_pybool: TdPyAny =
+                    is_complete.call1(py, (updated_acc.clone_ref(py),))?.into();
+                should_emit_and_discard_acc_pybool.extract(py).map_err(|_err| PyTypeError::new_err(format!("return value of `is_complete` in reduce operator must be a bool; got `{should_emit_and_discard_acc_pybool:?}` instead")))
+            });
+            debug!("reduce for key={key:?}: is_complete={is_complete:?}(updated_acc={updated_acc:?}) -> should_emit_and_discard_acc={should_emit_and_discard_acc:?}");
+
+            if should_emit_and_discard_acc {
+                (None, Some(updated_acc), None)
+            } else {
+                (Some(updated_acc), None, None)
+            }
+        })
+    } else {
+        (acc, None, None)
+    }
 }
 
 /// Extension trait for [`Stream`].
 // Based on the good work in
 // https://github.com/TimelyDataflow/timely-dataflow/blob/0d0d84885672d6369a78cd9aff7beb2048390d3b/timely/src/dataflow/operators/aggregation/state_machine.rs#L57
-pub(crate) trait StatefulMap<S: Scope, V: ExchangeData> {
-    /// See [`crate::dataflow::Dataflow::stateful_map`] for semantics.
+pub(crate) trait StatefulUnary<S: Scope, V: ExchangeData> {
+    /// Create a new generic stateful operator and add the required
+    /// utility operators to filter and serde backup data.
     ///
-    /// All stateful operators that need recovery are implemented in
-    /// terms of this so that we only need to write the recovery
-    /// system interop once.
+    /// See [`stateful_unary_raw`] for a description of how `logic` works.
+    fn stateful_unary<
+        R: Data,                   // Output item type
+        D: ExchangeData,           // Per-key state
+        I: IntoIterator<Item = R>, // Iterator of output items
+        L: Fn(&StateKey, Option<D>, Poll<Option<V>>) -> (Option<D>, I, Option<Duration>) + 'static, // Logic
+        H: Fn(&StateKey) -> u64 + 'static, // Hash function of key to worker
+    >(
+        &self,
+        step_id: StepId,
+        logic: L,
+        hasher: H,
+        state_loading_stream: &Stream<S, StateBackup<S::Timestamp, Vec<u8>>>,
+        state_backup_streams: &mut Vec<Stream<S, StateBackup<S::Timestamp, Vec<u8>>>>,
+    ) -> Stream<S, (StateKey, R)>;
+
+    /// Create a new generic stateful operator.
     ///
-    /// For recovery, this takes a state loading stream, where you can
-    /// pipe in all state updates from a previous execution to
-    /// resume. It also emits downstream [`StateBackup`] events to be
-    /// backed up.
-    fn stateful_map<
-        R: Data,                                            // Output item type
-        D: ExchangeData,                                    // Per-key state
-        I: IntoIterator<Item = R>,                          // Iterator of output items
-        B: Fn(&StateKey) -> D + 'static,                    // Builder of new per-key state
-        M: Fn(&StateKey, D, V) -> (Option<D>, I) + 'static, // Mapper
-        H: Fn(&StateKey) -> u64 + 'static,                  // Hash function of key to worker
+    /// This is the core Timely operator that all Bytewax stateful
+    /// operators are implemented in terms of. It is awkwardly generic
+    /// because of that. We do this so we only have to implement the
+    /// very tricky recovery system interop once.
+    ///
+    /// # Logic
+    ///
+    /// `logic` takes three arguments and is called on new input items
+    /// or after a delay timeout has expired:
+    ///
+    /// - The awoken key. This is due to the input stream having an
+    /// item of `(key, value)` or an awakening being scheduled on that
+    /// key
+    ///
+    /// - The last state for that key. That might be [`None`] if there
+    /// wasn't any.
+    ///
+    /// - A possible incoming value. This has the same protocol as
+    /// [`std::async_iter::AsyncIterator::poll_next`]: this logic
+    /// might be awoken with no incoming values yet
+    /// ([`Poll::Pending`]), a new value has arrived ([`Poll::Ready`]
+    /// with a [`Some`]), or the stream has ended and there will be no
+    /// more input ([`Poll::Ready`] with a [`None`]).
+    ///
+    /// `logic` must return a 3-tuple of:
+    ///
+    /// - The updated state for the key, or [`None`] if the state
+    /// should be discarded.
+    ///
+    /// - Values to be emitted downstream. You probably only want to
+    /// emit values when the incoming value is [`None`], signaling the
+    /// window has closed, but you might want something more
+    /// generic.
+    ///
+    /// - Timeout delay to be awoken after with [`Poll::Pending`] as
+    /// the value. It's possible the logic will be awoken for this key
+    /// earlier if new data comes in. Timeouts are not buffered across
+    /// calls to logic, so you should always specify the delay to the
+    /// next time you should be woken up every time.
+    ///
+    /// # Output
+    ///
+    /// The output will be a stream of `(key, value)` output
+    /// 2-tuples. Values emitted by `logic` will be automatically
+    /// paired with the key in the output stream.
+    ///
+    /// # Recovery
+    ///
+    /// For recovery, this requires an input of [`StateBackups`] to
+    /// load, and emits a second output stream of [`StateBackups`] to
+    /// be connected to the rest of the recovery machinery.
+    ///
+    /// These input and outputs must just be for this stateful
+    /// operator.
+    fn stateful_unary_raw<
+        R: Data,                   // Output item type
+        D: ExchangeData,           // Per-key state
+        I: IntoIterator<Item = R>, // Iterator of output items
+        L: Fn(&StateKey, Option<D>, Poll<Option<V>>) -> (Option<D>, I, Option<Duration>) + 'static, // Logic
+        H: Fn(&StateKey) -> u64 + 'static, // Hash function of key to worker
     >(
         &self,
         step_id: StepId,
         state_loading_stream: Stream<S, StateBackup<S::Timestamp, D>>,
-        builder: B,
-        mapper: M,
+        logic: L,
         hasher: H,
     ) -> (
         Stream<S, (StateKey, R)>,
@@ -230,44 +245,76 @@ pub(crate) trait StatefulMap<S: Scope, V: ExchangeData> {
         S::Timestamp: Hash + Eq;
 }
 
-impl<S: Scope, V: ExchangeData> StatefulMap<S, V> for Stream<S, (StateKey, V)>
+impl<S: Scope, V: ExchangeData> StatefulUnary<S, V> for Stream<S, (StateKey, V)>
 where
     S: Scope<Timestamp = u64>,
 {
-    fn stateful_map<
-        R: Data,                                            // Output item type
-        D: ExchangeData,                                    // Per-key state
-        I: IntoIterator<Item = R>,                          // Iterator of output items
-        B: Fn(&StateKey) -> D + 'static,                    // Builder of new per-key state
-        M: Fn(&StateKey, D, V) -> (Option<D>, I) + 'static, // Mapper
-        H: Fn(&StateKey) -> u64 + 'static,                  // Hash function of key to worker
+    fn stateful_unary<
+        R: Data,                   // Output item type
+        D: ExchangeData,           // Per-key state
+        I: IntoIterator<Item = R>, // Iterator of output items
+        L: Fn(&StateKey, Option<D>, Poll<Option<V>>) -> (Option<D>, I, Option<Duration>) + 'static, // Logic
+        H: Fn(&StateKey) -> u64 + 'static, // Hash function of key to worker
+    >(
+        &self,
+        step_id: StepId,
+        logic: L,
+        hasher: H,
+        state_loading_stream: &Stream<S, StateBackup<S::Timestamp, Vec<u8>>>,
+        state_backup_streams: &mut Vec<Stream<S, StateBackup<S::Timestamp, Vec<u8>>>>,
+    ) -> Stream<S, (StateKey, R)> {
+        let filter_step_id = step_id.clone();
+        let state_loading_stream = state_loading_stream
+            .filter(
+                move |StateBackup(RecoveryKey(loading_step_id, _key, _epoch), _state_update)| {
+                    &filter_step_id == loading_step_id
+                },
+            )
+            .deserialize_backup();
+
+        let (downstream, state_backup_stream) =
+            self.stateful_unary_raw(step_id, state_loading_stream, logic, hasher);
+
+        state_backup_streams.push(state_backup_stream.serialize_backup());
+        downstream
+    }
+
+    fn stateful_unary_raw<
+        R: Data,                   // Output item type
+        D: ExchangeData,           // Per-key state
+        I: IntoIterator<Item = R>, // Iterator of output items
+        L: Fn(&StateKey, Option<D>, Poll<Option<V>>) -> (Option<D>, I, Option<Duration>) + 'static, // Logic
+        H: Fn(&StateKey) -> u64 + 'static, // Hash function of key to worker
     >(
         &self,
         step_id: StepId,
         state_loading_stream: Stream<S, StateBackup<S::Timestamp, D>>,
-        builder: B,
-        mapper: M,
+        logic: L,
         hasher: H,
     ) -> (
         Stream<S, (StateKey, R)>,
         Stream<S, StateBackup<S::Timestamp, D>>,
     ) {
-        let mut op_builder = OperatorBuilder::new("StatefulMap".to_owned(), self.scope());
+        let mut op_builder = OperatorBuilder::new("StatefulUnary".to_owned(), self.scope());
 
         let (mut output_wrapper, output_stream) = op_builder.new_output();
         let (mut state_backup_wrapper, state_backup_stream) = op_builder.new_output();
 
         let hasher = Rc::new(hasher);
         let input_hasher = hasher.clone();
-        let mut input = op_builder.new_input_connection(
+        let mut input_handle = op_builder.new_input_connection(
             self,
             pact::Exchange::new(move |&(ref key, ref _value)| input_hasher(key)),
             // This is saying this input results in items on either
             // output.
             vec![Antichain::from_elem(0), Antichain::from_elem(0)],
+            // TODO: Figure out the magic incantation of
+            // S::Timestamp::minimum() and S::Timestamp::Summary that
+            // lets you do this without the trait bound S:
+            // Scope<Timestamp = u64> above.
         );
         let loading_hasher = hasher.clone();
-        let mut state_loading_input = op_builder.new_input_connection(
+        let mut state_loading_handle = op_builder.new_input_connection(
             &state_loading_stream,
             pact::Exchange::new(
                 move |StateBackup(RecoveryKey(ref _step_id, ref key, ref _epoch), ref _state)| {
@@ -279,11 +326,21 @@ where
             vec![Antichain::new(), Antichain::new()],
         );
 
-        op_builder.build(move |_init_capabilities| {
+        let info = op_builder.operator_info();
+        let activator = self.scope().activator_for(&info.address[..]);
+
+        op_builder.build(move |mut init_caps| {
             // This stores the working map of key to value on the
-            // frontier. We update this in-place when the frontier
-            // progresses and then emit the results.
+            // frontier. We update this in-place and emit the results.
             let mut state_cache = HashMap::new();
+
+            // We have to retain separate capabilities
+            // per-output. This seems to be only documented in
+            // https://github.com/TimelyDataflow/timely-dataflow/pull/187
+            // In reverse order because of how [`Vec::pop`] removes
+            // from back.
+            let mut state_backup_cap = init_caps.pop();
+            let mut output_cap = init_caps.pop();
 
             let mut tmp_backups = Vec::new();
             let mut incoming_epoch_to_backups_buffer = HashMap::new();
@@ -291,161 +348,212 @@ where
             let mut tmp_key_values = Vec::new();
             let mut incoming_epoch_to_key_values_buffer = HashMap::new();
 
+            let mut activate_epochs_buffer: Vec<S::Timestamp> = Vec::new();
+            let mut key_values_buffer = Vec::new();
+            let mut keys_buffer = Vec::new();
+            let mut key_to_next_activate_at_buffer: HashMap<StateKey, Instant> = HashMap::new();
+
             let mut outgoing_epoch_to_key_updates_buffer = HashMap::new();
 
-            // We have to jump through hoops to retain separate
-            // capabilities per-output. See
-            // https://github.com/TimelyDataflow/timely-dataflow/pull/187
-            let mut state_loading_fncater = FrontierNotificator::new();
-            let mut output_fncater = FrontierNotificator::new();
-            let mut state_backup_fncater = FrontierNotificator::new();
-
             move |input_frontiers| {
-                let mut input_handle = FrontieredInputHandle::new(&mut input, &input_frontiers[0]);
-                let mut state_loading_handle =
-                    FrontieredInputHandle::new(&mut state_loading_input, &input_frontiers[1]);
+                // Will there be no more data?
+                let eof = input_frontiers.iter().all(|f| f.is_empty());
+                let is_closed = |e: &S::Timestamp| input_frontiers.iter().all(|f| !f.less_equal(e));
 
-                let mut output_handle = output_wrapper.activate();
-                let mut state_backup_handle = state_backup_wrapper.activate();
+                if let (Some(output_cap), Some(state_backup_cap)) =
+                    (output_cap.as_mut(), state_backup_cap.as_mut())
+                {
+                    assert!(output_cap.time() == state_backup_cap.time());
+                    let mut output_handle = output_wrapper.activate();
+                    let mut state_backup_handle = state_backup_wrapper.activate();
 
-                // Store the state backups from the loading input in a
-                // buffer under the epoch until that frontier has
-                // passed.
-                state_loading_handle.for_each(|cap, backups| {
-                    let epoch = cap.time();
-                    backups.swap(&mut tmp_backups);
+                    // Buffer the state backups and item inputs so we
+                    // can apply them to the state cache in epoch
+                    // order.
+                    state_loading_handle.for_each(|cap, backups| {
+                        let epoch = cap.time();
+                        backups.swap(&mut tmp_backups);
 
-                    incoming_epoch_to_backups_buffer
-                        .entry(epoch.clone())
-                        .or_insert_with(Vec::new)
-                        .extend(tmp_backups.drain(..));
+                        incoming_epoch_to_backups_buffer
+                            .entry(epoch.clone())
+                            .or_insert_with(Vec::new)
+                            .extend(tmp_backups.drain(..));
+                    });
+                    input_handle.for_each(|cap, key_values| {
+                        let epoch = cap.time();
+                        key_values.swap(&mut tmp_key_values);
 
-                    state_loading_fncater.notify_at(cap.retain_for_output(1));
-                });
+                        incoming_epoch_to_key_values_buffer
+                            .entry(epoch.clone())
+                            .or_insert_with(Vec::new)
+                            .extend(tmp_key_values.drain(..));
 
-                // Store the input items in a buffer under the epoch
-                // until that frontier has passed.
-                input_handle.for_each(|cap, key_values| {
-                    let epoch = cap.time();
-                    key_values.swap(&mut tmp_key_values);
+                    });
 
-                    incoming_epoch_to_key_values_buffer
-                        .entry(epoch.clone())
-                        .or_insert_with(Vec::new)
-                        .extend(tmp_key_values.drain(..));
+                    // TODO: Is this the right way to get the epoch
+                    // from a frontier? I haven't seen any examples
+                    // with non-comparable timestamps to understand
+                    // this. Is the current capability reasonable for
+                    // when the frontiers are closed?
+                    let frontier_epoch = input_frontiers
+                        .iter()
+                        .flat_map(|mf| mf.frontier().iter().min().cloned())
+                        .min()
+                        .unwrap_or(output_cap.time().clone());
 
-                    // Input items will evolve the state and both emit
-                    // something downstream and result in a state
-                    // update.
+                    // Try to process all the epochs we have data for.
+                    // Filter out epochs that are ahead of the
+                    // frontier. The state at the beginning of those
+                    // epochs are not truly known yet, so we can't
+                    // apply input in those epochs yet.
+                    activate_epochs_buffer.extend(incoming_epoch_to_backups_buffer.keys().cloned().filter(is_closed));
+                    activate_epochs_buffer.extend(incoming_epoch_to_key_values_buffer.keys().cloned().filter(is_closed));
+                    // Even if we don't have input data from an epoch,
+                    // we might have some output data from the
+                    // previous activation we need to output and the
+                    // frontier might have already progressed and it
+                    // would be stranded.
+                    activate_epochs_buffer.extend(outgoing_epoch_to_key_updates_buffer.keys().cloned().filter(is_closed));
+                    // Eagarly execute the frontier.
+                    activate_epochs_buffer.push(frontier_epoch);
+                    activate_epochs_buffer.dedup();
+                    activate_epochs_buffer.sort();
 
-                    // AFAICT, ports are in order of `new_output()`
-                    // calls. Also I don't understand how to use
-                    // `retain_for_output()` multiple times since it
-                    // takes an owned
-                    // capability. `delayed_for_output()` seems to
-                    // work but might be incorrect?
-                    output_fncater.notify_at(cap.delayed_for_output(epoch, 0));
-                    state_backup_fncater.notify_at(cap.delayed_for_output(epoch, 1));
-                });
+                    // Drain to re-use buffer. For each epoch in
+                    // order:
+                    for epoch in activate_epochs_buffer.drain(..) {
+                        // Since the frontier has advanced to at least
+                        // this epoch (because we're going through
+                        // them in order), say that we'll not be
+                        // sending output at any older epochs. This
+                        // also asserts "apply changes in epoch order"
+                        // to the state cache.
+                        output_cap.downgrade(&epoch);
+                        state_backup_cap.downgrade(&epoch);
 
-                // Apply state loads first.
-                state_loading_fncater.for_each(
-                    &[input_handle.frontier(), state_loading_handle.frontier()],
-                    |state_update_cap, _ncater| {
-                        let epoch = state_update_cap.time();
+                        match (
+                            incoming_epoch_to_backups_buffer.remove(&epoch),
+                            incoming_epoch_to_key_values_buffer.remove(&epoch),
+                        ) {
+                            (Some(_), Some(_)) => panic!("Recoverable operator got both state backups and input for epoch {epoch:?}; is the resume epoch being respected?"),
+                            // Either load state backup.
+                            (Some(backups), None) => {
+                                // There will be multiple backups per
+                                // epoch, one for each key.
+                                for StateBackup(RecoveryKey(loading_step_id, key, _epoch), state_update) in
+                                    backups {
+                                        assert!(loading_step_id == step_id);
+                                        // Input on the state input
+                                        // fully overwrites state for
+                                        // that key.
+                                        match state_update {
+                                            StateUpdate::Upsert(state) => state_cache.insert(key, state),
+                                            StateUpdate::Reset => state_cache.remove(&key),
+                                        };
 
-                        if let Some(backups) = incoming_epoch_to_backups_buffer.remove(epoch) {
-                            for StateBackup(RecoveryKey(_step_id, key, _epoch), state_update) in
-                                backups
-                            {
-                                // Input on the state input fully
-                                // overwrites state for that key.
-                                match state_update {
-                                    StateUpdate::Upsert(state) => state_cache.insert(key, state),
-                                    StateUpdate::Reset => state_cache.remove(&key),
-                                };
-
-                                // Don't output state loads downstream
-                                // as backups.
-                            }
-                        }
-                    },
-                );
-
-                // Then run stateful map functionality.
-                output_fncater.for_each(
-                    &[input_handle.frontier(), state_loading_handle.frontier()],
-                    |downstream_cap, _ncater| {
-                        let epoch = downstream_cap.time();
-
-                        if let Some(key_values) = incoming_epoch_to_key_values_buffer.remove(epoch)
-                        {
-                            let mut output_session = output_handle.session(&downstream_cap);
-
-                            for (key, value) in key_values {
-                                let state_for_key = state_cache
-                                    .remove(&key)
-                                    // If there's no previous state, build
-                                    // anew.
-                                    .unwrap_or_else(|| builder(&key));
-
-                                let (updated_state_for_key, output) =
-                                    mapper(&key, state_for_key, value);
-                                let state_update = match updated_state_for_key {
-                                    Some(state) => StateUpdate::Upsert(state),
-                                    None => StateUpdate::Reset,
-                                };
-
-                                output_session.give_iterator(
-                                    output.into_iter().map(|item| (key.clone(), item)),
-                                );
-
-                                // Save the state so we can use it if
-                                // there are multiple values within
-                                // this epoch. We do not emit updated
-                                // state here because we don't have
-                                // finalized state for the epoch.
-                                match &state_update {
-                                    StateUpdate::Upsert(state) => {
-                                        state_cache.insert(key.clone(), state.clone())
+                                        // Don't output state loads
+                                        // downstream as backups.
                                     }
-                                    StateUpdate::Reset => state_cache.remove(&key),
-                                };
+                            }
+                            // Or run logic and buffer state updates.
+                            (None, incoming_key_values) => {
+                                let mut output_session = output_handle.session(&output_cap);
 
-                                outgoing_epoch_to_key_updates_buffer
-                                    .entry(epoch.clone())
-                                    .or_insert_with(HashMap::new)
-                                    .insert(key, state_update);
+                                // Include all the incoming data.
+                                key_values_buffer.extend(incoming_key_values.unwrap_or_default().into_iter().map(|(k, v)| (k, Poll::Ready(Some(v)))));
+
+                                if eof {
+                                    // If this is the last activation,
+                                    // signal that all keys have
+                                    // terminated.
+                                    keys_buffer.extend(key_values_buffer.iter().map(|(k, _v)| k).cloned());
+                                    keys_buffer.extend(state_cache.keys().cloned());
+                                    keys_buffer.dedup();
+                                    // Drain to re-use allocation.
+                                    key_values_buffer.extend(keys_buffer.drain(..).map(|k| (k.clone(), Poll::Ready(None))));
+                                } else {
+                                    // Otherwise, wake up any keys
+                                    // that are passed their requested
+                                    // activation time.
+                                    key_values_buffer.extend(key_to_next_activate_at_buffer.iter().filter(|(_k, a)| a.elapsed() >= Duration::ZERO).map(|(k, _a)| (k.clone(), Poll::Pending)));
+                                }
+
+                                // Drain to re-use allocation.
+                                for (key, next_value) in key_values_buffer.drain(..) {
+                                    let state = state_cache.remove(&key);
+                                    // Remove any activation times
+                                    // this current one will satisfy.
+                                    if let Entry::Occupied(next_activate_at_entry) = key_to_next_activate_at_buffer.entry(key.clone()) {
+                                        if next_activate_at_entry.get().elapsed() >= Duration::ZERO {
+                                            next_activate_at_entry.remove();
+                                        }
+                                    }
+
+                                    let (updated_state, output, activate_after) = logic(&key, state, next_value);
+
+                                    let state_update = match updated_state {
+                                        Some(state) => StateUpdate::Upsert(state),
+                                        None => StateUpdate::Reset,
+                                    };
+                                    match &state_update {
+                                        StateUpdate::Upsert(state) => {
+                                            state_cache.insert(key.clone(), state.clone())
+                                        }
+                                        StateUpdate::Reset => state_cache.remove(&key),
+                                    };
+                                    outgoing_epoch_to_key_updates_buffer
+                                        .entry(epoch.clone())
+                                        .or_insert_with(HashMap::new)
+                                        .insert(key.clone(), state_update);
+
+                                    output_session.give_iterator(
+                                        output.into_iter().map(|item| (key.clone(), item)),
+                                    );
+
+                                    if let Some(activate_after) = activate_after {
+                                        let activate_at = Instant::now() + activate_after;
+                                        key_to_next_activate_at_buffer.entry(key.clone())
+                                            .and_modify(|next_activate_at: &mut Instant| if activate_at < *next_activate_at { *next_activate_at = activate_at; })
+                                            .or_insert(activate_at);
+                                    }
+                                }
                             }
                         }
-                    },
-                );
 
-                // Then output final state update.
-                state_backup_fncater.for_each(
-                    &[input_handle.frontier(), state_loading_handle.frontier()],
-                    |state_update_cap, _ncater| {
-                        let epoch = state_update_cap.time();
+                        // Output a final state update output per
+                        // epoch. Remove will ensure we slowly drain
+                        // the buffer.
+                        if is_closed(&epoch) {
+                            if let Some(key_updates) =
+                                outgoing_epoch_to_key_updates_buffer.remove(&epoch)
+                            {
+                                let mut state_backup_session =
+                                    state_backup_handle.session(&state_backup_cap);
 
-                        let mut state_backup_session =
-                            state_backup_handle.session(&state_update_cap);
+                                let backups = key_updates.into_iter().map(|(key, update)| {
+                                    StateBackup(
+                                        RecoveryKey(step_id.clone(), key, epoch.clone()),
+                                        update,
+                                    )
+                                });
 
-                        // Now that this epoch is complete, write out any
-                        // modified state. `remove()` will ensure we
-                        // slowly drain the buffer.
-                        if let Some(key_updates) =
-                            outgoing_epoch_to_key_updates_buffer.remove(epoch)
-                        {
-                            let backups = key_updates.into_iter().map(|(key, update)| {
-                                StateBackup(
-                                    RecoveryKey(step_id.clone(), key, epoch.clone()),
-                                    update,
-                                )
-                            });
-                            state_backup_session.give_iterator(backups);
+                                state_backup_session.give_iterator(backups);
+                            }
                         }
-                    },
-                );
+                    }
+
+                    // Schedule an activation at the next requested
+                    // wake up time.
+                    let now = Instant::now();
+                    if let Some(delay) = key_to_next_activate_at_buffer.values().map(|a| a.duration_since(now)).min() {
+                        activator.activate_after(delay);
+                    }
+                }
+
+                if eof {
+                    output_cap = None;
+                    state_backup_cap = None;
+                }
             }
         });
 
@@ -462,22 +570,34 @@ pub(crate) fn build(builder: &TdPyCallable, key: &StateKey) -> TdPyAny {
 }
 
 pub(crate) fn stateful_map(
+    builder: &TdPyCallable,
     mapper: &TdPyCallable,
     key: &StateKey,
-    state: TdPyAny,
-    value: TdPyAny,
-) -> (Option<TdPyAny>, impl IntoIterator<Item = TdPyAny>) {
-    Python::with_gil(|py| {
-        let (updated_state, emit_value): (Option<TdPyAny>, TdPyAny) = with_traceback!(
-            py,
-            mapper
-                .call1(py, (state.clone_ref(py), value.clone_ref(py)))?
-                .extract(py)
-        );
-        debug!("stateful_map for key={key:?}: mapper={mapper:?}(state={state:?}, value={value:?}) -> (updated_state={updated_state:?}, emit_value={emit_value:?})");
+    state: Option<TdPyAny>,
+    next_value: Poll<Option<TdPyAny>>,
+) -> (
+    Option<TdPyAny>,
+    impl IntoIterator<Item = TdPyAny>,
+    Option<Duration>,
+) {
+    if let Poll::Ready(Some(value)) = next_value {
+        let state = state.unwrap_or_else(|| build(builder, key));
 
-        (updated_state, std::iter::once(emit_value))
-    })
+        Python::with_gil(|py| {
+            let (updated_state, updated_value): (Option<TdPyAny>, TdPyAny) = with_traceback!(py, {
+                let updated_state_value_pytuple: TdPyAny = mapper
+                    .call1(py, (state.clone_ref(py), value.clone_ref(py)))?
+                    .into();
+                updated_state_value_pytuple.extract(py)
+                        .map_err(|_err| PyTypeError::new_err(format!("return value of `mapper` in stateful map operator must be a 2-tuple of `(updated_state, updated_value)`; got `{updated_state_value_pytuple:?}` instead")))
+            });
+            debug!("stateful_map for key={key:?}: mapper={mapper:?}(state={state:?}, value={value:?}) -> (updated_state={updated_state:?}, updated_value={updated_value:?})");
+
+            (updated_state, Some(updated_value), None)
+        })
+    } else {
+        (state, None, None)
+    }
 }
 
 pub(crate) fn capture(captor: &TdPyCallable, epoch: &u64, item: &TdPyAny) {
@@ -817,7 +937,7 @@ where
 ///
 /// State must be stored in epoch order. [`WriteState`] above, does
 /// that.
-pub(crate) fn state_source<S: Scope, D: Data>(
+pub(crate) fn state_source<S: Scope, D: Data + Debug>(
     scope: &S,
     mut reader: Box<dyn StateReader<S::Timestamp, D>>,
     stop_at: S::Timestamp,

--- a/src/pyo3_extensions/mod.rs
+++ b/src/pyo3_extensions/mod.rs
@@ -358,6 +358,12 @@ impl<'source> FromPyObject<'source> for TdPyCallable {
     }
 }
 
+impl IntoPy<PyObject> for TdPyCallable {
+    fn into_py(self, _py: Python) -> Py<PyAny> {
+        self.0
+    }
+}
+
 impl ToPyObject for TdPyCallable {
     fn to_object(&self, py: Python) -> Py<PyAny> {
         self.0.clone_ref(py)

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -93,9 +93,9 @@ pub(crate) fn build_clock<V>(
     py: Python,
     clock_config: Py<ClockConfig>,
 ) -> Result<Box<dyn Clock<V>>, String> {
-    let window_config = clock_config.as_ref(py);
+    let clock_config = clock_config.as_ref(py);
 
-    if let Ok(system_clock_config) = window_config.downcast::<PyCell<SystemClockConfig>>() {
+    if let Ok(system_clock_config) = clock_config.downcast::<PyCell<SystemClockConfig>>() {
         let _system_clock_config = system_clock_config.borrow();
 
         let clock = SystemClock::new();
@@ -104,7 +104,7 @@ pub(crate) fn build_clock<V>(
     } else {
         Err(format!(
             "Unknown clock_config type: {}",
-            window_config.get_type(),
+            clock_config.get_type(),
         ))
     }
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -1,0 +1,601 @@
+//! Internal code for windowing.
+//!
+//! For a user-centric version of windowing, read the `bytewax.window`
+//! Python module docstring. Read that first.
+//!
+//! Architecture
+//! ------------
+//!
+//! Windowing is based around two core traits and one generic core
+//! operator: [`Clock`], [`Windower`], and
+//! [`StatefulWindowUnary::stateful_window_unary`].
+//!
+//! All user-facing windowing operators like
+//! [`crate::dataflow::Dataflow::reduce_window`] are built on top of
+//! [`StatefulWindowUnary::stateful_window_unary`] so we only have to
+//! write the window management code once.
+//!
+//! That operator itself is based upon
+//! [`crate::operators::StatefulUnary`], which provides a generic
+//! abstraction to the recovery system. We get recovery for "free" as
+//! long as we play by the rules of that operator.
+//!
+//! This system follows our standard pattern of having parallel Python
+//! config objects and Rust impl structs for each trait of behavior we
+//! want. E.g. [`SystemClockConfig`] represents a token in Python for
+//! how to create a [`SystemClock`].
+
+use crate::dataflow::StepId;
+use crate::operators::StatefulUnary;
+use crate::pyo3_extensions::{StateKey, TdPyAny, TdPyCallable};
+use crate::recovery::StateBackup;
+use crate::with_traceback;
+use chrono::{Duration, NaiveDateTime};
+use log::debug;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::task::Poll;
+use timely::dataflow::{Scope, Stream};
+use timely::{Data, ExchangeData};
+
+/// Base class for a clock config.
+///
+/// This describes how a windowing operator should determine the
+/// current time and the time for each element.
+///
+/// Use a specific subclass of this that matches the time definition
+/// you'd like to use.
+#[pyclass(module = "bytewax.window", subclass)]
+#[pyo3(text_signature = "()")]
+pub(crate) struct ClockConfig;
+
+/// Use the system time inside the windowing operator to determine
+/// times.
+///
+/// If the dataflow has no more input, all windows are closed.
+///
+/// Returns:
+///
+///     Config object. Pass this as the `clock_config` parameter to
+///     your windowing operator.
+#[pyclass(module="bytewax.window", extends=ClockConfig)]
+struct SystemClockConfig {}
+
+#[pymethods]
+impl SystemClockConfig {
+    #[new]
+    #[args()]
+    fn new() -> (Self, ClockConfig) {
+        (Self {}, ClockConfig {})
+    }
+
+    /// Pickle as a tuple.
+    fn __getstate__(&self) -> (&str,) {
+        ("SystemClockConfig",)
+    }
+
+    /// Unpickle from tuple of arguments.
+    fn __setstate__(&mut self, state: &PyAny) -> PyResult<()> {
+        if let Ok(("SystemClockConfig",)) = state.extract() {
+            Ok(())
+        } else {
+            Err(PyValueError::new_err(format!(
+                "bad pickle contents for SystemClockConfig: {state:?}"
+            )))
+        }
+    }
+}
+
+pub(crate) fn build_clock<V>(
+    py: Python,
+    clock_config: Py<ClockConfig>,
+) -> Result<Box<dyn Clock<V>>, String> {
+    let window_config = clock_config.as_ref(py);
+
+    if let Ok(system_clock_config) = window_config.downcast::<PyCell<SystemClockConfig>>() {
+        let _system_clock_config = system_clock_config.borrow();
+
+        let clock = SystemClock::new();
+
+        Ok(Box::new(clock))
+    } else {
+        Err(format!(
+            "Unknown clock_config type: {}",
+            window_config.get_type(),
+        ))
+    }
+}
+
+/// Base class for a windower config.
+///
+/// This describes the type of windows you would like.
+///
+/// Use a specific subclass of this that matches the window definition
+/// you'd like to use.
+#[pyclass(module = "bytewax.window", subclass)]
+#[pyo3(text_signature = "()")]
+pub(crate) struct WindowConfig;
+
+/// Tumbling windows of fixed duration.
+///
+/// Args:
+///
+///     length (datetime.timedelta): Length of window.
+///
+///     start_at (datetime.datetime): Instant of the first window. You
+///         can use this to align all windows to an hour, e.g.
+///
+/// Returns:
+///
+///     Config object. Pass this as the `window_config` parameter to
+///     your windowing operator.
+#[pyclass(module="bytewax.window", extends=WindowConfig)]
+struct TumblingWindowConfig {
+    #[pyo3(get)]
+    length: pyo3_chrono::Duration,
+    #[pyo3(get)]
+    start_at: Option<pyo3_chrono::NaiveDateTime>,
+}
+
+#[pymethods]
+impl TumblingWindowConfig {
+    #[new]
+    #[args(length, start_at = "None")]
+    fn new(
+        length: pyo3_chrono::Duration,
+        start_at: Option<pyo3_chrono::NaiveDateTime>,
+    ) -> (Self, WindowConfig) {
+        (Self { length, start_at }, WindowConfig {})
+    }
+
+    /// Pickle as a tuple.
+    fn __getstate__(
+        &self,
+    ) -> (
+        &str,
+        pyo3_chrono::Duration,
+        Option<pyo3_chrono::NaiveDateTime>,
+    ) {
+        ("TumblingWindowConfig", self.length, self.start_at)
+    }
+
+    /// Egregious hack see [`SqliteRecoveryConfig::__getnewargs__`].
+    fn __getnewargs__(&self) -> (pyo3_chrono::Duration, Option<pyo3_chrono::NaiveDateTime>) {
+        (pyo3_chrono::Duration(Duration::zero()), None)
+    }
+
+    /// Unpickle from tuple of arguments.
+    fn __setstate__(&mut self, state: &PyAny) -> PyResult<()> {
+        if let Ok(("TumblingWindowConfig", length, start_at)) = state.extract() {
+            self.length = length;
+            self.start_at = start_at;
+            Ok(())
+        } else {
+            Err(PyValueError::new_err(format!(
+                "bad pickle contents for TumblingWindowConfig: {state:?}"
+            )))
+        }
+    }
+}
+
+pub(crate) fn build_windower(
+    py: Python,
+    window_config: Py<WindowConfig>,
+) -> Result<Box<dyn Windower>, String> {
+    let window_config = window_config.as_ref(py);
+
+    if let Ok(tumbling_window_config) = window_config.downcast::<PyCell<TumblingWindowConfig>>() {
+        let tumbling_window_config = tumbling_window_config.borrow();
+
+        let length = tumbling_window_config.length.0;
+        let start_at = tumbling_window_config
+            .start_at
+            .map(|t| t.0)
+            .unwrap_or(chrono::offset::Local::now().naive_local());
+
+        let windower = TumblingWindower::new(length, start_at);
+
+        Ok(Box::new(windower))
+    } else {
+        Err(format!(
+            "Unknown window_config type: {}",
+            window_config.get_type(),
+        ))
+    }
+}
+
+/// Any persistent state that a [`Clock`] might need.
+///
+/// This is stored in the recovery system.
+///
+/// Add new stuff here that newer [`Clock`]s might need.
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
+pub(crate) struct ClockState {}
+
+/// Defines the sense of time for a windowing operator.
+pub(crate) trait Clock<V> {
+    /// Return the current time of the stream.
+    ///
+    /// There should be no more items with times before the
+    /// watermark. If there unexpectedly is, those items are marked as
+    /// late and routed separately.
+    ///
+    /// This will be called with each value in arrival order, but also
+    /// might be called between values and should use the internal
+    /// state to still return the watermark.
+    ///
+    /// This can mutate the [`ClockState`] on every call to ensure
+    /// future calls are accurate.
+    fn watermark(&self, state: &mut ClockState, value: &Poll<Option<V>>) -> NaiveDateTime;
+
+    /// Get the time for an item.
+    ///
+    /// This can mutate the [`ClockState`] if noting that an item has
+    /// arrived should advance the clock or something.
+    fn time_for(&self, state: &mut ClockState, value: &V) -> NaiveDateTime;
+}
+
+/// Use the current system time.
+struct SystemClock {}
+
+impl SystemClock {
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn now(&self) -> NaiveDateTime {
+        chrono::offset::Local::now().naive_local()
+    }
+}
+
+impl<V> Clock<V> for SystemClock {
+    fn watermark(&self, _state: &mut ClockState, item: &Poll<Option<V>>) -> NaiveDateTime {
+        match item {
+            // If there will be no more values, close out all windows.
+            Poll::Ready(None) => chrono::naive::MAX_DATETIME,
+            _ => self.now(),
+        }
+    }
+
+    fn time_for(&self, _state: &mut ClockState, _item: &V) -> NaiveDateTime {
+        self.now()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+pub(crate) struct WindowId(i64);
+
+/// Any persistent state a [`Windower`] might need.
+///
+/// This is stored in the recovery system.
+///
+/// Add new stuff here that newer [`Windower`]s might need.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub(crate) struct WindowerState {
+    close_times: HashMap<WindowId, NaiveDateTime>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+struct Window {
+    id: WindowId,
+    close: NaiveDateTime,
+}
+
+/// An error that can occur when windowing an item.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) enum InsertError {
+    /// The inserted item was late for a window.
+    Late(WindowId),
+}
+
+/// Defines a kind of time-based windows.
+///
+/// All relevant data needed to perform the inner methods must be
+/// stored in the [`WindowerState`].
+pub(crate) trait Windower {
+    /// Attempt to insert an incoming value into a window, creating it
+    /// if necessary.
+    ///
+    /// If the current item is "late" for all windows, return
+    /// [`WindowError::Late`].
+    ///
+    /// This must update the [`WindowerState`].
+    fn insert(
+        &self,
+        state: &mut WindowerState,
+        watermark: &NaiveDateTime,
+        item_time: NaiveDateTime,
+    ) -> Vec<Result<WindowId, InsertError>>;
+
+    /// Look at the current watermark, determine which windows are now
+    /// closed, return them, and remove them from the state.
+    ///
+    /// This must update the [`WindowerState`].
+    fn drain_closed(&self, state: &mut WindowerState, watermark: &NaiveDateTime) -> Vec<WindowId>;
+
+    /// Return how much system time should pass before the windowing
+    /// operator should be activated again, even if there is no
+    /// incoming values.
+    ///
+    /// Use this to signal to Timely's execution when windows will be
+    /// closing so we can close them without data.
+    fn activate_after(
+        &self,
+        state: &mut WindowerState,
+        watermark: &NaiveDateTime,
+    ) -> Option<Duration>;
+}
+
+/// Use fixed-length tumbling windows aligned to a start time.
+struct TumblingWindower {
+    length: Duration,
+    start_at: NaiveDateTime,
+}
+
+impl TumblingWindower {
+    fn new(length: Duration, start_at: NaiveDateTime) -> Self {
+        Self { length, start_at }
+    }
+}
+
+impl Windower for TumblingWindower {
+    fn insert(
+        &self,
+        state: &mut WindowerState,
+        watermark: &NaiveDateTime,
+        item_time: NaiveDateTime,
+    ) -> Vec<Result<WindowId, InsertError>> {
+        let since_start_at = item_time - self.start_at;
+        let window_count = since_start_at.num_milliseconds() / self.length.num_milliseconds();
+
+        let id = WindowId(window_count);
+        let close_at = self.start_at + self.length * (window_count as i32 + 1);
+
+        if &close_at < watermark {
+            vec![Err(InsertError::Late(id))]
+        } else {
+            state.close_times.insert(id.clone(), close_at);
+            vec![Ok(id)]
+        }
+    }
+
+    fn drain_closed(&self, state: &mut WindowerState, watermark: &NaiveDateTime) -> Vec<WindowId> {
+        // TODO: Gosh I really want [`HashMap::drain_filter`].
+        let mut future_close_times = HashMap::new();
+        let mut closed_ids = Vec::new();
+
+        for (id, close_at) in state.close_times.iter() {
+            if close_at < &watermark {
+                closed_ids.push(id.clone());
+            } else {
+                future_close_times.insert(id.clone(), close_at.clone());
+            }
+        }
+
+        state.close_times = future_close_times;
+        closed_ids
+    }
+
+    fn activate_after(
+        &self,
+        state: &mut WindowerState,
+        watermark: &NaiveDateTime,
+    ) -> Option<Duration> {
+        let watermark = watermark.clone();
+        state
+            .close_times
+            .values()
+            .cloned()
+            .map(|t| t - watermark)
+            .min()
+    }
+}
+/// The persistent state per-window that
+/// [`StatefulWindowUnary::stateful_window_unary`] will need.
+///
+/// The return types of the logic function in
+/// [`StatefulWindowUnary::stateful_window_unary`] determine what
+/// values we'll need to store here.
+///
+/// This is stored in the recovery system.
+#[derive(Clone, Serialize, Deserialize)]
+struct LogicState<D> {
+    window_states: HashMap<WindowId, D>,
+}
+
+impl<D> Default for LogicState<D> {
+    fn default() -> Self {
+        Self {
+            window_states: HashMap::new(),
+        }
+    }
+}
+
+/// Possible errors emitted downstream from windowing operators.
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) enum WindowError<V> {
+    /// This item was late for a window.
+    Late(V),
+}
+
+/// Extension trait for [`Stream`].
+pub(crate) trait StatefulWindowUnary<S: Scope, V: ExchangeData> {
+    /// Create a new generic windowing operator.
+    ///
+    /// This is the core Timely operator that all Bytewax windowing
+    /// operators are implemented in terms of. We do this so we only
+    /// have to implement the detailed windowing code once.
+    ///
+    /// # Logic
+    ///
+    /// `logic` takes three arguments and is called on each incoming
+    /// item and when the window closes:
+    ///
+    /// - The relevant key.
+    ///
+    /// - The last state for that key and window. This might be
+    /// [`None`] if there wasn't any.
+    ///
+    /// - An incoming value or [`None`] if the window for this key has
+    /// just closed. Think of this as the same protocol as
+    /// [`std::iter::Iterator::next`].
+    ///
+    /// `logic` must return a 2-tuple of:
+    ///
+    /// - The updated state for the key, or [`None`] if the state
+    /// should be discarded.
+    ///
+    /// - Values to be emitted downstream. You probably only want to
+    /// emit values when the incoming value is [`None`], signaling the
+    /// window has closed, but you might want something more
+    /// generic. They will be automatically paired with the key in the
+    /// output stream.
+    ///
+    /// # Output
+    ///
+    /// The output will be a stream of `(key, value)` output
+    /// 2-tuples. Values emitted by `logic` will automatically be
+    /// paired with the key in the output stream.
+    fn stateful_window_unary<
+        R: Data,                                                            // Output item type
+        D: ExchangeData,           // Per-key per-window state
+        I: IntoIterator<Item = R>, // Iterator of output items
+        L: Fn(&StateKey, Option<D>, Option<V>) -> (Option<D>, I) + 'static, // Logic
+        H: Fn(&StateKey) -> u64 + 'static, // Hash function of key to worker
+    >(
+        &self,
+        step_id: StepId,
+        clock: Box<dyn Clock<V>>,
+        windower: Box<dyn Windower>,
+        logic: L,
+        hasher: H,
+        state_loading_stream: &Stream<S, StateBackup<S::Timestamp, Vec<u8>>>,
+        state_backup_streams: &mut Vec<Stream<S, StateBackup<S::Timestamp, Vec<u8>>>>,
+    ) -> Stream<S, (StateKey, Result<R, WindowError<V>>)>;
+}
+
+impl<S, V: ExchangeData + Debug> StatefulWindowUnary<S, V> for Stream<S, (StateKey, V)>
+where
+    S: Scope<Timestamp = u64>,
+{
+    fn stateful_window_unary<
+        R: Data,                                                            // Output item type
+        D: ExchangeData,           // Per-key per-window state
+        I: IntoIterator<Item = R>, // Iterator of output items
+        L: Fn(&StateKey, Option<D>, Option<V>) -> (Option<D>, I) + 'static, // Logic
+        H: Fn(&StateKey) -> u64 + 'static, // Hash function of key to worker
+    >(
+        &self,
+        step_id: StepId,
+        clock: Box<dyn Clock<V>>,
+        windower: Box<dyn Windower>,
+        logic: L,
+        hasher: H,
+        state_loading_stream: &Stream<S, StateBackup<S::Timestamp, Vec<u8>>>,
+        state_backup_streams: &mut Vec<Stream<S, StateBackup<S::Timestamp, Vec<u8>>>>,
+    ) -> Stream<S, (StateKey, Result<R, WindowError<V>>)> {
+        self.stateful_unary(
+            step_id,
+            move |key, state: Option<(ClockState, WindowerState, LogicState<D>)>, value| {
+                let mut state = state.unwrap_or_default();
+                let (clock_state, windower_state, logic_state) = &mut state;
+
+                let mut emits = Vec::new();
+
+                let watermark = clock.watermark(clock_state, &value);
+
+                if let Poll::Ready(Some(value)) = value {
+                    let item_time = clock.time_for(clock_state, &value);
+
+                    for window_result in windower.insert(windower_state, &watermark, item_time) {
+                        let value = value.clone();
+                        match window_result {
+                            Err(InsertError::Late(_id)) => {
+                                emits.push(Err(WindowError::Late(value)));
+                            }
+                            Ok(id) => {
+                                let window_state = logic_state.window_states.remove(&id);
+
+                                let (updated_window_state, output) =
+                                    logic(&key, window_state, Some(value));
+
+                                match updated_window_state {
+                                    Some(state) => logic_state.window_states.insert(id, state),
+                                    None => logic_state.window_states.remove(&id),
+                                };
+
+                                emits.extend(output.into_iter().map(Ok));
+                            }
+                        }
+                    }
+                }
+
+                for id in windower.drain_closed(windower_state, &watermark) {
+                    let window_state = logic_state.window_states.remove(&id);
+
+                    let (updated_window_state, output) = logic(&key, window_state, None);
+
+                    if let Some(_) = updated_window_state {
+                        panic!("Stateful window logic did not return `None` on window close; state would be lost");
+                    }
+                    logic_state.window_states.remove(&id);
+
+                    emits.extend(output.into_iter().map(Ok));
+                }
+
+                let activate_after = windower
+                    .activate_after(windower_state, &watermark)
+                    .map(|d| d.to_std().unwrap_or(std::time::Duration::ZERO));
+
+                (Some(state), emits, activate_after)
+            },
+            hasher,
+            state_loading_stream,
+            state_backup_streams,
+        )
+    }
+}
+
+/// Shim function for [`crate::dataflow::Dataflow::reduce_window`].
+pub(crate) fn reduce_window(
+    reducer: &TdPyCallable,
+    key: &StateKey,
+    acc: Option<TdPyAny>,
+    next_value: Option<TdPyAny>,
+) -> (Option<TdPyAny>, impl IntoIterator<Item = TdPyAny>) {
+    match next_value {
+        Some(value) => {
+            Python::with_gil(|py| {
+                let updated_acc: TdPyAny = match acc {
+                    // If there's no previous state for this key, use
+                    // the current value.
+                    None => value,
+                    Some(acc) => {
+                        let updated_acc = with_traceback!(
+                            py,
+                            reducer.call1(py, (acc.clone_ref(py), value.clone_ref(py)))
+                        )
+                        .into();
+                        debug!("reduce_window for key={key:?}: reducer={reducer:?}(acc={acc:?}, value={value:?}) -> updated_acc={updated_acc:?}",);
+
+                        updated_acc
+                    }
+                };
+
+                (Some(updated_acc), None)
+            })
+        }
+        None => (None, acc),
+    }
+}
+
+pub(crate) fn register(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<ClockConfig>()?;
+    m.add_class::<SystemClockConfig>()?;
+    m.add_class::<WindowConfig>()?;
+    m.add_class::<TumblingWindowConfig>()?;
+    Ok(())
+}


### PR DESCRIPTION
I am incapable of making a PR with less than 1500 lines of code.

Docstrings explain what is going on. Start with `bytewax.window` for
an overview of windowing concepts. Then read the Rust code in the
`window` module for how that's implemented.

There are a few changes to the recovery system you can see in diffs to
the Rust `recovery` module. The main thing is now we mostly are
passing around backups of `Vec<u8>` rather than explicit types so we
can mush all the backup types together.

The most horrible part of all the code is the renaming / re-invention
of the `StatefulMap` operator into `StatefulUnary` which very very
carefully lets you run arbitrary logic on incoming values, keeps track
of state per key, lets you "awaken" the operator per-key even if
there's no data, and in all that manages to send out state snapshots.

I disabled markdown tests until we figure out what we want for input
and how much we want to expose epochs, then we can turn them back
on. There's one pytest for windowing now, though.

The `KafkaPump` has been slightly modified to emit epochs periodically
and not deal with batch sizes, since we're moving in the direction of
heartbeat epochs.