### PR TITLE
Event time processing

### DIFF
--- a/examples/event_time_processing.py
+++ b/examples/event_time_processing.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+###################
+# ---IMPORTANT--- #
+###################
+# To run this example you'll need a Kafka (or redpanda) cluster.
+# Create a topic with using the `create_temperature_events` function
+# in examples/utils/topics_helper.py:
+#
+# ```python
+# from utils.topics_helper import create_temperature_events
+# create_temperature_events("sensors")
+# ```
+#
+# The events generated in the stream will be a json string with 3 keys:
+# - type: a string representing the type of reading (eg: "temp")
+# - value: a float representing the value of the reading
+# - time: A string representing the UTC datetime the event was generated,
+#         in isoformat (eg: datetime.now(timezone.utc).isoformat() )
+import json
+
+from datetime import timedelta, datetime, timezone
+
+from bytewax.dataflow import Dataflow
+from bytewax.execution import run_main
+from bytewax.inputs import KafkaInputConfig
+from bytewax.window import TumblingWindowConfig, EventClockConfig
+from bytewax.outputs import StdOutputConfig
+
+
+# Define the dataflow object and kafka input.
+flow = Dataflow()
+flow.input(
+    "input",
+    KafkaInputConfig(
+        brokers=["localhost:9092"], topic="sensors", starting_offset="beginning"
+    ),
+)
+
+
+# We expect a json string that represents a reading from a sensor.
+def parse_value(key__data):
+    _, data = key__data
+    return json.loads(data)
+
+
+flow.map(parse_value)
+
+
+# Divide the readings by sensor type, so that we only
+# aggregate readings of the same type.
+def extract_sensor_type(event):
+    return event["type"], event
+
+
+flow.map(extract_sensor_type)
+
+
+# Here is where we use the event time processing, with
+# the fold_window operator.
+# The `EventClockConfig` allows us to advance our internal clock
+# based on the time received in each event.
+
+# This is the accumulator function, and outputs a list of 2-tuples,
+# containing the event's "value" and it's "time" (used later to print info)
+def acc_values(acc, event):
+    acc.append((event["value"], event["time"]))
+    return acc
+
+
+# This function instructs the event clock on how to retrieve the
+# event's datetime from the input.
+# Note that the datetime MUST be UTC. If the datetime is using a different
+# representation, we would have to convert it here.
+def get_event_time(event):
+    return datetime.fromisoformat(event["time"])
+
+
+# Configure the `fold_window` operator to use the event time.
+cc = EventClockConfig(get_event_time, wait_for_system_duration=timedelta(seconds=10))
+
+# And a 5 seconds tumbling window, that starts at the beginning of the hour
+start_at = datetime.now(timezone.utc)
+start_at = start_at - timedelta(
+    minutes=start_at.minute, seconds=start_at.second, microseconds=start_at.microsecond
+)
+wc = TumblingWindowConfig(start_at=start_at, length=timedelta(seconds=5))
+flow.fold_window("running_average", cc, wc, list, acc_values)
+
+
+# Calculate the average of the values for each window, and
+# format the data to a string
+def format(event):
+    key, data = event
+    values = [x[0] for x in data]
+    dates = [datetime.fromisoformat(x[1]) for x in data]
+    return (
+        f"Average {key}: {sum(values) / len(values):.2f}\t"
+        f"Num events: {len(values)}\t"
+        f"From {(min(dates) - start_at).total_seconds():.2f}s\t"
+        f"to {(max(dates) - start_at).total_seconds():.2f}s"
+    )
+
+
+flow.map(format)
+
+
+flow.capture(StdOutputConfig())
+run_main(flow)

--- a/examples/utils/topics_helper.py
+++ b/examples/utils/topics_helper.py
@@ -1,10 +1,14 @@
 import json
-from time import sleep
-
 import fake_events
 import pandas as pd
-from kafka import KafkaAdminClient, KafkaConsumer, KafkaProducer
+
+from datetime import datetime, timezone, timedelta
+from random import random
+from time import sleep
+
+from kafka import KafkaAdminClient, KafkaProducer
 from kafka.admin import NewTopic
+
 
 def create_local_kafka_producer(topic_name, servers=["localhost:9092"]):
     topic_name = topic_name
@@ -19,6 +23,18 @@ def create_local_kafka_producer(topic_name, servers=["localhost:9092"]):
         print(f"Topic {topic_name} is already created")
 
     return producer
+
+
+def create_temperature_events(topic_name, servers=["localhost:9092"]):
+    producer = create_local_kafka_producer(topic_name)
+    for i in range(10):
+        dt = datetime.now(timezone.utc)
+        if random() > 0.8:
+            dt = dt - timedelta(minutes=random())
+        event = {"type": "temp", "value": i, "time": dt.isoformat()}
+        producer.send(topic_name, json.dumps(event).encode("utf-8"))
+        sleep(random())
+
 
 def create_fake_events(topic_name, servers=["localhost:9092"]):
     producer = create_local_kafka_producer(topic_name)
@@ -35,17 +51,21 @@ def create_anomaly_stream(topic_name, servers=["localhost:9092"]):
     for row in df[["index", "timestamp", "value", "instance"]].to_dict("records"):
         producer.send(topic_name, json.dumps(row).encode())
 
+
 def create_driver_stream(topic_name, servers=["localhost:9092"]):
     producer = create_local_kafka_producer(topic_name)
 
     # Sort values to support tumbling_epoch for input building
-    df = pd.read_parquet("examples/sample_data/driver_stats.parquet").sort_values(by="event_timestamp")
+    df = pd.read_parquet("examples/sample_data/driver_stats.parquet").sort_values(
+        by="event_timestamp"
+    )
     for row in df[
         ["driver_id", "event_timestamp", "conv_rate", "acc_rate", "created"]
     ].to_dict("records"):
         row["event_timestamp"] = row["event_timestamp"].strftime("%Y-%m-%d %H:%M:%S")
         row["created"] = row["created"].strftime("%Y-%m-%d %H:%M:%S")
         producer.send(topic_name, json.dumps(row).encode())
+
 
 if __name__ == "__main__":
     create_anomaly_stream("ec2_metrics")

--- a/pysrc/bytewax/window.py
+++ b/pysrc/bytewax/window.py
@@ -69,6 +69,7 @@ adjust epochs.
 
 from .bytewax import (  # noqa: F401
     ClockConfig,
+    EventClockConfig,
     SystemClockConfig,
     TestingClockConfig,
     TumblingWindowConfig,

--- a/pytests/test_event_time.py
+++ b/pytests/test_event_time.py
@@ -27,17 +27,17 @@ def test_event_time_processing():
         # This too should be processed in the first window
         clock.now = start_at + timedelta(seconds=6)
         yield None, {"type": "temp", "time": start_at + s(2), "value": 2}
-        # This should be processed in the second window
-        clock.now = start_at + timedelta(seconds=10.1)
-        yield None, {"type": "temp", "time": start_at + s(7), "value": 200}
-        # This should be processed in the third window
-        clock.now = start_at + timedelta(seconds=11.1)
-        yield None, {"type": "temp", "time": start_at + s(12), "value": 17}
         # This should be dropped, because its event_time is before
         # the latest event time, and it arrives `late` seconds after
         # the closing of the window + the delay of the latest received item.
         clock.now = start_at + timedelta(seconds=19.1)
         yield None, {"type": "temp", "time": start_at + s(1), "value": 200}
+        # This should be processed in the second window
+        clock.now += timedelta(seconds=1)
+        yield None, {"type": "temp", "time": start_at + s(7), "value": 200}
+        # This should be processed in the third window
+        clock.now += timedelta(seconds=1)
+        yield None, {"type": "temp", "time": start_at + s(12), "value": 17}
 
     def extract_sensor_type(event):
         return event["type"], event

--- a/pytests/test_event_time.py
+++ b/pytests/test_event_time.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 from bytewax.dataflow import Dataflow
 from bytewax.execution import run_main
 from bytewax.inputs import ManualInputConfig
-from bytewax.window import TumblingWindowConfig, EventClockConfig, TestingClockConfig
+from bytewax.window import TumblingWindowConfig, EventClockConfig
 from bytewax.outputs import TestingOutputConfig
 from bytewax.testing import TestingClock
 
@@ -33,13 +33,9 @@ def test_event_time_processing():
         # This should be processed in the third window
         clock.now = start_at + timedelta(seconds=11.1)
         yield None, {"type": "temp", "time": start_at + s(12), "value": 17}
-        # This should be dropped, because its received "late".
-        # Calling "x" the time between latest_event_time (start_at + 2s) and
-        # the time we received the event at (start_at + 4s), events for the
-        # first window are late after:
-        # late + windows_length + x = 19 seconds
-        # ^      ^                ^
-        # 5s     10s              4s
+        # This should be dropped, because its event_time is before
+        # the latest event time, and it arrives `late` seconds after
+        # the closing of the window + the delay of the latest received item.
         clock.now = start_at + timedelta(seconds=19.1)
         yield None, {"type": "temp", "time": start_at + s(1), "value": 200}
 

--- a/pytests/test_event_time.py
+++ b/pytests/test_event_time.py
@@ -48,7 +48,7 @@ def test_event_time_processing():
 
     cc = EventClockConfig(
         lambda event: event["time"],
-        late_after_system_duration=late,
+        wait_for_system_duration=late,
         system_clock=clock
     )
     wc = TumblingWindowConfig(start_at=start_at, length=window_length)

--- a/pytests/test_event_time.py
+++ b/pytests/test_event_time.py
@@ -1,0 +1,77 @@
+from datetime import datetime, timedelta
+
+from bytewax.dataflow import Dataflow
+from bytewax.execution import run_main
+from bytewax.inputs import ManualInputConfig
+from bytewax.window import TumblingWindowConfig, EventClockConfig, TestingClockConfig
+from bytewax.outputs import TestingOutputConfig
+
+
+def test_event_time_processing():
+    """
+    Test used to validate the EventClockConfig workings.
+    """
+    start_at = datetime.now()
+    late = timedelta(seconds=10)
+    window_length = timedelta(seconds=5)
+
+    # Utility functions to generate "temp" events
+    def temp(val, seconds):
+        time = start_at + timedelta(seconds=seconds)
+        return None, {"type": "temp", "time": time, "value": val}
+
+    # Utility functions to generate wait events (used for advancing the clock)
+    def wait():
+        return None, {"type": "temp", "time": start_at}
+
+    def input_builder(worker_index, worker_count, state):
+        # Each yield advances the clock by 1 second
+        # This should be processed in the first window
+        yield temp(1, 1)
+        # This too should be processed in the first window
+        yield temp(2, 2)
+        # Wait 10 seconds
+        for _ in range(10):
+            yield wait()
+        # This should be dropped, because its received is after start_at + late
+        yield temp(200, 1)
+        # This should be processed in the second window
+        yield temp(200, 7)
+        # This should be processed in the third window
+        yield temp(17, 12)
+
+    def extract_sensor_type(event):
+        return event["type"], event
+
+    def acc_values(acc, event):
+        if "value" in event:
+            acc.append(event["value"])
+        return acc
+
+    cc = EventClockConfig(
+        lambda event: event["time"],
+        late_after_system_duration=late,
+        system_clock_config=TestingClockConfig(start_at=start_at, item_incr=timedelta(seconds=1))
+    )
+    wc = TumblingWindowConfig(start_at=start_at, length=window_length)
+
+    flow = Dataflow()
+    flow.input("input", ManualInputConfig(input_builder))
+
+    flow.map(extract_sensor_type)
+    flow.fold_window("running_average", cc, wc, list, acc_values)
+    flow.map(lambda x: {f"{x[0]}_avg": sum(x[1]) / len(x[1])})
+
+    out = []
+    flow.capture(TestingOutputConfig(out))
+    run_main(flow)
+
+    expected = [
+        {"temp_avg": 1.5},
+        {"temp_avg": 200},
+        {"temp_avg": 17},
+    ]
+    assert len(out) == 3
+    assert expected[0] in out
+    assert expected[1] in out
+    assert expected[2] in out

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -286,7 +286,7 @@ fn build_production_dataflow<A: Allocate>(
                         .remove(&step_id)
                         .unwrap_or_default();
 
-                    let clock_builder = build_clock_builder(clock_config.as_ref(py))?;
+                    let clock_builder = build_clock_builder(py, clock_config)?;
                     let windower_builder = build_windower_builder(py, window_config)?;
 
                     let (downstream, update_stream) =
@@ -345,7 +345,7 @@ fn build_production_dataflow<A: Allocate>(
                         .remove(&step_id)
                         .unwrap_or_default();
 
-                    let clock_builder = build_clock_builder(clock_config.as_ref(py))?;
+                    let clock_builder = build_clock_builder(py, clock_config)?;
                     let windower_builder = build_windower_builder(py, window_config)?;
 
                     let (downstream, update_stream) =

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -286,7 +286,7 @@ fn build_production_dataflow<A: Allocate>(
                         .remove(&step_id)
                         .unwrap_or_default();
 
-                    let clock_builder = build_clock_builder(py, clock_config)?;
+                    let clock_builder = build_clock_builder(clock_config.as_ref(py))?;
                     let windower_builder = build_windower_builder(py, window_config)?;
 
                     let (downstream, update_stream) =
@@ -345,7 +345,7 @@ fn build_production_dataflow<A: Allocate>(
                         .remove(&step_id)
                         .unwrap_or_default();
 
-                    let clock_builder = build_clock_builder(py, clock_config)?;
+                    let clock_builder = build_clock_builder(clock_config.as_ref(py))?;
                     let windower_builder = build_windower_builder(py, window_config)?;
 
                     let (downstream, update_stream) =

--- a/src/pyo3_extensions/mod.rs
+++ b/src/pyo3_extensions/mod.rs
@@ -38,6 +38,12 @@ impl Deref for TdPyAny {
     }
 }
 
+impl ToPyObject for TdPyAny {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        self.0.to_object(py)
+    }
+}
+
 impl IntoPy<PyObject> for TdPyAny {
     fn into_py(self, _py: Python) -> Py<PyAny> {
         self.0

--- a/src/window/event_time_clock.rs
+++ b/src/window/event_time_clock.rs
@@ -1,0 +1,277 @@
+use std::task::Poll;
+
+use chrono::{Utc, DateTime};
+use pyo3::{exceptions::PyValueError, pyclass, pymethods, PyAny, PyResult, Python, ToPyObject};
+
+use crate::{
+    pyo3_extensions::{TdPyAny, TdPyCallable},
+    recovery::StateBytes,
+    window::ClockConfig,
+};
+
+use super::{
+    system_clock::SystemClock,
+    testing_clock::{TestingClock, TestingClockConfig},
+    Builder, Clock, ClockBuilder,
+};
+
+/// Use datetimes from events as clock.
+///
+/// If the dataflow has no more input, all windows are closed.
+///
+/// The watermark is the system time since the last element
+/// plus the value of `late`. It is updated every time an event
+/// with a newer datetime is processed.
+///
+/// Args:
+///   getter: Python function to get a datetime from an event.
+///   late_after_system_duration: How much (system) time to wait before considering an event late.
+///   system_clock_config: TODO
+///
+/// Returns:
+///   Config object. Pass this as the `clock_config` parameter to your
+///   windowing operator.
+#[pyclass(module="bytewax.window", extends=ClockConfig)]
+#[pyo3(text_signature = "(getter, late_after_system_duration, system_clock_config)")]
+#[derive(Clone)]
+pub(crate) struct EventClockConfig {
+    #[pyo3(get)]
+    pub(crate) dt_getter: TdPyCallable,
+    #[pyo3(get)]
+    pub(crate) late_after_system_duration: chrono::Duration,
+    #[pyo3(get)]
+    pub(crate) system_clock_config: Option<TestingClockConfig>,
+}
+
+impl ClockBuilder<TdPyAny> for EventClockConfig {
+    fn builder(self) -> Builder<TdPyAny> {
+        Box::new(move |resume_state_bytes: Option<StateBytes>| {
+            let (latest_event_time, system_time_of_last_event, watermark) = resume_state_bytes
+                .map(StateBytes::de)
+                .unwrap_or_else(|| (None, None, Utc::now()));
+
+            Box::new(EventClock::new(
+                self.dt_getter.clone(),
+                self.late_after_system_duration,
+                system_time_of_last_event,
+                latest_event_time,
+                watermark,
+                self.system_clock_config
+                    .map(InternalClock::test)
+                    .unwrap_or_else(InternalClock::system),
+            ))
+        })
+    }
+}
+
+#[pymethods]
+impl EventClockConfig {
+    #[new]
+    #[args(dt_getter, late, test)]
+    fn new(
+        dt_getter: TdPyCallable,
+        late_after_system_duration: chrono::Duration,
+        system_clock_config: Option<TestingClockConfig>,
+    ) -> (Self, ClockConfig) {
+        (
+            Self {
+                dt_getter,
+                late_after_system_duration,
+                system_clock_config,
+            },
+            ClockConfig {},
+        )
+    }
+
+    /// Pickle as a tuple.
+    fn __getstate__(
+        &self,
+    ) -> (
+        &str,
+        TdPyCallable,
+        chrono::Duration,
+        Option<TestingClockConfig>,
+    ) {
+        (
+            "EventClockConfig",
+            self.dt_getter.clone(),
+            self.late_after_system_duration,
+            self.system_clock_config,
+        )
+    }
+
+    /// Egregious hack see [`SqliteRecoveryConfig::__getnewargs__`].
+    fn __getnewargs__(&self) -> (TdPyCallable, chrono::Duration, Option<TestingClockConfig>) {
+        (
+            pyo3::Python::with_gil(TdPyCallable::pickle_new),
+            chrono::Duration::zero(),
+            None,
+        )
+    }
+
+    /// Unpickle from tuple of arguments.
+    fn __setstate__(&mut self, state: &PyAny) -> PyResult<()> {
+        if let Ok(("EventClockConfig", dt_getter, late, test)) = state.extract() {
+            self.dt_getter = dt_getter;
+            self.late_after_system_duration = late;
+            self.system_clock_config = test;
+            Ok(())
+        } else {
+            Err(PyValueError::new_err(format!(
+                "bad pickle contents for EventClockConfig: {state:?}"
+            )))
+        }
+    }
+}
+
+enum InternalClock {
+    Testing(TestingClock),
+    System(SystemClock),
+}
+
+impl InternalClock {
+    pub(crate) fn test(config: TestingClockConfig) -> Self {
+        Self::Testing(TestingClock::new(config.item_incr, config.start_at))
+    }
+
+    pub(crate) fn system() -> Self {
+        Self::System(SystemClock::new())
+    }
+
+    pub(crate) fn time(&mut self) -> DateTime<Utc> {
+        // Since this should only be SystemClock or TestingClock, the value
+        // we pass to `time_for` is not used, and we can just pass ().
+        match self {
+            Self::Testing(clock) => clock.time_for(&()),
+            Self::System(clock) => clock.time_for(&()),
+        }
+    }
+}
+
+pub(crate) struct EventClock {
+    dt_getter: TdPyCallable,
+    late: chrono::Duration,
+    clock: InternalClock,
+    // State
+    latest_event_time: Option<DateTime<Utc>>,
+    system_time_of_last_event: Option<DateTime<Utc>>,
+    watermark: DateTime<Utc>,
+}
+
+impl EventClock {
+    fn new(
+        dt_getter: TdPyCallable,
+        late: chrono::Duration,
+        latest_event_time: Option<DateTime<Utc>>,
+        system_time_of_last_event: Option<DateTime<Utc>>,
+        watermark: DateTime<Utc>,
+        clock: InternalClock,
+    ) -> Self {
+        Self {
+            dt_getter,
+            late,
+            latest_event_time,
+            system_time_of_last_event,
+            watermark,
+            clock,
+        }
+    }
+
+    fn get_event_time(&self, event: &TdPyAny) -> DateTime<Utc> {
+        Python::with_gil(|py| {
+            self.dt_getter
+                // Call the event time getter function with the event as parameter
+                .call1(py, (event.to_object(py),))
+                .unwrap()
+                // Convert to DateTime<Utc>
+                .extract(py)
+                .unwrap()
+        })
+    }
+
+    fn advance_watermark_by_event_time(&mut self, event_time: DateTime<Utc>) {
+        // Get the latest_event_time:
+        // max between self.latest_event_time and event_time
+        // if self.latest_event_time is some, otherwise just event_time.
+        let latest_event_time = self
+            .latest_event_time
+            .map(|latest_event_time| latest_event_time.max(event_time))
+            .unwrap_or(event_time);
+        // Assign it to self.latest_event_time
+        self.latest_event_time = Some(latest_event_time);
+
+        // Get current clock's time
+        let now = self.clock.time();
+        // Get watermark
+        let watermark = now
+            .checked_add_signed(now - latest_event_time)
+            // Panic if the watermark overflowed
+            .expect("watermark in date range (overflowed)")
+            .checked_sub_signed(self.late)
+            // Panic if the watermark underflowed
+            .expect("watermark in date range (underflowed)");
+        // But only assign it to self.watermark if it's after the current
+        // one, since it can be advanced by system time too.
+        self.watermark = watermark.max(self.watermark);
+
+        // Also update self.system_time_of_last_event
+        self.system_time_of_last_event = Some(now);
+    }
+
+    fn advance_watermark_by_system_time(&mut self) {
+        let now = self.clock.time();
+        let elapsed = now - self.system_time_of_last_event.unwrap_or(self.watermark);
+        self.watermark = self
+            .watermark
+            .checked_add_signed(elapsed)
+            .expect("watermark in date range (overflowed)");
+    }
+}
+
+impl Clock<TdPyAny> for EventClock {
+    fn watermark(&mut self, next_value: &Poll<Option<TdPyAny>>) -> DateTime<Utc> {
+        match next_value {
+            // If there will be no more values, close out all windows.
+            Poll::Ready(None) => DateTime::<Utc>::MAX_UTC,
+            // If we received an event, set the new watermark and return it
+            Poll::Ready(Some(event)) => {
+                self.advance_watermark_by_event_time(self.get_event_time(event));
+                self.watermark
+            }
+            // Advance the watermark by system time since
+            // system_time_of_last_event, then return it
+            _ => {
+                self.advance_watermark_by_system_time();
+                self.watermark
+            }
+        }
+    }
+
+    fn time_for(&mut self, event: &TdPyAny) -> DateTime<Utc> {
+        self.get_event_time(event)
+    }
+
+    fn snapshot(&self) -> StateBytes {
+        // Manually implement snapshotting here, because we'd have to
+        // serialize the state two times if we used Clock::snapshot:
+        // StateBytes::ser(&(
+        //     self.latest_event_time,
+        //     self.watermark,
+        //     // This would already be serialized
+        //     clock.snapshot()
+        // ))
+        match &self.clock {
+            InternalClock::System(_) => StateBytes::ser(&(
+                self.latest_event_time,
+                self.system_time_of_last_event,
+                self.watermark,
+            )),
+            InternalClock::Testing(clock) => StateBytes::ser(&(
+                self.latest_event_time,
+                self.system_time_of_last_event,
+                self.watermark,
+                clock.current_time(),
+            )),
+        }
+    }
+}

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -404,7 +404,6 @@ where
             let item_time = self.clock.time_for(&value);
 
             for window_result in self.windower.insert(&watermark, item_time) {
-                println!("{:?}", window_result);
                 let value = value.clone();
                 match window_result {
                     Err(InsertError::Late(_window_key)) => {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -402,6 +402,7 @@ where
             let item_time = self.clock.time_for(&value);
 
             for window_result in self.windower.insert(&watermark, item_time) {
+                println!("{:?}", window_result);
                 let value = value.clone();
                 match window_result {
                     Err(InsertError::Late(_window_key)) => {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -108,8 +108,10 @@ pub(crate) trait ClockBuilder<V> {
 }
 
 pub(crate) fn build_clock_builder(
-    clock_config: &PyCell<ClockConfig>,
+    py: Python,
+    clock_config: Py<ClockConfig>,
 ) -> StringResult<Builder<TdPyAny>> {
+    let clock_config = clock_config.as_ref(py);
     // System clock
     if let Ok(conf) = clock_config.extract::<SystemClockConfig>() {
         Ok(conf.builder())

--- a/src/window/system_clock.rs
+++ b/src/window/system_clock.rs
@@ -18,7 +18,7 @@ use super::{Clock, ClockBuilder, ClockConfig, Builder};
 ///   Config object. Pass this as the `clock_config` parameter to
 ///   your windowing operator.
 #[pyclass(module="bytewax.window", extends=ClockConfig)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(crate) struct SystemClockConfig {}
 
 impl<V> ClockBuilder<V> for SystemClockConfig {

--- a/src/window/system_clock.rs
+++ b/src/window/system_clock.rs
@@ -6,7 +6,7 @@ use pyo3::{exceptions::PyValueError, PyResult};
 
 use crate::recovery::StateBytes;
 
-use super::{Clock, ClockConfig};
+use super::{Clock, ClockBuilder, ClockConfig, Builder};
 
 /// Use the system time inside the windowing operator to determine
 /// times.
@@ -18,7 +18,14 @@ use super::{Clock, ClockConfig};
 ///   Config object. Pass this as the `clock_config` parameter to
 ///   your windowing operator.
 #[pyclass(module="bytewax.window", extends=ClockConfig)]
+#[derive(Clone, Copy)]
 pub(crate) struct SystemClockConfig {}
+
+impl<V> ClockBuilder<V> for SystemClockConfig {
+    fn builder(self) -> Builder<V> {
+        Box::new(move |_resume_state_bytes| Box::new(SystemClock::new()))
+    }
+}
 
 #[pymethods]
 impl SystemClockConfig {
@@ -49,8 +56,8 @@ impl SystemClockConfig {
 pub(crate) struct SystemClock {}
 
 impl SystemClock {
-    pub(crate) fn builder<V>() -> impl Fn(Option<StateBytes>) -> Box<dyn Clock<V>> {
-        move |_resume_state_bytes| Box::new(Self {})
+    pub(crate) fn new() -> Self {
+        Self {}
     }
 }
 
@@ -63,9 +70,8 @@ impl<V> Clock<V> for SystemClock {
         }
     }
 
-    fn time_for(&mut self, item: &V) -> DateTime<Utc> {
-        let next_value = Poll::Ready(Some(item));
-        self.watermark(&next_value)
+    fn time_for(&mut self, _item: &V) -> DateTime<Utc> {
+        Utc::now()
     }
 
     fn snapshot(&self) -> StateBytes {

--- a/src/window/testing_clock.rs
+++ b/src/window/testing_clock.rs
@@ -20,10 +20,11 @@ use crate::recovery::StateBytes;
 ///   `bytewax.window.TestingClockConfig`.
 #[pyclass(module = "bytewax.testing", name = "TestingClock")]
 #[pyo3(text_signature = "(init_datetime)")]
+#[derive(Clone)]
 pub(crate) struct PyTestingClock {
     /// Modify this to change the current "now".
     #[pyo3(get, set)]
-    now: DateTime<Utc>,
+    pub(crate) now: DateTime<Utc>,
 }
 
 impl PyTestingClock {


### PR DESCRIPTION
This PR introduces a new Clock Config: `EventClockConfig`.

`EventClockConfig` is a clock based on datetimes retrieved from events.
Whenever an event is received, its datetime is extracted through a user specified function.
Events are awaited until a user specified duration is passed reached, if an event comes late it's dropped.

This configuration requires the user to specify 3 parameters:
- `dt_getter`: a function that receives an event as input and should return a datetime extracted from the event
- `late`: a duration after which (in event-time, not realtime) the window for waiting late events is closed
- `system_clock`: by default the system clock is used internally, but a TestingClock can be passed here

~This PR is ready for review, but is blocked by~:
- https://github.com/PyO3/pyo3/pull/2612
- https://github.com/bytewax/bytewax/pull/115

### TODO
- [x] Do not rely on `time.sleep` in tests
- [x] Add documentation
- [x] Add an example
- [x] More tests