### PR TITLE
[Fix]: Remove 'Understanding epochs' article from docs metadata

### DIFF
--- a/docs/articles/metadata.json
+++ b/docs/articles/metadata.json
@@ -16,10 +16,6 @@
         "filename": "simple-example"
       },
       {
-        "title": "Understanding epochs",
-        "filename": "epochs"
-      },
-      {
         "title": "Execution",
         "filename": "execution"
       },


### PR DESCRIPTION
[Understanding epochs](https://docs.bytewax.io/getting-started/epochs) article file was removed in the v0.11.0 release, but it's still visible in the navigation due to its presence in `metadata.json`.