### PR TITLE
Solved some clippy warnings, enabled doctests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [lib]
 name = "bytewax"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [package.metadata.maturin]
 python-source = "pysrc"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@ pub(crate) mod window;
 #[macro_use]
 pub(crate) mod macros;
 
+/// Result type used in the crate that holds a String as the Err type.
+pub(crate) type StringResult<E> = Result<E, String>;
+
 #[pyfunction]
 #[pyo3(text_signature = "(secs)")]
 fn sleep_keep_gil(secs: u64) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub(crate) mod window;
 pub(crate) mod macros;
 
 /// Result type used in the crate that holds a String as the Err type.
-pub(crate) type StringResult<E> = Result<E, String>;
+pub(crate) type StringResult<T> = Result<T, String>;
 
 #[pyfunction]
 #[pyo3(text_signature = "(secs)")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,15 +1,78 @@
 //! Internal macros
 
+/// Unwraps using [`std::panic::panic_any`], needed to panic with any structure in Rust 2021.
+/// See [https://github.com/rust-lang/rust/issues/78500]
 #[macro_export]
-macro_rules! with_traceback {
-    ($py:expr, $pyfunc:expr) => {
+macro_rules! unwrap_any {
+    ($pyfunc:expr) => {
+        $pyfunc.unwrap_or_else(|err| std::panic::panic_any(err))
+    };
+}
+
+#[macro_export]
+/// Creates a new scope for the expression where the `?` operator can be used if the expression
+/// returns the same type of the `?` call, then unwraps the result using [`std::panic::panic_any`]
+/// This can be used to panic and send a proper error message to the python interpreter.
+///
+/// ```rust
+/// // Example usage
+///
+/// use std::num::ParseIntError;
+/// use bytewax::try_unwrap;
+///
+/// struct RangeParser {
+///     start: u64,
+///     end: Option<u64>,
+/// }
+///
+/// impl RangeParser {
+///     pub fn new(start: &str) -> Result<RangeParser, ParseIntError> {
+///         let start = start.parse::<u64>()?;
+///         Ok(Self { start, end: None })
+///     }
+///
+///     pub fn end(mut self, end: &str) -> Result<RangeParser, ParseIntError> {
+///         self.end = Some(end.parse::<u64>()?);
+///         Ok(self)
+///     }
+/// }
+///
+/// let res = try_unwrap!(RangeParser::new("0")?.end("12"));
+/// assert_eq!(res.start, 0);
+/// assert_eq!(res.end, Some(12));
+/// ```
+macro_rules! try_unwrap {
+    ($pyfunc:expr) => {
         // This would be the perfect use for the
         // https://doc.rust-lang.org/nightly/unstable-book/language-features/try-blocks.html
         // feature.
-        match (|| $pyfunc)() {
-            Ok(r) => r,
-            Err(err) => std::panic::panic_any(err),
-        }
+        (|| $pyfunc)().unwrap_or_else(|err| std::panic::panic_any(err))
+    };
+}
+
+#[macro_export]
+/// Unwraps the result of the expression using [`std::panic::panic_any`].
+/// The error is mapped to a [`PyTypeError`] with a custom error message,
+/// taken from the second parameter of the macro.
+/// This can be used to panic and send a proper error message to the python interpreter.
+/// The macro invocations requires that [`pyo3::exceptions::PyTypeError`]
+/// is in scope and that the Python interpreter is available to PyO3.
+///
+/// ```rust
+/// use bytewax::py_unwrap;
+/// use pyo3::exceptions::PyTypeError;
+///
+/// pyo3::prepare_freethreaded_python();
+///
+/// let something = "abc".parse::<u64>();
+/// let res = std::panic::catch_unwind(|| py_unwrap!(something, "A custom python error message"));
+/// assert!(res.is_err());
+/// ```
+macro_rules! py_unwrap {
+    ($pyfunc:expr, $err_msg:expr) => {
+        $pyfunc
+            .map_err(|_err| PyTypeError::new_err($err_msg))
+            .unwrap_or_else(|err| std::panic::panic_any(err))
     };
 }
 


### PR DESCRIPTION
In this PR I solved some of the remaining clippy issues, and added the "rlib" crate type to the Cargo.toml so that doctests are ran when running `cargo test`.

The clippy issues where of four kinds:
1) Too complex types
2) Some uses of the `with_traceback!` macro where defining a function and immediately calling it without any advantage in doing so
3) Functions with too many arguments
4) PyO3 related warnings (deref on an immutable reference)

## Too complex types
To solve most of those issues, I created 2 type aliases:
- `StringResult<T>` which is just `Result<T, String>`
- `EpochData` which represents a tuple of `(StateKey, (StepId, StateUpdate))`

I'm not sure `EpochData` is a proper name though, so let me know if you can think of something better.
Some of the warnings remain, but I'd like some help on the naming there, because the intent is not always clear to me.

## with_traceback! macro
Spoiler: I wanted to remove the macro, I ended up writing 2 more...
The intention of the macros looks clearer to me this way, but if you don't like adding more macros than we already had I can revert these changes and either ignore the clippy issues or find a way to make it all work with a single macro.

The macro definition was quite simple:
```rust
macro_rules! with_traceback {
    ($py:expr, $pyfunc:expr) => {
        match (|| $pyfunc)() {
            Ok(r) => r,
            Err(err) => std::panic::panic_any(err),
        }
    };
}
```

Clippy was warning that sometimes defining the function and running it was not needed, so it suggested something like this:
```rust
macro_rules! with_traceback {
    ($py:expr, $pyfunc:expr) => {
        match  $pyfunc {
            Ok(r) => r,
            Err(err) => std::panic::panic_any(err),
        }
    };
}
```
The warning made sense, because we sometimes called the macro with just a simple expression inside.
The macro did not generate the warning when we used the `?` operator inside the expression (emulating a `try` block).
Also a lot of times when the macro was used, there was a mapping of the error to a `PyTypeError` at the calling site.

So I split what that macro was doing into 3 macros, documented and with doctests included.
Now we have:
```rust
macro_rules! unwrap_any {
    ($pyfunc:expr) => {
        $pyfunc.unwrap_or_else(|err| std::panic::panic_any(err))
    };
}
```
```rust
macro_rules! try_unwrap {
    ($pyfunc:expr) => {
        (|| $pyfunc)().unwrap_or_else(|err| std::panic::panic_any(err))
    };
}
```
```rust
macro_rules! py_unwrap {
    ($pyfunc:expr, $err_msg:expr) => {
        $pyfunc
            .map_err(|_err| PyTypeError::new_err($err_msg))
            .unwrap_or_else(|err| std::panic::panic_any(err))
    };
}
```
See the file `src/macros.rs` for documentation, examples and reference

## Functions with too many arguments
I didn't touch anything here, this would require to better define the types we move around and probably a non trivial refactoring, but let me know if you want me to work on that too.

## PyO3 related warnings
Those are already fixed in PyO3 0.17, but we need to wait until `pyo3-chrono` and `pyo3-log` release a new version based on PyO3 0.17 before upgrading.