### PR TITLE
Update Readme and Add Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ To build a specific branch, you will need to use Maturin and have Rust installed
 maturin develop
 ```
 
-*Important*: If you are doing performance testing on a version you're building from source, you should use `maturin develop --release`. Debug mode is the default and the performance characteristics are very different.
+*Important*: If you are testing with a maturin built version from source, you should use `maturin build --release` since develop will be slower.
 
 ## More Examples
 

--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ if __name__ == "__main__":
 
 ### Deploying and Scaling
 
-Bytewax can be run on a local machine, or remote machine just like a regular python script.
+Bytewax can be run on a local machine or remote machine, just like a regular Python script.
 
 ```sh
 python my_dataflow.py
 ```
 
-It can also be run in a docker container as described further in the [documentation](https://docs.bytewax.io/deployment/container).
+It can also be run in a Docker container as described further in the [documentation](https://docs.bytewax.io/deployment/container).
 
 #### Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Python Stateful Stream Processing Framework
 
-Bytewax is a Python framework that simplifies event and stream processing. Because Bytewax couples the stream & event processing capabilities of Flink, Spark, and Kafka Streams with the friendly and familiar interface of Python, you can re-use the Python libraries you already know and love. Connect data sources, run stateful transformations and write to various different downstream systems with built-in connectors or existing Python libraries. 
+Bytewax is a Python framework that simplifies event and stream processing. Because Bytewax couples the stream and event processing capabilities of Flink, Spark, and Kafka Streams with the friendly and familiar interface of Python, you can re-use the Python libraries you already know and love. Connect data sources, run stateful transformations and write to various different downstream systems with built-in connectors or existing Python libraries. 
 
 <img width="1303" alt="Screen Shot 2022-10-07 at 2 22 49 PM" src="https://user-images.githubusercontent.com/6073079/194624582-c16df8d6-d501-46b2-bdbc-78dbed67902e.png">
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ flow.map(anonymize_email)
 flow.filter(remove_bytewax)
 ```
 
-Bytewax is a stateful stream processor, which means that you can do things like aggregations and windowing. With Bytewax, state is stored in memory on the workers by default and is also persisted with different [state recovery mechanisms](https://docs.bytewax.io/apidocs/bytewax.recovery). There are different stateful operators available like `reduce`, `stateful_map` and `fold_window`. The complete list can be found in the [API documentation for all operators](https://docs.bytewax.io/apidocs/bytewax.dataflow). Below we use the `fold_window` operator with a tumbling window based on system time to gather events and calculate the number of times different events happen per user.
+Bytewax is a stateful stream processing framework, which means that some operations remember information across multiple events.  Windows and aggregations are also stateful, and can be reconstructed in the event of failure. Bytewax can be configured with different [state recovery mechanisms](https://docs.bytewax.io/apidocs/bytewax.recovery) to durably persist state in order to recover from failure.
+
+There are multiple stateful operators available like `reduce`, `stateful_map` and `fold_window`. The complete list can be found in the [API documentation for all operators](https://docs.bytewax.io/apidocs/bytewax.dataflow). Below we use the `fold_window` operator with a tumbling window based on system time to gather events and calculate the number of times events have occurred on a per-user basis.
 
 ```python
 import datetime

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ def output_builder(worker_index, worker_count):
 flow.capture(ManualOutputConfig(output_builder))
 ```
 
-Bytewax comes with a few different execution models. They are used to run dataflows in different manners, like running across a cluster of worker processes or running on a single worker process and single worker thread on a local machine. Below is an example of running using a clustered approach, but with only one worker process and two worker threads.
+Bytewax dataflows can be executed on a single host with multiple Python processes, or on multiple hosts. Below is an example of running bytewax across multiple hosts. When processing data in a distributed fashion, Bytewax will ensure that all items with the same key are routed to the same host.
 
 ```python
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ from bytewax.outputs import ManualOutputConfig
 # but you can also create your own with the ManualOutputConfig.
 ```
 
-At a high-level, the dataflow compute model is one in which a program execution is conceptualized as data flowing through a series of operator-based steps. Operators like `map` and `filter` are the processing primitives of bytewax. Each of them gives you a “shape” of data transformation, and you give them regular Python functions to customize them to a specific task you need. See the documentation for a list of the [available operators](https://docs.bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow)
+At a high-level, the dataflow compute model is one in which a program execution is conceptualized as data flowing through a series of operator-based steps. Operators like `map` and `filter` are the processing primitives of Bytewax. Each of them gives you a “shape” of data transformation, and you give them regular Python functions to customize them to a specific task you need. See the documentation for a list of the [available operators](https://docs.bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow)
 
 ```python
 import json

--- a/README.md
+++ b/README.md
@@ -2,18 +2,17 @@
 [![PyPI](https://img.shields.io/pypi/v/bytewax.svg?style=flat-square)](https://pypi.org/project/bytewax/)
 [![Bytewax User Guide](https://img.shields.io/badge/user-guide-brightgreen?style=flat-square)](https://docs.bytewax.io/)
 
-
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/6073079/190717414-1cb12001-95be-453e-a5a0-15d2be938053.svg" width="350">
-  <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/6073079/157465283-c106c4e5-301a-4e7a-a26e-586229356fdd.svg" width="350">
+  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/6073079/194626717-6c4ecbfe-afa9-408e-b8bb-91552842762c.png" width="350">
+  <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/6073079/194626697-425ade3d-3d72-4b4c-928e-47bad174a376.png" width="350">
   <img alt="Bytewax">
 </picture>
 
 ## Python Stateful Stream Processing Framework
 
-Bytewax is a Python framework that simplifies event and stream processing. Because Bytewax couples the stream & event processing capabilities of Flink, Spark, and Kafka Streams with the friendly and familiar interface of Python, you can re-use the Python libraries you already know and love.
+Bytewax is a Python framework that simplifies event and stream processing. Because Bytewax couples the stream & event processing capabilities of Flink, Spark, and Kafka Streams with the friendly and familiar interface of Python, you can re-use the Python libraries you already know and love. Connect data sources, run stateful transformations and write to various different downstream systems with built-in connectors or existing Python libraries. 
 
-![Diagram]()
+<img width="1303" alt="Screen Shot 2022-10-07 at 2 22 49 PM" src="https://user-images.githubusercontent.com/6073079/194624582-c16df8d6-d501-46b2-bdbc-78dbed67902e.png">
 
 
 ### How it all works

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ To build a specific branch, you will need to use Maturin and have Rust installed
 maturin develop
 ```
 
-*Important*: If you are testing with a maturin built version from source, you should use `maturin build --release` since develop will be slower.
+*Important*: If you are testing with a maturin built version from source, you should use `maturin build --release` since `maturin develop` will be slower.
 
 ## More Examples
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,16 @@
   <img alt="Bytewax">
 </picture>
 
+## Python Stateful Stream Processing Framework
+
+Bytewax is a Python framework that simplifies event and stream processing. Because Bytewax couples the stream & event processing capabilities of Flink, Spark, and Kafka Streams with the friendly and familiar interface of Python, you can re-use the Python libraries you already know and love.
+
+![Diagram]()
 
 
-## Modern distributed processing framework for bounded and unbounded streams. 
+### How it all works
 
-Bytewax is a Python framework and Rust distributed processing engine that uses a dataflow computational model to provide parallelizable stream processing and event processing capabilities similar to Flink, Spark, and Kafka Streams. You can use Bytewax for a variety of workloads from moving data à la Kafka Connect style all the way to advanced online machine learning workloads. Bytewax is not limited to streaming applications but excels anywhere that data can be distributed at the input and output. 
+Bytewax is a Python framework and Rust distributed processing engine that uses a dataflow computational model to provide parallelizable stream processing and event processing capabilities similar to Flink, Spark, and Kafka Streams. You can use Bytewax for a variety of workloads from moving data à la Kafka Connect style all the way to advanced online machine learning workloads. Bytewax is not limited to streaming applications but excels anywhere that data can be distributed at the input and output.
 
 Bytewax has an accompanying command line interface, [waxctl](https://docs.bytewax.io/deployment/waxctl/), which supports the deployment of dataflows on cloud vms or kuberentes. You can download it [here](https://docs.bytewax.io/downloads/).
 
@@ -37,7 +42,7 @@ from bytewax.outputs import ManualOutputConfig
 # but you can also create your own with the ManualOutputConfig.
 ```
 
-At a high-level, dataflow programming is a programming paradigm where program execution is conceptualized as data flowing through a series of operator-based steps. Operators like `map` and `filter` are the processing primitives of bytewax. Each of them gives you a “shape” of data transformation, and you give them regular Python functions to customize them to a specific task you need. See the documentation for a list of the [available operators](https://docs.bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow)
+At a high-level, the dataflow compute model is one in which a program execution is conceptualized as data flowing through a series of operator-based steps. Operators like `map` and `filter` are the processing primitives of bytewax. Each of them gives you a “shape” of data transformation, and you give them regular Python functions to customize them to a specific task you need. See the documentation for a list of the [available operators](https://docs.bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow)
 
 ```python
 import json
@@ -63,7 +68,7 @@ flow.map(anonymize_email)
 flow.filter(remove_bytewax)
 ```
 
-Bytewax is a stateful stream processor, which means that you can do things like aggregations and windowing. With Bytewax, state is stored in memory on the workers by default and can is also persisted with different [state recovery mechanisms](https://docs.bytewax.io/apidocs/bytewax.recovery). There are different stateful operators available like `reduce`, `stateful_map` and `fold_window`. The complete list can be found in the [API documentation for all operators](https://docs.bytewax.io/apidocs/bytewax.dataflow). Below we use the `fold_window` operator with a tumbling window based on system time to gather events and calculate the number of times different events happen per user.
+Bytewax is a stateful stream processor, which means that you can do things like aggregations and windowing. With Bytewax, state is stored in memory on the workers by default and is also persisted with different [state recovery mechanisms](https://docs.bytewax.io/apidocs/bytewax.recovery). There are different stateful operators available like `reduce`, `stateful_map` and `fold_window`. The complete list can be found in the [API documentation for all operators](https://docs.bytewax.io/apidocs/bytewax.dataflow). Below we use the `fold_window` operator with a tumbling window based on system time to gather events and calculate the number of times different events happen per user.
 
 ```python
 import datetime
@@ -84,7 +89,7 @@ def count_events(results, event):
 flow.fold_window("session_state_recovery", cc, wc, build, count_events)
 ```
 
-Output mechanisms in Bytewax are managed in the [capture operator](https://docs.bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow.capture). There are a number of helpers that allow you to easily connect and write to other systems ([output docs](https://docs.bytewax.io/apidocs/bytewax.outputs)). If there isn’t a helper built, it is easy to build a custom version. Like the input, Bytewax output can be parallelized and will occur on the worker.
+Output mechanisms in Bytewax are managed in the [capture operator](https://docs.bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow.capture). There are a number of helpers that allow you to easily connect and write to other systems ([output docs](https://docs.bytewax.io/apidocs/bytewax.outputs)). If there isn’t a helper built, it is easy to build a custom version, which we will do below. Similar the input, Bytewax output can be parallelized and the client connection will occur on the worker.
 
 ```python
 import json
@@ -111,7 +116,7 @@ def output_builder(worker_index, worker_count):
 flow.capture(ManualOutputConfig(output_builder))
 ```
 
-Bytewax comes with a few different execution models. They are used to run dataflows in different manners, like running across a cluster or running on a local machine. Below is an example of running on across a manual managed cluster
+Bytewax comes with a few different execution models. They are used to run dataflows in different manners, like running across a cluster of worker processes or running on a single worker process and single worker thread on a local machine. Below is an example of running using a clustered approach, but with only one worker process and two worker threads.
 
 ```python
 if __name__ == "__main__":
@@ -137,7 +142,8 @@ python my_dataflow.py
 It can also be run in a docker container as described further in the [documentation](https://docs.bytewax.io/deployment/container).
 
 #### Kubernetes
-The recommended way to run dataflows at scale is to leverage the [kubernetes ecosystem](https://docs.bytewax.io/deployment/k8s-ecosystem). To help manage deployment, we built [wactl](https://docs.bytewax.io/deployment/waxctl), which allows you to easily deploy dataflows that will run at huge scale across pods. 
+
+The recommended way to run dataflows at scale is to leverage the [kubernetes ecosystem](https://docs.bytewax.io/deployment/k8s-ecosystem). To help manage deployment, we built [waxctl](https://docs.bytewax.io/deployment/waxctl), which allows you to easily deploy dataflows that will run at huge scale across multiple compute nodes.
 
 ```sh
 waxctl df deploy my_dataflow.py --name my-dataflow

--- a/docs/examples/event-processing.md
+++ b/docs/examples/event-processing.md
@@ -1,7 +1,7 @@
 Processing Events from Redpanda to Postgres
 ===========================
 
-This example will cover building a data product with Bytewax. We will write a data flow that will aggregate event data generated via a user's interaction with a software product. The event data in this example will stream into a Redpanda Topic and our dataflow will consume from this topic. The dataflow will anonymize user data, filter out employee generated events and then count the number of events per type of event, per user over a time window. The results will be written to a postgres database that will serve the final application.
+This example will cover building a data product with Bytewax. We will write a data flow that will aggregate event data generated via a user's interaction with a software product. The event data in this example will stream into a Redpanda Topic and our dataflow will consume from this topic. The dataflow will anonymize user data, filter out employee generated events and then count the number of events per event type and per user over a time window. The results will be written to a postgres database that will serve the final application.
 
 Prerequisites
 ---------

--- a/docs/examples/event-processing.md
+++ b/docs/examples/event-processing.md
@@ -1,11 +1,101 @@
 Processing Events from Redpanda to Postgres
 ===========================
 
-This example will cover building a data product with Bytewax. We will write a data flow that will aggregate event data generated via a user's interaction with a software product. The event data in this example are streaming into a Redpanda Topic and our dataflow will consume from this topic. The dataflow will anonymize user data, filter out employee generated events and then count the number of events per type of event, per user over a time window. The results will be written to a postgres database that will serve the final application.
+This example will cover building a data product with Bytewax. We will write a data flow that will aggregate event data generated via a user's interaction with a software product. The event data in this example will stream into a Redpanda Topic and our dataflow will consume from this topic. The dataflow will anonymize user data, filter out employee generated events and then count the number of events per type of event, per user over a time window. The results will be written to a postgres database that will serve the final application.
+
+Prerequisites
+---------
+
+**Kafka/Redpanda**
+To get started you will need a Kafka ([Docker setup](https://developer.confluent.io/quickstart/kafka-docker/)) or Redpanda ([Docker setup](https://docs.redpanda.com/docs/quickstart/quick-start-docker/)) cluster running.
+
+**Postgres**
+Follow the correct installation guide for your OS from those listed on the [wiki](https://wiki.postgresql.org/wiki/Detailed_installation_guides). Once you have completed the installation, you will need to create a db and a table with the correct schema.
+
+```sql doctest:SKIP
+CREATE DATABASE website;
+CREATE USER bytewax;
+ALTER USER bytewax WITH SUPERUSER;
+\c website;
+CREATE TABLE events (
+    user_id VARCHAR unique PRIMARY KEY,
+    data JSON
+);
+```
+
+**Python Modules**
+You should also have the following installed:
+
+```bash
+pip install bytewax==0.11.1 psycopg2==2.9.4 kafka-python==2.0.2
+```
+
+**Data**
+To get started with some data we will use the code below to generate some web events in our topic for processing in the dataflow we are going to write. Create a new file named `fake_events.py` with the code below included.
+
+```python doctest:SKIP
+import json
+from random import randint
+from time import sleep
+
+from kafka import KafkaProducer
+from kafka.admin import KafkaAdminClient, NewTopic
+from kafka.errors import KafkaError
+
+input_topic_name = "web_events"
+localhost_bootstrap_server = "localhost:9092"
+producer = KafkaProducer(bootstrap_servers=[localhost_bootstrap_server])
+admin = KafkaAdminClient(bootstrap_servers=[localhost_bootstrap_server])
+
+# Create input topic
+try:
+    input_topic = NewTopic(input_topic_name, num_partitions=3, replication_factor=1)
+    admin.create_topics([input_topic])
+    print(f"input topic {input_topic_name} created successfully")
+except:
+    print(f"Topic {input_topic_name} already exists")
+
+# Add data to input topic
+users = [
+    {"user_id":"a12", "email":"joe@mail.com"}, 
+    {"user_id":"a34", "email":"jane@mail.com"}, 
+    {"user_id":"a56", "email":"you@mail.com"}, 
+    {"user_id":"a78", "email":"the@mail.com"}, 
+    {"user_id":"a99", "email":"employee@bytewax.io"}
+    ]
+
+event_types = [
+    "click",
+    "post",
+    "comment",
+    "login"
+]
+
+try:
+    for i in range(500):
+        event = users[randint(0,4)]
+        event['type'] = event_types[randint(0,3)]
+        event_ = json.dumps(event).encode()
+        producer.send(input_topic_name, value=event_)
+        sleep(0.1)
+    print(f"input topic {input_topic_name} populated successfully")
+except KafkaError:
+    print("A kafka error occurred")
+```
+
+Now run `fake_events.py` to load our topic up with some event data.
+
+```python doctest:SKIP
+python fake_events.py
+```
+
+Dataflow
+-----------
 
 The dataflow will start with us defining the input. In this case, consuming from a Redpanda topic.
 
 ```python doctest:SKIP
+
 ​​from bytewax.dataflow import Dataflow
 from bytewax.inputs import KafkaInputConfig 
 
@@ -37,7 +127,7 @@ flow.map(anonymize_email)
 flow.filter(remove_bytewax)
 ```
 
-Bytewax is a stateful stream processor, which means that you can do things like aggregations and windowing. With Bytewax, state is stored in memory on the workers by default and can is also persisted with different [state recovery mechanisms](https://docs.bytewax.io/apidocs/bytewax.recovery). There are different stateful operators available like `reduce`, `stateful_map` and `fold_window`. The complete list can be found in the [API documentation for all operators](https://docs.bytewax.io/apidocs/bytewax.dataflow). Below we use the `fold_window` operator with a tumbling window based on system time to gather events and calculate the number of times different events happen per user.
+Bytewax is a stateful stream processor, which means that you can do things like aggregations and windowing. With Bytewax, state is stored in memory on the workers by default and can also be persisted with different [state recovery mechanisms](https://docs.bytewax.io/apidocs/bytewax.recovery). There are different stateful operators available like `reduce`, `stateful_map` and `fold_window`. The complete list can be found in the [API documentation for all operators](https://docs.bytewax.io/apidocs/bytewax.dataflow). Below we use the `fold_window` operator with a tumbling window based on system time to gather events and calculate the number of times different events happen per user.
 
 ```python doctest:SKIP
 import datetime
@@ -58,7 +148,7 @@ def count_events(results, event):
 flow.fold_window("session_state_recovery", cc, wc, build, count_events)
 ```
 
-Output mechanisms in Bytewax are managed in the [capture operator](https://docs.bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow.capture). There are a number of helpers that allow you to easily connect and write to other systems ([output docs](https://docs.bytewax.io/apidocs/bytewax.outputs)). If there isn’t a helper built, it is easy to build a custom version. Like the input, Bytewax output can be parallelized and will occur on the worker.
+Output mechanisms in Bytewax are managed in the [capture operator](https://docs.bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow.capture). There are a number of helpers that allow you to easily connect and write to other systems ([output docs](https://docs.bytewax.io/apidocs/bytewax.outputs)). If there isn’t a helper built, it is easy to build a custom version. Like the input, Bytewax output can be parallelized and connection will occur on the worker.
 
 ```python doctest:SKIP
 import json
@@ -86,7 +176,7 @@ def output_builder(worker_index, worker_count):
 flow.capture(ManualOutputConfig(output_builder))
 ```
 
-Bytewax comes with a few different execution models. They are used to run dataflows in different manners, like running across a cluster or running on a local machine. Below is an example of running on across a manual managed cluster
+Bytewax comes with a few different execution models. They are used to run the dataflow in different manners, like running across a cluster or running on a local machine. Below is an example of running on across a manual managed cluster
 
 ```python doctest:SKIP
 if __name__ == "__main__":
@@ -104,7 +194,7 @@ if __name__ == "__main__":
 **Deploying and Scaling**
 --------
 
-Bytewax can be run on a local machine, or remote machine just like a regular python script.
+Bytewax can be run as a single worker thread, single worker process on a local machine, or remote machine with multiple worker threads and worker processes just like a regular python script.
 
 ```sh doctest:SKIP
 python my_dataflow.py
@@ -114,7 +204,7 @@ It can also be run in a docker container as described further in the [documentat
 
 **Kubernetes**
 
-The recommended way to run dataflows at scale is to leverage the [kubernetes ecosystem](https://docs.bytewax.io/deployment/k8s-ecosystem). To help manage deployment, we built [wactl](https://docs.bytewax.io/deployment/waxctl), which allows you to easily deploy dataflows that will run at huge scale across pods. 
+The recommended way to run dataflows at scale is to leverage the [kubernetes ecosystem](https://docs.bytewax.io/deployment/k8s-ecosystem). To help manage deployment, we built [wactl](https://docs.bytewax.io/deployment/waxctl), which allows you to easily deploy dataflows that will run at huge scale across pods.
 
 ```sh doctest:SKIP
 waxctl df deploy my_dataflow.py --name my-dataflow

--- a/docs/examples/event-processing.md
+++ b/docs/examples/event-processing.md
@@ -194,13 +194,13 @@ if __name__ == "__main__":
 **Deploying and Scaling**
 --------
 
-Bytewax can be run like a regular python script using a single worker thread and process. Alternatively it could be scaled up to multiple worker threads and processes.
+Bytewax can be run like a regular Python script using a single worker thread and process. Alternatively, it could be scaled up to multiple worker threads and processes.
 
 ```sh doctest:SKIP
 python my_dataflow.py
 ```
 
-It can also be run in a docker container as described further in the [documentation](https://docs.bytewax.io/deployment/container).
+It can also be run in a Docker container as described further in the [documentation](https://docs.bytewax.io/deployment/container).
 
 **Kubernetes**
 

--- a/docs/examples/event-processing.md
+++ b/docs/examples/event-processing.md
@@ -7,9 +7,11 @@ Prerequisites
 ---------
 
 **Kafka/Redpanda**
+
 To get started you will need a Kafka ([Docker setup](https://developer.confluent.io/quickstart/kafka-docker/)) or Redpanda ([Docker setup](https://docs.redpanda.com/docs/quickstart/quick-start-docker/)) cluster running.
 
 **Postgres**
+
 Follow the correct installation guide for your OS from those listed on the [wiki](https://wiki.postgresql.org/wiki/Detailed_installation_guides). Once you have completed the installation, you will need to create a db and a table with the correct schema.
 
 ```sql doctest:SKIP
@@ -24,6 +26,7 @@ CREATE TABLE events (
 ```
 
 **Python Modules**
+
 You should also have the following installed:
 
 ```bash
@@ -31,6 +34,7 @@ pip install bytewax==0.11.1 psycopg2==2.9.4 kafka-python==2.0.2
 ```
 
 **Data**
+
 To get started with some data we will use the code below to generate some web events in our topic for processing in the dataflow we are going to write. Create a new file named `fake_events.py` with the code below included.
 
 ```python doctest:SKIP

--- a/docs/examples/event-processing.md
+++ b/docs/examples/event-processing.md
@@ -1,45 +1,21 @@
-[![Actions Status](https://github.com/bytewax/bytewax/workflows/CI/badge.svg)](https://github.com/bytewax/bytewax/actions)
-[![PyPI](https://img.shields.io/pypi/v/bytewax.svg?style=flat-square)](https://pypi.org/project/bytewax/)
-[![Bytewax User Guide](https://img.shields.io/badge/user-guide-brightgreen?style=flat-square)](https://docs.bytewax.io/)
+Processing Events from Redpanda to Postgres
+===========================
 
+This example will cover building a data product with Bytewax. We will write a data flow that will aggregate event data generated via a user's interaction with a software product. The event data in this example are streaming into a Redpanda Topic and our dataflow will consume from this topic. The dataflow will anonymize user data, filter out employee generated events and then count the number of events per type of event, per user over a time window. The results will be written to a postgres database that will serve the final application.
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/6073079/190717414-1cb12001-95be-453e-a5a0-15d2be938053.svg" width="350">
-  <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/6073079/157465283-c106c4e5-301a-4e7a-a26e-586229356fdd.svg" width="350">
-  <img alt="Bytewax">
-</picture>
+The dataflow will start with us defining the input. In this case, consuming from a Redpanda topic.
 
-
-
-## Modern distributed processing framework for bounded and unbounded streams. 
-
-Bytewax is a Python framework and Rust distributed processing engine that uses a dataflow computational model to provide parallelizable stream processing and event processing capabilities similar to Flink, Spark, and Kafka Streams. You can use Bytewax for a variety of workloads from moving data à la Kafka Connect style all the way to advanced online machine learning workloads. Bytewax is not limited to streaming applications but excels anywhere that data can be distributed at the input and output. 
-
-Bytewax has an accompanying command line interface, [waxctl](https://docs.bytewax.io/deployment/waxctl/), which supports the deployment of dataflows on cloud vms or kuberentes. You can download it [here](https://docs.bytewax.io/downloads/).
-
-_____________
-
-### Getting Started with Bytewax
-
-```sh
-pip install bytewax
-```
-
-[_Install waxctl_](https://docs.bytewax.io/downloads/)
-
-A Bytewax dataflow is Python code that will represent an input, a series of processing steps, and an output. The inputs could range from a Kafka stream to a WebSocket and the outputs could vary from a data lake to a key-value store.
-
-```python
+```python doctest:SKIP
 ​​from bytewax.dataflow import Dataflow
 from bytewax.inputs import KafkaInputConfig 
-from bytewax.outputs import ManualOutputConfig
-# Bytewax has input and output helpers for common input and output data sources
-# but you can also create your own with the ManualOutputConfig.
+
+flow = Dataflow()
+flow.input("inp", KafkaInputConfig(brokers=["localhost:9092"], topic="web_events"))
 ```
 
 At a high-level, dataflow programming is a programming paradigm where program execution is conceptualized as data flowing through a series of operator-based steps. Operators like `map` and `filter` are the processing primitives of bytewax. Each of them gives you a “shape” of data transformation, and you give them regular Python functions to customize them to a specific task you need. See the documentation for a list of the [available operators](https://docs.bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow)
 
-```python
+```python doctest:SKIP
 import json
 def deserialize(key_bytes__payload_bytes):
     key_bytes, payload_bytes = key_bytes__payload_bytes
@@ -56,8 +32,6 @@ def remove_bytewax(user_id__event_data):
     user_id, event_data = user_id__event_data
     return "bytewax" not in event_data["email"]
 
-flow = Dataflow()
-flow.input("inp", KafkaInputConfig(brokers=["localhost:9092"], topic="web_events"))
 flow.map(deserialize)
 flow.map(anonymize_email)
 flow.filter(remove_bytewax)
@@ -65,7 +39,7 @@ flow.filter(remove_bytewax)
 
 Bytewax is a stateful stream processor, which means that you can do things like aggregations and windowing. With Bytewax, state is stored in memory on the workers by default and can is also persisted with different [state recovery mechanisms](https://docs.bytewax.io/apidocs/bytewax.recovery). There are different stateful operators available like `reduce`, `stateful_map` and `fold_window`. The complete list can be found in the [API documentation for all operators](https://docs.bytewax.io/apidocs/bytewax.dataflow). Below we use the `fold_window` operator with a tumbling window based on system time to gather events and calculate the number of times different events happen per user.
 
-```python
+```python doctest:SKIP
 import datetime
 from collections import defaultdict
 
@@ -86,10 +60,11 @@ flow.fold_window("session_state_recovery", cc, wc, build, count_events)
 
 Output mechanisms in Bytewax are managed in the [capture operator](https://docs.bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow.capture). There are a number of helpers that allow you to easily connect and write to other systems ([output docs](https://docs.bytewax.io/apidocs/bytewax.outputs)). If there isn’t a helper built, it is easy to build a custom version. Like the input, Bytewax output can be parallelized and will occur on the worker.
 
-```python
+```python doctest:SKIP
 import json
 
 import psycopg2
+from bytewax.outputs import ManualOutputConfig
 
 def output_builder(worker_index, worker_count):
     # create the connection at the worker level
@@ -113,7 +88,7 @@ flow.capture(ManualOutputConfig(output_builder))
 
 Bytewax comes with a few different execution models. They are used to run dataflows in different manners, like running across a cluster or running on a local machine. Below is an example of running on across a manual managed cluster
 
-```python
+```python doctest:SKIP
 if __name__ == "__main__":
     addresses = [
     "localhost:2101"
@@ -126,75 +101,21 @@ if __name__ == "__main__":
         worker_count_per_proc=2)
 ```
 
-### Deploying and Scaling
+**Deploying and Scaling**
+--------
 
 Bytewax can be run on a local machine, or remote machine just like a regular python script.
 
-```sh
+```sh doctest:SKIP
 python my_dataflow.py
 ```
 
 It can also be run in a docker container as described further in the [documentation](https://docs.bytewax.io/deployment/container).
 
-#### Kubernetes
+**Kubernetes**
+
 The recommended way to run dataflows at scale is to leverage the [kubernetes ecosystem](https://docs.bytewax.io/deployment/k8s-ecosystem). To help manage deployment, we built [wactl](https://docs.bytewax.io/deployment/waxctl), which allows you to easily deploy dataflows that will run at huge scale across pods. 
 
-```sh
+```sh doctest:SKIP
 waxctl df deploy my_dataflow.py --name my-dataflow
 ```
-
-## Why Bytewax?
-
-At a high level, Bytewax provides a few major benefits:
-
-* The operators in Bytewax are largely “data-parallel”, meaning they can operate on independent parts of the data concurrently.
-* Bytewax offers the ability to express higher-level control constructs, like iteration.
-* Bytewax allows you to develop and run your code locally, and then easily scale that code to multiple workers or processes without changes.
-* Bytewax can be used in both a streaming and batch context
-* Ability to leverage the Python ecosystem directly
-
-## Community
-
-[Slack](https://join.slack.com/t/bytewaxcommunity/shared_invite/zt-vkos2f6r-_SeT9pF2~n9ArOaeI3ND2w) Is the main forum for communication and discussion.
-
-[GitHub Issues](https://github.com/bytewax/bytewax/issues) is reserved only for actual issues. Please use the slack community for discussions.
-
-[Code of Conduct](https://github.com/bytewax/bytewax/blob/main/CODE_OF_CONDUCT.md)
-
-## Usage
-
-Install the [latest release](https://github.com/bytewax/bytewax/releases/latest) with pip:
-
-```shell
-pip install bytewax
-```
-
-### Building From Source
-
-To build a specific branch, you will need to use Maturin and have Rust installed on your machine. Once those have been installed run
-
-```shell
-maturin develop
-```
-
-*Important*: If you are testing with a maturin built version from source, you should use `maturin release` since develop will be slower.
-
-## More Examples
-
-For a more complete example, and documentation on the available operators, check out the [User Guide](https://docs.bytewax.io/) and the [Examples](https://docs.bytewax.io/examples)
-
-For an exhaustive list of examples, checkout the [/examples](/examples) folder
-
-## License
-
-Bytewax is licensed under the [Apache-2.0](https://opensource.org/licenses/APACHE-2.0) license.
-
-## Contributing
-
-Contributions are welcome! This community and project would not be what it is without the [contributors](https://github.com/bytewax/bytewax/graphs/contributors). All contributions, from bug reports to new features, are welcome and encouraged. Please view the [contribution guidelines](/CONTRIBUTING.md) before getting started.
-
-</br>
-</br>
-
-<p align="center"> With ❤️ Bytewax</p> 
-<p align="center"><img src="https://user-images.githubusercontent.com/6073079/157482621-331ad886-df3c-4c92-8948-9e50accd38c9.png" /> </p>

--- a/docs/examples/event-processing.md
+++ b/docs/examples/event-processing.md
@@ -127,7 +127,7 @@ flow.map(anonymize_email)
 flow.filter(remove_bytewax)
 ```
 
-Bytewax is a stateful stream processor, which means that you can do things like aggregations and windowing. With Bytewax, state is stored in memory on the workers by default and can also be persisted with different [state recovery mechanisms](https://docs.bytewax.io/apidocs/bytewax.recovery). There are different stateful operators available like `reduce`, `stateful_map` and `fold_window`. The complete list can be found in the [API documentation for all operators](https://docs.bytewax.io/apidocs/bytewax.dataflow). Below we use the `fold_window` operator with a tumbling window based on system time to gather events and calculate the number of times different events happen per user.
+Bytewax is a stateful stream processor, which means that you can do things like aggregations and windowing. With Bytewax, state is stored in memory on the workers by default, but can also be persisted with different [state recovery mechanisms](https://docs.bytewax.io/apidocs/bytewax.recovery) for failure recovery. There are different stateful operators available like `reduce`, `stateful_map` and `fold_window`. The complete list can be found in the [API documentation for all operators](https://docs.bytewax.io/apidocs/bytewax.dataflow). Below we use the `fold_window` operator with a tumbling window based on system time to gather events and calculate the number of times different events happen per user.
 
 ```python doctest:SKIP
 import datetime
@@ -194,7 +194,7 @@ if __name__ == "__main__":
 **Deploying and Scaling**
 --------
 
-Bytewax can be run as a single worker thread, single worker process on a local machine, or remote machine with multiple worker threads and worker processes just like a regular python script.
+Bytewax can be run like a regular python script using a single worker thread and process. Alternatively it could be scaled up to multiple worker threads and processes.
 
 ```sh doctest:SKIP
 python my_dataflow.py

--- a/docs/examples/kafka-enrichment.md
+++ b/docs/examples/kafka-enrichment.md
@@ -92,7 +92,7 @@ flow.input(
 
 After initializing a Dataflow object, we use the `input` method to define our input. The input method takes two arguments, the `step_id` and the `input_config`. The `step_id` is used for recovery purposes and the input configuration is where we will use the `KafkaInputConfig` to set up our dataflow to consume from Kafka.
 
-_A Quick Aside on Recovery: With Bytewax you can persist state in more durable formats. This is so that in the case that the dataflow fails, you can recover state and the dataflow will not be required to recompute from the beginning. This is oftentimes referred to as checkpointing for other processing frameworks. With the `KafkaInputConfig` this will also handle the offset and consumer groups for you. This makes it easy to get started working with data in Kafka._
+_A Quick Aside on Recovery: With Bytewax you can persist state in more durable formats. This is so that in the case that the dataflow fails, you can recover state and the dataflow will not be required to recompute from the beginning. This is oftentimes referred to as checkpointing for other processing frameworks. With the `KafkaInputConfig` configuring recovery will handle the offset and consumer groups for you. This makes it easy to get started working with data in Kafka._
 
 **Data Transformation**
 

--- a/docs/examples/kafka-enrichment.md
+++ b/docs/examples/kafka-enrichment.md
@@ -11,6 +11,7 @@ Prerequisites
 To get started you will need a Kafka ([Docker setup](https://developer.confluent.io/quickstart/kafka-docker/)) or Redpanda ([Docker setup](https://docs.redpanda.com/docs/quickstart/quick-start-docker/)) cluster running.
 
 **Python Modules**
+
 You should also have the following installed:
 
 pip install bytewax==0.11.1 requests==2.28.0 kafka-python==2.0.2

--- a/docs/examples/kafka-enrichment.md
+++ b/docs/examples/kafka-enrichment.md
@@ -66,7 +66,8 @@ With some data loaded and our infrastructure running. We can move onto the fun p
 
 Every dataflow will contain, at the very least an input and an output. In this example the data input source will be a kafka topic and the output sink will be another kafka topic. Between the input and output lies the code used to transform the data. This is illustrated by the diagram below.
 
-![dataflow diagram]()
+<img width="600" alt="dataflow diagram" src="https://user-images.githubusercontent.com/6073079/194627909-9f5d7b52-7fbb-4137-8b0e-1163469a9c75.png">
+
 
 Let's walk through constructing the input, the transformation code and the output.
 

--- a/docs/examples/kafka-enrichment.md
+++ b/docs/examples/kafka-enrichment.md
@@ -1,0 +1,172 @@
+Enriching Streaming Data from Kafka
+===========================
+
+This example will cover how to write a dataflow to support in-line data enrichment. Data enrichment is the process of adding to or enhancing data to make it more suitable or useful for a specific purpose. It is most often the result of joining additional data from a 3rd party database or another internal data source. For this specific example we will consume a stream of ip addresses from Kafka as input, enrich them with third party data to determine the location of the IP address and then produce data to Kafka. This example will leverage the `KafkaInputConfig` and `KafkaOutputConfig` to do so.
+
+Prerequisites
+---------
+
+**Kafka**
+
+To get started you will need a Kafka ([Docker setup](https://developer.confluent.io/quickstart/kafka-docker/)) or Redpanda ([Docker setup](https://docs.redpanda.com/docs/quickstart/quick-start-docker/)) cluster running.
+
+**Python Modules**
+You should also have the following installed:
+
+pip install bytewax==0.11.1 requests==2.28.0 kafka-python==2.0.2
+
+**Data**
+
+The data source for this example is under the [examples directory]() in the bytewax repo and you can load it to the running kafka cluster with the code shown below. This code is outside of the scope of this example. It is creating an input and output topic and then writing some sample data to the topic.
+
+```python doctest:SKIP
+from kafka import KafkaProducer
+from kafka.admin import KafkaAdminClient, NewTopic
+from kafka.errors import KafkaError
+from time import sleep
+
+input_topic_name = "ip_address_by_country"
+output_topic_name = "ip_address_by_location"
+localhost_bootstrap_server = "localhost:9092"
+producer = KafkaProducer(bootstrap_servers=[localhost_bootstrap_server])
+admin = KafkaAdminClient(bootstrap_servers=[localhost_bootstrap_server])
+
+# Create input topic
+try:
+    input_topic = NewTopic(input_topic_name, num_partitions=20, replication_factor=1)
+    admin.create_topics([input_topic])
+    print(f"input topic {input_topic_name} created successfully")
+except:
+    print(f"Topic {input_topic_name} already exists")
+
+# Create output topic
+try:
+    output_topic = NewTopic(output_topic_name, num_partitions=20, replication_factor=1)
+    admin.create_topics([output_topic])
+    print(f"output topic {output_topic_name} created successfully")
+except:
+    print(f"Topic {output_topic_name} already exists")
+
+# Add data to input topic
+try:
+    for line in open("misc/ip_address_w_country.txt"):
+        ip_address, country_raw = line.split(",")
+        country = country_raw[:-1]
+        producer.send(input_topic_name, key=f"{country}".encode('ascii'), value=f"{ip_address}".encode('ascii'))
+        sleep(0.1)
+    print(f"input topic {output_topic_name} populated successfully")
+except KafkaError:
+    print("A kafka error occured")
+```
+
+Building the Dataflow
+--------
+
+With some data loaded and our infrastructure running. We can move onto the fun part :).
+
+Every dataflow will contain, at the very least an input and an output. In this example the data input will be a kafka topic and the output another topic. Between the input and output lies the code used to transform the data. This is illustrated by the diagram below.
+
+![diagram place holder](diagram)
+
+Let's walk through constructing the input, the transformation code and the output.
+
+**Kafka Input**
+
+Bytewax has a concept around input configurations. At a high level, these are code that can be configured and will be used as the input source for the dataflow. The [`KafkaInputConfig`](https://docs.bytewax.io/apidocs/bytewax.inputs#bytewax.inputs.KafkaInputConfig) is one of the more popular input configurations. It is important to note that the input connection will be made on each worker.
+
+```python doctest:SKIP
+from bytewax.dataflow import Dataflow
+from bytewax.inputs import KafkaInputConfig
+
+
+flow = Dataflow()
+flow.input(
+    step_id = "ip_address", 
+    input_config = KafkaInputConfig(
+        brokers=["localhost:9092"], 
+        topic="ip_address_by_countries",
+        tail=False
+        )
+    )
+```
+
+After initializing a Dataflow object, we use the `input` method to define our input. The input method takes two arguments, the `step_id` and the `input_config`. The `step_id` is used for recovery purposes and the input configuration is where we will use the `KafkaInputConfig` to set up our dataflow to consume from Kafka.
+
+_A Quick Aside on Recovery: With Bytewax you can persist state in more durable formats. This is so that in the case that the dataflow fails, you can recover state and the dataflow will not be required to recompute from the beginning. This is oftentimes referred to as checkpointing for other processing frameworks. With the `KafkaInputConfig` this will also handle the offset and consumer groups for you. This makes it easy to get started working with data in Kafka._
+
+**Data Transformation**
+
+[Operators](https://docs.bytewax.io/apidocs/bytewax.dataflow) are Dataflow class methods that define how data will flow through the dataflow. Whether it will be filtered, modified, aggregated or accumulated. In this example we are modifying our data in-flight and will use the `map` operator. The `map` operator will receive a Python function as an argument and this will contain the code to modify the data payload.
+
+```python doctest:SKIP
+def get_location(data):
+    key, value = data
+    ip_address = value.decode('ascii')
+    response = requests.get(f'https://ipapi.co/{ip_address}/json/')
+    response_json = response.json()
+    location_data = {
+        "ip": ip_address,
+        "city": response_json.get("city"),
+        "region": response_json.get("region"),
+        "country_name": response_json.get("country_name")
+    }
+    return location_data
+
+# corresponding flow module for the Map operator
+flow.map(get_location)
+```
+
+In the code above, we are making an http request to an external service, this is only for demonstration purposes. You should use something that is lower latency so you do not risk having the http request as a bottleneck or having network errors.
+
+**Kafka Output**
+
+To capture data that is transformed in a dataflow, the capture method is used.Similarly to the input method, it takes a configuration as the argument. Bytewax has built-in output configurations and [`KafkaOutputConfig`](https://docs.bytewax.io/apidocs/bytewax.outputs#bytewax.outputs.KafkaOutputConfig) is one of those. We are going to use it in this example to write out the enriched data to a new topic.
+
+```python doctest:SKIP
+flow.capture(
+    KafkaOutputConfig(
+        brokers=["localhost:9092"],
+        topic="ip_address_by_location"
+    )
+)
+```
+
+### Kicking off execution
+
+With the above dataflow written the final step is to specify the execution method. Whether it will run as a single threaded process on our local machine or be capable of scaling across a kubernetes cluster. The methods used to define the execution are part of the execution module and more detail can be found in the long format documentation as well as in the API documentation.
+
+```python doctest:SKIP
+if __name__ == "__main__":
+    addresses = [
+    "localhost:2101"
+    ]
+
+    cluster_main(
+        flow, 
+        addresses=addresses,
+        proc_id=0,
+        worker_count_per_proc=1)
+```
+
+There are two types of workers, worker threads and worker processes. In most use cases where you are running Python code to transform and enrich data, you will want to use processes.
+
+Deploying the Enrichment Dataflow
+---------
+
+Bytewax dataflows can be run as you would a regular python script.
+
+```sh doctest:SKIP
+> python kafka_enrich.py
+```
+
+You could also run them in a docker container.
+
+TODO: Load Docker Container to Dockerhub
+
+They can also be run on a cloud compute instance on AWS or GCP using waxctl.
+
+```
+TODO: waxctl command
+```
+
+Or they can run across a kubernetes cluster, also using waxctl.

--- a/docs/examples/kafka-enrichment.md
+++ b/docs/examples/kafka-enrichment.md
@@ -1,7 +1,7 @@
 Enriching Streaming Data from Kafka
 ===========================
 
-This example will cover how to write a dataflow to support in-line data enrichment. Data enrichment is the process of adding to or enhancing data to make it more suitable or useful for a specific purpose. It is most often the result of joining additional data from a 3rd party database or another internal data source. For this specific example we will consume a stream of ip addresses from Kafka as input, enrich them with third party data to determine the location of the IP address and then produce data to Kafka. This example will leverage the `KafkaInputConfig` and `KafkaOutputConfig` to do so.
+This example will cover how to write a dataflow to support in-line data enrichment. Data enrichment is the process of adding to or enhancing data to make it more suitable or useful for a specific purpose. It is most often the result of joining additional data from a 3rd party database or another internal data source. For this specific example we will consume a stream of IP addresses from Kafka as input, enrich them with third party data to determine the location of the IP address, and then produce data to Kafka. This example will leverage the `KafkaInputConfig` and `KafkaOutputConfig` to do so.
 
 Prerequisites
 ---------
@@ -124,7 +124,7 @@ In the code above, we are making an http request to an external service, this is
 
 **Kafka Output**
 
-To capture data that is transformed in a dataflow, the capture method is used.Similarly to the input method, it takes a configuration as the argument. Bytewax has built-in output configurations and [`KafkaOutputConfig`](https://docs.bytewax.io/apidocs/bytewax.outputs#bytewax.outputs.KafkaOutputConfig) is one of those. We are going to use it in this example to write out the enriched data to a new topic.
+To capture data that is transformed in a dataflow, we will use the `capture` method. Similar to the input method, it takes a configuration as the argument. Bytewax has built-in output configurations and [`KafkaOutputConfig`](https://docs.bytewax.io/apidocs/bytewax.outputs#bytewax.outputs.KafkaOutputConfig) is one of those. We are going to use it in this example to write out the enriched data to a new topic.
 
 ```python doctest:SKIP
 flow.capture(
@@ -137,7 +137,7 @@ flow.capture(
 
 ### Kicking off execution
 
-With the above dataflow written the final step is to specify the execution method. Whether it will run as a single threaded process on our local machine or be capable of scaling across a kubernetes cluster. The methods used to define the execution are part of the execution module and more detail can be found in the long format documentation as well as in the API documentation.
+With the above dataflow written, the final step is to specify the execution method. Whether it will run as a single threaded process on our local machine or be capable of scaling across a Kubernetes cluster. The methods used to define the execution are part of the execution module and more detail can be found in the long format documentation as well as in the API documentation.
 
 ```python doctest:SKIP
 from bytewax.execution import cluster_main
@@ -154,18 +154,18 @@ if __name__ == "__main__":
         worker_count_per_proc=1)
 ```
 
-There are two types of workers, worker threads and worker processes. In most use cases where you are running Python code to transform and enrich data, you will want to use processes.
+There are two types of workers: worker threads and worker processes. In most use cases where you are running Python code to transform and enrich data, you will want to use processes.
 
 Deploying the Enrichment Dataflow
 ---------
 
-Bytewax dataflows can be run as you would a regular python script.
+Bytewax dataflows can be run as you would a regular Python script.
 
 ```bash doctest:SKIP
 > python kafka_enrich.py
 ```
 
-It is also possible to run a bytewax dataflow on one of the public clouds, like AWS with Waxctl with very little configuration. You will need to have the AWS cli install and configured.
+With Waxctl, it is also possible to run a Bytewax dataflow on one of the public clouds, like AWS, with very little configuration. You will need to have the AWS CLI installed and configured.
 
 ```bash doctest:SKIP
 waxctl aws deploy kafka-enrichment.py --name kafka-enrichment \
@@ -178,7 +178,7 @@ Waxctl will configure and start an AWS EC2 instance and run your dataflow on the
 waxctl aws deploy -h                                               
 Deploy a dataflow to a new EC2 instance.
 ​
-The deploy command expects one argument, which is the path of your python dataflow file.
+The deploy command expects one argument, which is the path of your Python dataflow file.
 By default, Waxctl creates a policy and a role that will allow the EC2 instance to store Cloudwatch logs and start sessions through Systems Manager.
 ​
 Examples:

--- a/docs/examples/kafka-enrichment.md
+++ b/docs/examples/kafka-enrichment.md
@@ -17,7 +17,7 @@ pip install bytewax==0.11.1 requests==2.28.0 kafka-python==2.0.2
 
 **Data**
 
-The data source for this example is under the [examples directory]() in the bytewax repo and you can load it to the running kafka cluster with the code shown below. This code is outside of the scope of this example. It is creating an input and output topic and then writing some sample data to the topic.
+The data source for this example is under the [examples directory](https://github.com/bytewax/bytewax/tree/main/docs/examples) in the [bytewax repo](https://github.com/bytewax/bytewax) and you can load it the data to the running kafka cluster with the code shown below. This code is outside of the scope of this example. It is creating an input and output topic and then writing some sample data to the topic.
 
 ```python doctest:SKIP
 from kafka import KafkaProducer
@@ -49,7 +49,7 @@ except:
 
 # Add data to input topic
 try:
-    for line in open("misc/ip_address_w_country.txt"):
+    for line in open("ip_address_with_country.txt"):
         ip_address, country_raw = line.split(",")
         country = country_raw[:-1]
         producer.send(input_topic_name, key=f"{country}".encode('ascii'), value=f"{ip_address}".encode('ascii'))
@@ -64,9 +64,9 @@ Building the Dataflow
 
 With some data loaded and our infrastructure running. We can move onto the fun part :).
 
-Every dataflow will contain, at the very least an input and an output. In this example the data input will be a kafka topic and the output another topic. Between the input and output lies the code used to transform the data. This is illustrated by the diagram below.
+Every dataflow will contain, at the very least an input and an output. In this example the data input source will be a kafka topic and the output sink will be another kafka topic. Between the input and output lies the code used to transform the data. This is illustrated by the diagram below.
 
-![diagram place holder](diagram)
+![dataflow diagram]()
 
 Let's walk through constructing the input, the transformation code and the output.
 
@@ -77,14 +77,14 @@ Bytewax has a concept around input configurations. At a high level, these are co
 ```python doctest:SKIP
 from bytewax.dataflow import Dataflow
 from bytewax.inputs import KafkaInputConfig
-
+from bytewax.outputs import KafkaOutputConfig
 
 flow = Dataflow()
 flow.input(
     step_id = "ip_address", 
     input_config = KafkaInputConfig(
         brokers=["localhost:9092"], 
-        topic="ip_address_by_countries",
+        topic="ip_address_by_country",
         tail=False
         )
     )
@@ -99,6 +99,9 @@ _A Quick Aside on Recovery: With Bytewax you can persist state in more durable f
 [Operators](https://docs.bytewax.io/apidocs/bytewax.dataflow) are Dataflow class methods that define how data will flow through the dataflow. Whether it will be filtered, modified, aggregated or accumulated. In this example we are modifying our data in-flight and will use the `map` operator. The `map` operator will receive a Python function as an argument and this will contain the code to modify the data payload.
 
 ```python doctest:SKIP
+import json
+import requests
+
 def get_location(data):
     key, value = data
     ip_address = value.decode('ascii')
@@ -110,7 +113,7 @@ def get_location(data):
         "region": response_json.get("region"),
         "country_name": response_json.get("country_name")
     }
-    return location_data
+    return key, json.loads(location_data)
 
 # corresponding flow module for the Map operator
 flow.map(get_location)
@@ -136,6 +139,8 @@ flow.capture(
 With the above dataflow written the final step is to specify the execution method. Whether it will run as a single threaded process on our local machine or be capable of scaling across a kubernetes cluster. The methods used to define the execution are part of the execution module and more detail can be found in the long format documentation as well as in the API documentation.
 
 ```python doctest:SKIP
+from bytewax.execution import cluster_main
+
 if __name__ == "__main__":
     addresses = [
     "localhost:2101"
@@ -155,18 +160,55 @@ Deploying the Enrichment Dataflow
 
 Bytewax dataflows can be run as you would a regular python script.
 
-```sh doctest:SKIP
+```bash doctest:SKIP
 > python kafka_enrich.py
 ```
 
-You could also run them in a docker container.
+It is also possible to run a bytewax dataflow on one of the public clouds, like AWS with Waxctl with very little configuration. You will need to have the AWS cli install and configured.
 
-TODO: Load Docker Container to Dockerhub
-
-They can also be run on a cloud compute instance on AWS or GCP using waxctl.
-
-```
-TODO: waxctl command
+```bash doctest:SKIP
+waxctl aws deploy kafka-enrichment.py --name kafka-enrichment \
+  --requirements-file-name requirements-ke.txt
 ```
 
-Or they can run across a kubernetes cluster, also using waxctl.
+Waxctl will configure and start an AWS EC2 instance and run your dataflow on the instance. To see the default parameters, you can run the help command and see them in the command line:
+
+```bash doctest:SKIP
+waxctl aws deploy -h                                               
+Deploy a dataflow to a new EC2 instance.
+​
+The deploy command expects one argument, which is the path of your python dataflow file.
+By default, Waxctl creates a policy and a role that will allow the EC2 instance to store Cloudwatch logs and start sessions through Systems Manager.
+​
+Examples:
+  # The default command to deploy a dataflow named "bytewax" in a new EC2 instance running my-dataflow.py file.
+  waxctl aws deploy my-dataflow.py
+​
+  # Deploy a dataflow named "custom" using specific security groups and instance profile
+  waxctl aws deploy dataflow.py --name custom \
+    --security-groups-ids "sg-006a1re044efb2d23" \
+    --principal-arn "arn:aws:iam::1111111111:instance-profile/my-profile"
+​
+Usage:
+  waxctl aws deploy [PATH] [flags]
+​
+Flags:
+  -P, --associate-public-ip-address     associate a public IP address to the EC2 instance (default true)
+  -m, --detailed-monitoring             specifies whether detailed monitoring is enabled for the EC2 instance
+  -e, --extra-tags strings              extra tags to apply to the EC2 instance. The format must be KEY=VALUE
+  -h, --help                            help for deploy
+  -t, --instance-type string            EC2 instance type to be created (default "t2.micro")
+  -k, --key-name string                 name of an existing key pair
+  -n, --name string                     name of the EC2 instance to deploy the dataflow (default "bytewax")
+  -p, --principal-arn string            principal ARN to assign to the EC2 instance
+      --profile string                  AWS cli configuration profile
+  -f, --python-file-name string         python script file to run. Only needed when [PATH] is a tar file
+      --region string                   AWS region
+  -r, --requirements-file-name string   requirements.txt file if needed
+      --save-cloud-config               save cloud-config file to disk for troubleshooting purposes
+  -S, --security-groups-ids strings     security groups Ids to assign to the EC2 instance
+  -s, --subnet-id string                the ID of the subnet to launch the EC2 instance into
+​
+Global Flags:
+      --debug   enable verbose output
+```

--- a/docs/examples/metadata.json
+++ b/docs/examples/metadata.json
@@ -14,4 +14,16 @@
     "description": "Connect to webhooks, and aggregate incoming events to maintain an order book in real-time.",
     "filename": "crypto-sockets"
   }
+  ,
+  {
+    "title": "Processing Events from Redpanda to Postgres",
+    "description": "Process and analyze web events in real-time and write them to Postgres",
+    "filename": "event-processing"
+  }
+  ,
+  {
+    "title": "Enriching Streaming Data from Kafka",
+    "description": "Enriching streaming data inline with Bytewax.",
+    "filename": "kafka-enrichment"
+  }
 ]

--- a/docs/examples/requirements-ke.txt
+++ b/docs/examples/requirements-ke.txt
@@ -1,0 +1,2 @@
+bytewax==0.11.1 
+requests==2.28.0


### PR DESCRIPTION
I wanted to add a couple of additional examples to those listed on bytewax.io along with an update to the README. 

- `event-processing.md` uses kafka input, manual output, fold_window, filter and map
- `kafka-enrichment.md` uses kafka input and output and map. 
- `README.md` uses the same example as `event-processing.md`

TODO:
- [x] Add working dark/light images
- [x] Fix broken diagrams