### PR TITLE
Cooperative manual input

### DIFF
--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -18,15 +18,18 @@ from .bytewax import InputConfig, KafkaInputConfig, ManualInputConfig  # noqa: F
 
 
 def TestingInputConfig(it):
-    """Produce input from this Python iterator. You only want to use this
+    """Produce input from this Python iterable. You only want to use this
     for unit testing.
 
-    The iterator must be identical on all workers; this will
+    The iterable must be identical on all workers; this will
     automatically distribute the items across workers.
+
+    The value `None` in the iterable will be ignored. See
+    `ManualInputConfig` for more info.
 
     Args:
 
-        it: Iterator for input.
+        it: Iterable for input.
 
     Returns:
 

--- a/pytests/test_inputs.py
+++ b/pytests/test_inputs.py
@@ -1,4 +1,24 @@
-from bytewax.inputs import distribute
+from bytewax.dataflow import Dataflow
+from bytewax.execution import run_main
+from bytewax.inputs import distribute, ManualInputConfig
+from bytewax.outputs import TestingOutputConfig
+
+
+def test_manual_input_config():
+    def input_builder(worker_index, worker_count):
+        yield 1
+        yield
+        yield 2
+        yield
+        yield 3
+
+    flow = Dataflow(ManualInputConfig(input_builder))
+    out = []
+    flow.capture(TestingOutputConfig(out))
+
+    run_main(flow)
+
+    assert sorted(out) == sorted([1, 2, 3])
 
 
 def test_distribute():


### PR DESCRIPTION
Asking an `InputReader` for the next piece of data should never
block. That's why it returns a `Poll<Option<T>`. But we need to expose
this Python-side if we want people to make well-behaved custom input
sources. This change allows that by intepreting any `None` in the
input stream as "no data, just yield and let other work happen".

You can see an example of how this would work in the unit test.
