### PR TITLE
Update KafkaInput to prevent listening to non-existent topics

### DIFF
--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -1,6 +1,6 @@
 """Dataflow input sources.
 
-Bytewax provides pre-packaged output configuration options for common
+Bytewax provides pre-packaged input configuration options for common
 sources you might want to read dataflow input from.
 
 Use

--- a/src/inputs/kafka_input.rs
+++ b/src/inputs/kafka_input.rs
@@ -127,12 +127,19 @@ fn get_kafka_partition_count(brokers: &[String], topic: &str) -> i32 {
 
     let timeout = Some(Duration::from_secs(5));
 
+    println!("Attempting to fetch metadata from {}", topic);
     let metadata = consumer
         .fetch_metadata(Some(topic), timeout)
         .map_err(|e| e.to_string())
         .expect("Unable to fetch topic metadata for {topic}");
-    let topic = &metadata.topics()[0];
-    topic
+
+    let user_topic = &metadata.topics()[0];
+    
+    if user_topic.partitions().len() == 0 {
+        panic!("Topic does not exist, please create first");
+    }
+
+    user_topic
         .partitions()
         .len()
         .try_into()

--- a/src/inputs/kafka_input.rs
+++ b/src/inputs/kafka_input.rs
@@ -8,7 +8,7 @@ use pyo3::types::PyBytes;
 
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::base_consumer::BaseConsumer;
-use rdkafka::consumer::{Consumer, DefaultConsumerContext};
+use rdkafka::consumer::{Consumer};
 use rdkafka::error::KafkaError;
 use rdkafka::message::Message;
 use rdkafka::{Offset, TopicPartitionList};
@@ -119,15 +119,11 @@ impl KafkaInputConfig {
 // Using an rdkafka::admin::AdminClient did not always return partition counts
 // for a topic, so create a BaseConsumer to fetch the metadata for a topic instead.
 // Inspired by https://github.com/fede1024/rust-rdkafka/blob/5d23e82a675d9df1bf343aedcaa35be864787dab/tests/test_admin.rs#L33
-fn get_kafka_partition_count(brokers: &[String], topic: &str) -> i32 {
-    let consumer: BaseConsumer<DefaultConsumerContext> = ClientConfig::new()
-        .set("bootstrap.servers", brokers.join(","))
-        .create()
-        .expect("creating consumer failed");
-
+fn get_kafka_partition_count(consumer: &BaseConsumer, topic: &str) -> i32 {
     let timeout = Some(Duration::from_secs(5));
 
     log::debug!("Attempting to fetch metadata from {}", topic);
+    
     let metadata = consumer
         .fetch_metadata(Some(topic), timeout)
         .map_err(|e| e.to_string())
@@ -201,9 +197,9 @@ impl KafkaInput {
             .create()
             .expect("Error building input Kafka consumer");
 
-        let partition_count = get_kafka_partition_count(brokers, topic);
+        let partition_count = get_kafka_partition_count(&consumer, topic);
         if partition_count == 0 {
-            panic!("Topic does not exist, please create first");
+            panic!("Topic {} does not exist, please create first", topic);
         }
         let mut partitions = TopicPartitionList::new();
         for partition in distribute(0..partition_count, worker_index, worker_count) {

--- a/src/inputs/kafka_input.rs
+++ b/src/inputs/kafka_input.rs
@@ -127,18 +127,13 @@ fn get_kafka_partition_count(brokers: &[String], topic: &str) -> i32 {
 
     let timeout = Some(Duration::from_secs(5));
 
-    println!("Attempting to fetch metadata from {}", topic);
+    log::debug!("Attempting to fetch metadata from {}", topic);
     let metadata = consumer
         .fetch_metadata(Some(topic), timeout)
         .map_err(|e| e.to_string())
         .expect("Unable to fetch topic metadata for {topic}");
 
     let user_topic = &metadata.topics()[0];
-    
-    if user_topic.partitions().len() == 0 {
-        panic!("Topic does not exist, please create first");
-    }
-
     user_topic
         .partitions()
         .len()
@@ -207,6 +202,9 @@ impl KafkaInput {
             .expect("Error building input Kafka consumer");
 
         let partition_count = get_kafka_partition_count(brokers, topic);
+        if partition_count == 0 {
+            panic!("Topic does not exist, please create first");
+        }
         let mut partitions = TopicPartitionList::new();
         for partition in distribute(0..partition_count, worker_index, worker_count) {
             let partition = KafkaPartition(partition);


### PR DESCRIPTION
Current method of getting partitions from metadata will return `Metadata` for a topic regardless of whether or not the topic exists and the partition value will be 0. rdkafka does not ever error if the topic exists so the bytewax worker0 ends up listening to a non-existent topic. 

This fix will just check if there are 0 partitions and then panic and let the user know that the topic doesn't exist.

This will fix #116 