### PR TITLE
Adding a CD step to upgrade pip

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -105,12 +105,16 @@ jobs:
           hosts: localhost
           tasks:
           - name: Loop
-            shell: "pip install bytewax=={{ bytewax_version }}"
+            shell: "pip install bytewax=={{ bytewax_version }} -v"
             register: pip_result
             retries: 60
             until: pip_result.rc == 0
             delay: 10
         EOF
+    - name: Upgrade pip version
+      run: |
+        pip --version
+        pip install --upgrade pip
     - name: Check PyPI index before building docker images
       run: |
         ansible-playbook ./pip_task.yaml -e bytewax_version=${{ needs.release.outputs.bytewax-version }} -vvv


### PR DESCRIPTION
This PR adds a step to CD workflow to upgrade `pip` before trying to install Bytewax latest version.

That step should resolve the pip install missing version issue that we have randomly.