### PR TITLE
Fix key usage in docstring

### DIFF
--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -399,7 +399,7 @@ impl Dataflow {
     /// ...     ]
     /// >>> def extract_id(event):
     /// ...     return (event["user"], event)
-    /// >>> def build(key):
+    /// >>> def build():
     /// ...     return defaultdict(lambda: 0)
     /// >>> def count(results, event):
     /// ...     results[event["type"]] += 1


### PR DESCRIPTION
Remove the key from the builder in the docstring for the fold window operator.