### PR TITLE
Update and fix documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "bytewax"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "axum",
  "bincode",

--- a/docs/articles/getting-started/execution.md
+++ b/docs/articles/getting-started/execution.md
@@ -134,7 +134,7 @@ spawn_cluster(
 ```
 ## Multiple Workers Cluster Main
 
-The final entry point, `bytewax.execution.cluster_main()` is the most flexible. It allows you to start up a single process within a cluster of processes that you are manually coordinating. The input and output API also use operators and associated [builders](#builders), but you have to pass in the network addresses of the other processes you have started up yourself and assign them each a unique ID.
+The final entry point, `bytewax.execution.cluster_main()` is the most flexible. It allows you to start up a single process within a cluster of processes that you are manually coordinating, but you have to pass in the network addresses of the other processes you have started up yourself and assign them each a unique ID.
 
 `cluster_main()` takes in a list of hostname and port of all workers (including itself). Each worker must be given a unique process ID.
 

--- a/docs/articles/getting-started/ins_and_outs.md
+++ b/docs/articles/getting-started/ins_and_outs.md
@@ -1,0 +1,39 @@
+# Inputs
+
+The first thing we need to define on a Dataflow is the `input`.
+We do this by passing a specific input configuration to the `input` operator.
+
+Bytewax offers two input configurations (more to come in the future):
+- ManualInputConfig
+- KafkaInputConfig
+
+[ManualInputConfig]() allows you to define the input **builder** as a python function.
+The input builder is a function that is called on each worker and will produce the input for that worker.
+This input builder accepts three parameters: `worker_index, worker_count, resume_state`. The input builder function should return an iterable that yields a tuple of `(state, event)`.
+The input builder must know how to skip ahead in its input data to start at that `resume_state`. The `resume_state` parameter allows you to configure recovery should a failure interrupt a stateful operation, such as `stateful_map`.
+
+You can use any existing python library to extract the data you need.
+You then pass the builder to `ManualInputConfig` and that will be polled to retrieve new items.
+
+[KafkaInputConfig]() is a specific input configuration tailored for Kafka (and kafka-api compatible platforms, like Redpanda).
+This input generator is in the Rust side of Bytewax, and while you can build a custom Kafka input using the [ManualInputConfig]() and any python library to talk to Kafka, this is the recommended approach, since it also automatically handles recovery.
+`KafkaInputConfig` accepts four parameters: a list of brokers, a topic, a tail boolean and a starting_offset. See our API docs for `bytewax.inputs` for more on a Kafka configuration.
+
+
+
+### Input Configuration
+
+You can manually configure your dataflow's input with an input builder and a `ManualInputConfig` or use a Kafka stream with `KafkaInputConfig`. You'll configure these with the `Dataflow.input` operator.
+
+For a manual input source, you'll define an input **builder**, a function that is called on each worker and will produce the input for that worker. This input builder accepts three parameters: `worker_index, worker_count, resume_state`. The input builder function should return an iterable that yields a tuple of `(state, event)` and will be the `input_builder` parameter on the `ManualInputConfig` passed to the dataflow. The input builder must know how to skip ahead in its input data to start at that `resume_state`. The `resume_state` parameter allows you to configure recovery should a failure interrupt a stateful operation, such as `stateful_map`.
+
+A `KafkaInputConfig` accepts four parameters: a list of brokers, a topic, a tail boolean and a starting_offset. See our API docs for `bytewax.inputs` for more on a Kafka configuration.
+
+
+As in `spawn_cluster()`, the input builder function passed to a manual input configuration should return an iterable that yields `(state, item)` tuples. If you are using a `KafkaInputConfig`, state recovery will be managed for you.
+
+### Output
+
+Output is configured similarly to input, using a configuration and the `capture` operator. Akin to the `ManualInputConfig`, the `ManualOutputConfig` requires **builder** function that is called on each worker and will handle the output for that worker. However, the output builder function should return a callback **output handler** function that can be called with each item of output produced.
+
+(ManualOutputConfig) `run_main()` collects all output into a list internally first, thus it will not support infinite, larger than memory datasets.

--- a/docs/articles/getting-started/ins_and_outs.md
+++ b/docs/articles/getting-started/ins_and_outs.md
@@ -1,4 +1,7 @@
-# Inputs
+Each bytewax dataflow needs to know how to get the input data, and what to do with the processed data.
+There are 2 operators that allow you to configure this: `Dataflow.input` and `Dataflow.capture`.
+
+## Input
 
 The first thing we need to define on a Dataflow is the `input`.
 We do this by passing a specific input configuration to the `input` operator.
@@ -7,33 +10,24 @@ Bytewax offers two input configurations (more to come in the future):
 - ManualInputConfig
 - KafkaInputConfig
 
-[ManualInputConfig]() allows you to define the input **builder** as a python function.
-The input builder is a function that is called on each worker and will produce the input for that worker.
-This input builder accepts three parameters: `worker_index, worker_count, resume_state`. The input builder function should return an iterable that yields a tuple of `(state, event)`.
-The input builder must know how to skip ahead in its input data to start at that `resume_state`. The `resume_state` parameter allows you to configure recovery should a failure interrupt a stateful operation, such as `stateful_map`.
+[ManualInputConfig](/apidocs/bytewax.inputs#bytewax.inputs.ManualInputConfig) allows you to define the input **builder** as a python function.  
+The input builder is a function that is called on each worker and will produce the input for that worker.  
+It accepts three parameters: `worker_index, worker_count, resume_state`. The input builder function should return an iterable that yields a tuple of `(state, event)`, and it must know how to skip ahead in its input data to start at that `resume_state`. The `resume_state` parameter allows you to configure recovery should a failure interrupt a stateful operation, such as `stateful_map`.  
+You can use any existing python library to extract the data you need inside the builder function.  
+You then pass the builder to `ManualInputConfig` and the generator will be polled to retrieve new items.
 
-You can use any existing python library to extract the data you need.
-You then pass the builder to `ManualInputConfig` and that will be polled to retrieve new items.
-
-[KafkaInputConfig]() is a specific input configuration tailored for Kafka (and kafka-api compatible platforms, like Redpanda).
-This input generator is in the Rust side of Bytewax, and while you can build a custom Kafka input using the [ManualInputConfig]() and any python library to talk to Kafka, this is the recommended approach, since it also automatically handles recovery.
+[KafkaInputConfig](/apidocs/bytewax.inputs#bytewax.inputs.KafkaInputConfig) is a specific input configuration tailored for Apache Kafka (and kafka-api compatible platforms, like Redpanda).  
+This input generator is provided by the Rust Bytewax library, and while you can build a custom Kafka input using the `ManualInputConfig` and any python library to talk to Kafka, this is the recommended approach, since it also automatically handles recovery.  
 `KafkaInputConfig` accepts four parameters: a list of brokers, a topic, a tail boolean and a starting_offset. See our API docs for `bytewax.inputs` for more on a Kafka configuration.
 
+## Output
 
+Output too is configured using a configuration and the `capture` operator.
 
-### Input Configuration
+Bytewax offers three output configurations:
+- ManualOutputConfig
+- StdOutputConfig
 
-You can manually configure your dataflow's input with an input builder and a `ManualInputConfig` or use a Kafka stream with `KafkaInputConfig`. You'll configure these with the `Dataflow.input` operator.
+[ManualOutputConfig](/apidocs/bytewax.outputs#bytewax.outputs.ManualOutputConfig) requires a **builder** function that is called on each worker and will handle the output for that worker. The output builder function should return a callback **output handler** function that can be called with each item of output produced.
 
-For a manual input source, you'll define an input **builder**, a function that is called on each worker and will produce the input for that worker. This input builder accepts three parameters: `worker_index, worker_count, resume_state`. The input builder function should return an iterable that yields a tuple of `(state, event)` and will be the `input_builder` parameter on the `ManualInputConfig` passed to the dataflow. The input builder must know how to skip ahead in its input data to start at that `resume_state`. The `resume_state` parameter allows you to configure recovery should a failure interrupt a stateful operation, such as `stateful_map`.
-
-A `KafkaInputConfig` accepts four parameters: a list of brokers, a topic, a tail boolean and a starting_offset. See our API docs for `bytewax.inputs` for more on a Kafka configuration.
-
-
-As in `spawn_cluster()`, the input builder function passed to a manual input configuration should return an iterable that yields `(state, item)` tuples. If you are using a `KafkaInputConfig`, state recovery will be managed for you.
-
-### Output
-
-Output is configured similarly to input, using a configuration and the `capture` operator. Akin to the `ManualInputConfig`, the `ManualOutputConfig` requires **builder** function that is called on each worker and will handle the output for that worker. However, the output builder function should return a callback **output handler** function that can be called with each item of output produced.
-
-(ManualOutputConfig) `run_main()` collects all output into a list internally first, thus it will not support infinite, larger than memory datasets.
+[StdOutputConfig](/apidocs/bytewax.outputs#bytewax.outputs.StdOutputConfig) just prints all the output to the standard output, and it does not require any other configuration.

--- a/docs/articles/getting-started/operators.md
+++ b/docs/articles/getting-started/operators.md
@@ -8,9 +8,9 @@ If not, no worries, we'll give a quick overview of each and links to our annotat
 
 ## Using Operators
 
-You can add steps to your dataflow by calling the method with the name of the operator you'd like to use on a [`bytewax.Dataflow`](/apidocs#bytewax.Dataflow) instance.
+You can add steps to your dataflow by calling the method with the name of the operator you'd like to use on a [`bytewax.dataflow.Dataflow`](/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow) instance.
 
-There is a detailed description of every operator, its behavior, and a simple example in the API docs for [`bytewax.Dataflow`](/apidocs#bytewax.Dataflow).
+There is a detailed description of every operator, its behavior, and a simple example in the API docs for [`bytewax.dataflow.Dataflow`](/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow).
 
 ## Stateful Operators
 
@@ -20,4 +20,4 @@ In order to coordinate this state in a multiple-worker execution, all stateful o
 
 ### Stateful Operators and Recovery
 
-When a Bytewax dataflow is configured with recovery, state for operators can be periodically persisted. In the event of a or a crash or a restart, stateful operators can recover their internal state from a recovery store. For more information, see the documentation on [recovery](/getting-started/recovery/).
+When a Bytewax dataflow is configured with recovery, state for operators can be periodically persisted. In the event of a crash or a restart, stateful operators can recover their internal state from a recovery store. For more information, see the documentation on [recovery](/getting-started/recovery/).

--- a/docs/articles/getting-started/recovery.md
+++ b/docs/articles/getting-started/recovery.md
@@ -29,7 +29,7 @@ requirements:
 Your dataflow needs a few features to enable recovery on Bytewax:
 
 1. You must design your [input
-   builder](/getting-started/execution#builders) to be able to resume
+   builder](/getting-started/ins_and_outs) to be able to resume
    and replay all data from the `resume_state` onwards. Do not
    ignore this argument!
 

--- a/docs/articles/getting-started/simple-example.md
+++ b/docs/articles/getting-started/simple-example.md
@@ -26,10 +26,9 @@ from bytewax.window import SystemClockConfig, TumblingWindowConfig
 
 
 def input_builder(worker_index, worker_count, resume_state):
-    # resume_state is used for recovery, we can ignore it for now
-    resume_state = None
+    state = None # ignore recovery
     for line in open("wordcount.txt"):
-        yield resume_state, line
+        yield state, line
 
 
 def lower(line):

--- a/docs/articles/getting-started/simple-example.md
+++ b/docs/articles/getting-started/simple-example.md
@@ -206,20 +206,21 @@ Its super power is that it can repeatedly combine together items into a single, 
 
 In this case, we pass it the reducing function `add()` which will sum together the counts of words so that the final aggregator value is the total.
 
-How does reduce_window know which items to combine? Part of its requirements are that the input items from the previous step in the dataflow are `(key, value)` two-tuples, and it will make sure that all values for a given key are passed to the reducing function. Thus, if we make the word the key, we'll be able to get separate counts!
+How does `reduce_window` know which items to combine? Part of its requirements are that the input items from the previous step in the dataflow are `(key, value)` two-tuples, and it will make sure that all values for a given key are passed to the reducing function. Thus, if we make the word the key, we'll be able to get separate counts!
 
 That explains the previous map step in the dataflow with `initial_count()`.
 
-This map sets up the shape that reduce_window needs: two-tuples where the key is the word, and the value is something we can add together. In this case, since we have a copy of a word for each instance, it represents that we should add `1` to the total count, so label that here.
+This map sets up the shape that `reduce_window` needs: two-tuples where the key is the word, and the value is something we can add together. In this case, since we have a copy of a word for each instance, it represents that we should add `1` to the total count, so label that here.
 
 How does reduce_window know **when** to emit combined items? That is what `clock_config` and `window_config` are for.
 [SystemClockConfig](/apidocs/bytewax.window#bytewax.window.SystemClockConfig) is used to synchronize the flow's clock to the system one.
 [TumblingWindowConfig](/apidocs/bytewax.window#bytewax.window.TumblingWindowConfig) instructs the flow to close windows every `length` period, 5 seconds in our case.
+`reduce_window` will emit the accumulated value every 5 seconds, and once the input is completely consumed.
 
 
 ### Print out the counts
 
-The last part of our dataflow program will use the [capture operator](/apidocs#bytewax.Dataflow.capture) to mark the output of our reduction as the dataflow's final output.
+The last part of our dataflow program will use the [capture operator](/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow.capture) to mark the output of our reduction as the dataflow's final output.
 
 ```python
 flow.capture(StdOutputConfig())

--- a/docs/articles/metadata.json
+++ b/docs/articles/metadata.json
@@ -16,12 +16,12 @@
         "filename": "simple-example"
       },
       {
-        "title": "Understanding epochs",
-        "filename": "epochs"
-      },
-      {
         "title": "Execution",
         "filename": "execution"
+      },
+      {
+        "title": "Inputs and Outputs",
+        "filename": "ins_and_outs"
       },
       {
         "title": "Operators",

--- a/docs/articles/reference/changes-in-v11.md
+++ b/docs/articles/reference/changes-in-v11.md
@@ -12,9 +12,9 @@ Epochs continue to exist in Bytewax, but are now managed internally to represent
 
 ## Recoverable input
 
-Bytewax 0.11 will now allow you recover the state of the input to your dataflow.
+Bytewax 0.11 will now allow you to recover the state of the input to your dataflow.
 
-Manually constructed input functions, like those used with [ManualInputConfig](/apidocs#bytewax.inputs.ManualInputConfig), now take a third argument. In the case that your dataflow is interrupted, the third argument passed to your input function can be used to reconstruct the state of your input at the last recovery snapshot, provided you write your input logic accordingly. The `input_builder` function must return a tuple of (resume_state, datum). 
+Manually constructed input functions, like those used with [ManualInputConfig](/apidocs#bytewax.inputs.ManualInputConfig), now take a third argument. If your dataflow is interrupted, the third argument passed to your input function can be used to reconstruct the state of your input at the last recovery snapshot, provided you write your input logic accordingly. The `input_builder` function must return a tuple of (resume_state, datum). 
 
 Bytewax's built-in input handlers, like [KafkaInputConfig](/apidocs#bytewax.inputs.KafkaInputConfig) are also recoverable. `KafkaInputConfig` will store information about consumer offsets in the configured Bytewax recovery store. In the event of recovery, `KafkaInputConfig` will start reading from the offsets that were last committed to the recovery store.
 
@@ -41,3 +41,206 @@ In Bytewax 0.11, the overall Python module structure has changed, and some execu
 - `cluster_main`, `spawn_cluster`, and `run_main` have moved to `bytewax.execution`
 - `Dataflow` has moved to `bytewax.dataflow`
 - `run` and `run_cluster` have been removed
+
+## Porting the Simple example from 0.10 to 0.11
+
+This is what the `Simple example` looked like in `0.10`:
+
+```python doctest:SKIP
+import re
+
+from bytewax import Dataflow, run
+
+
+def file_input():
+    for line in open("wordcount.txt"):
+        yield 1, line
+
+
+def lower(line):
+    return line.lower()
+
+
+def tokenize(line):
+    return re.findall(r'[^\s!,.?":;0-9]+', line)
+
+
+def initial_count(word):
+    return word, 1
+    
+    
+def add(count1, count2):
+    return count1 + count2
+
+
+flow = Dataflow()
+flow.map(lower)
+flow.flat_map(tokenize)
+flow.map(initial_count)
+flow.reduce_epoch(add)
+flow.capture()
+
+
+for epoch, item in run(flow, file_input()):
+    print(item)
+```
+
+To port the example to the `0.11` version we need to make a few changes.
+
+### Imports
+Let's start with the existing imports:
+
+```python doctest:SKIP
+from bytewas import Dataflow, run
+```
+
+Becomes:
+```python doctest:SKIP
+from bytewax.dataflow import Dataflow
+from bytewax.execution import run_main
+```
+
+We moved from `run` to `run_main` as the execution API has been simplified, and we can now just use the `run_main` function to execute our dataflow.
+
+### Input
+
+The way bytewax handles input changed with `0.11`. `input` is now a proper operator on the Dataflow, and the function now takes 3 parameters: `worker_index`, `worker_count`, `resume_state`.
+This allows us to distribute the input across workers, and to handle recovery if we want to.
+We are not going to do that in this example, so the change is minimal.
+
+The input function goes from:
+
+```python doctest:SKIP
+def file_input():
+    for line in open("wordcount.txt"):
+        yield 1, line
+```
+
+to:
+
+```python doctest:SKIP
+def input_builder(worker_index, worker_count, resume_state):
+    # resume_state can be used to handle recovery, we ignore it here
+    state = None
+    for line in open("wordcount.txt"):
+        yield state, line
+```
+
+So instead of manually yielding the `epoch` in the input function, we can either ignore it (passing `None` as state), or handle the value to implement recovery (see the `recovery` chapter).
+
+Then we need to wrap the `input_builder` with our `ManualInputConfig`, give it a name ("file_input" here) and pass it to the `input` operator (rather than the `run` function):
+
+```python doctest:SKIP
+from bytewax.inputs import ManualInputConfig
+
+
+flow.input("file_input", ManualInputConfig(input_builder))
+```
+
+### Operators
+
+Most of the operators are the same, but there is a notable change in the flow: where we used `reduce_epoch` we are now using `reduce_window`.
+Since the epochs concept is now considered an internal feature in bytewax, we need to define a way to let the `reduce` operator know when to close a specific window.
+Previously this was done everytime the `epoch` changed, while now it can be configured with a time window.
+We need two config objects to do this:
+- `clock_config`
+- `window_config`
+
+The `clock_config` is used to tell the window-based operators what reference clock to use, here we use the `SystemClockConfig` that just uses the system's clock.
+The `window_config` is used to define the time window we want to use. Here we'll use the `TumblingWindowConfig` that allows us to have tumbling windows defined by a length (`timedelta`), and we configure it to have windows of 5 seconds each.
+
+So the old `reduce_epoch`:
+```python doctest:SKIP
+flow.reduce_epoch(add)
+```
+
+becomes `reduce_window`:
+
+```python doctest:SKIP
+from bytewax.window import SystemClockConfig, TumblingWindowConfig
+
+
+clock_config = SystemClockConfig()
+window_config = TumblingWindowConfig(length=timedelta(seconds=5))
+flow.reduce_window("sum", clock_config, window_config, add)
+```
+
+### Output and execution
+
+Similarly to the `input`, the output configuration is now part of an operator, `capture`.
+Rather than collecting the output in a python iterator and then manually printing it, we can now configure the `capture` operator to print to standard output.
+
+Since all the input and output handling is now defined inside the Dataflow, we don't need to pass this information to the execution method.
+
+So we move from this:
+
+```python doctest:SKIP
+flow.capture()
+
+for epoch, item in run(flow, file_input()):
+    print(item)
+```
+
+To this:
+
+```python doctest:SKIP
+from bytewax.outputs import StdOutputConfig
+
+
+flow.capture(StdOutputConfig())
+
+run_main(flow)
+```
+
+### Complete code
+The complete code for the new simple example now looks like this:
+
+```python doctest:SKIP
+import operator
+import re
+
+from datetime import timedelta, datetime
+
+from bytewax.dataflow import Dataflow
+from bytewax.inputs import ManualInputConfig
+from bytewax.outputs import StdOutputConfig
+from bytewax.execution import run_main
+from bytewax.window import SystemClockConfig, TumblingWindowConfig
+
+
+def input_builder(worker_index, worker_count, resume_state):
+    # resume_state is used for recovery, we can ignore it for now
+    resume_state = None
+    for line in open("wordcount.txt"):
+        yield resume_state, line
+
+
+def lower(line):
+    return line.lower()
+
+
+def tokenize(line):
+    return re.findall(r'[^\s!,.?":;0-9]+', line)
+
+
+def initial_count(word):
+    return word, 1
+    
+    
+def add(count1, count2):
+    return count1 + count2
+
+
+clock_config = SystemClockConfig()
+window_config = TumblingWindowConfig(length=timedelta(seconds=5))
+
+flow = Dataflow()
+flow.input("input", ManualInputConfig(input_builder))
+flow.map(lower)
+flow.flat_map(tokenize)
+flow.map(initial_count)
+flow.reduce_window("sum", clock_config, window_config, add)
+flow.capture(StdOutputConfig())
+
+run_main(flow)
+```

--- a/docs/articles/reference/changes-in-v11.md
+++ b/docs/articles/reference/changes-in-v11.md
@@ -120,15 +120,14 @@ to:
 
 ```python doctest:SKIP
 def input_builder(worker_index, worker_count, resume_state):
-    # resume_state can be used to handle recovery, we ignore it here
-    state = None
+    state = None # ignore recovery
     for line in open("wordcount.txt"):
         yield state, line
 ```
 
-So instead of manually yielding the `epoch` in the input function, we can either ignore it (passing `None` as state), or handle the value to implement recovery (see the `recovery` chapter).
+So instead of manually yielding the `epoch` in the input function, we can either ignore it (passing `None` as state), or handle the value to implement recovery (see the [recovery chapter](/getting-started/recovery)).
 
-Then we need to wrap the `input_builder` with our `ManualInputConfig`, give it a name ("file_input" here) and pass it to the `input` operator (rather than the `run` function):
+Then we need to wrap the `input_builder` with `ManualInputConfig`, give it a name ("file_input" here) and pass it to the `input` operator (rather than the `run` function):
 
 ```python doctest:SKIP
 from bytewax.inputs import ManualInputConfig
@@ -140,7 +139,7 @@ flow.input("file_input", ManualInputConfig(input_builder))
 ### Operators
 
 Most of the operators are the same, but there is a notable change in the flow: where we used `reduce_epoch` we are now using `reduce_window`.
-Since the epochs concept is now considered an internal feature in bytewax, we need to define a way to let the `reduce` operator know when to close a specific window.
+Since the epochs concept is now considered an internal detail in bytewax, we need to define a way to let the `reduce` operator know when to close a specific window.
 Previously this was done everytime the `epoch` changed, while now it can be configured with a time window.
 We need two config objects to do this:
 - `clock_config`
@@ -209,10 +208,9 @@ from bytewax.window import SystemClockConfig, TumblingWindowConfig
 
 
 def input_builder(worker_index, worker_count, resume_state):
-    # resume_state is used for recovery, we can ignore it for now
-    resume_state = None
+    state = None # ignore recovery
     for line in open("wordcount.txt"):
-        yield resume_state, line
+        yield state, line
 
 
 def lower(line):

--- a/src/inputs/mod.rs
+++ b/src/inputs/mod.rs
@@ -109,7 +109,7 @@ impl InputConfig {
 ///   Config object. Pass this as the `input_config` argument to the
 ///   `bytewax.dataflow.Dataflow.input`.
 #[pyclass(module = "bytewax.inputs", extends = InputConfig)]
-#[pyo3(text_signature = "(input_builder)")]
+#[pyo3(text_signature = "(input_builder)", subclass)]
 pub(crate) struct ManualInputConfig {
     #[pyo3(get)]
     input_builder: TdPyCallable,


### PR DESCRIPTION
I was reading the newly deployed version of the documentation for `0.11`, and I noticed some things needed fixing:
- The simple-example chapter links to `Understanding epochs` which is a 404. The epoch chapter is still referenced in `metadata.json`. (I now see that Konrad already fixed that in #111 so maybe merge that first)
- The input and output sections are within the execution chapters. I moved them in their own chapter since there is more to say about them than there was on 0.10, and their definition is now passed to the flow itself rather than to the execution method.
- Most of the links were broken since we moved stuff in the python library, I should have fixed all of them
- in the `simple-example` page, we use `window_config` and `clock_config` without ever mentioning what they are in the long text form. I added a brief explanation there.
- I noticed that `ManualInputConfig` is still a function rather than a class (like `ManualOutputConfig`), so I refactored that one too.
- While fixing the documentation for the distribute function in `bytewax.inputs` and trying the code in the python repl, I noticed the same issue we had with the jupyter notebook: functions don't get the whole scope of the session, but just what's written inside. I think we should take that into account and maybe discourage people from trying flows in the repl since the behavior is different. I refactored the example in the docstring to look like a python file rather than a python repl session, to avoid confusion.
- I added a section to the `changes-in-v11.md` outlining the process of porting the `simple example` from `0.10` to `0.11`

Let me know what you think, and please review the copy as I might have introduced more typos or badly worded sentences in the new paragraphs I wrote.
