### PR TITLE
Allow manually adjusting `TestingClockConfig`

### DIFF
--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -4,6 +4,8 @@ import multiprocessing.dummy
 from contextlib import contextmanager
 from threading import Lock
 
+from .bytewax import TestingClock  # noqa: F401
+
 _print_lock = Lock()
 
 

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -1,27 +1,33 @@
-from collections import defaultdict
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 
 from bytewax.dataflow import Dataflow
 from bytewax.execution import run_main
 from bytewax.inputs import TestingInputConfig
 from bytewax.outputs import TestingOutputConfig
+from bytewax.testing import TestingClock
 from bytewax.window import TestingClockConfig, TumblingWindowConfig
 
 
 def test_tumbling_window():
+    start_at = datetime(2022, 1, 1)
+    clock = TestingClock(start_at)
+
     flow = Dataflow()
 
     def gen():
-        for _ in range(4):
-            yield ("ALL", 1)
+        yield ("ALL", 1)
+        clock.now += timedelta(seconds=4)
+        yield ("ALL", 1)
+        clock.now += timedelta(seconds=4)
+        yield ("ALL", 1)
+        # Window should close here.
+        clock.now += timedelta(seconds=4)
+        yield ("ALL", 1)
+        clock.now += timedelta(seconds=4)
 
     flow.input("inp", TestingInputConfig(gen()))
 
-    start_at = datetime(2022, 1, 1)
-    # This will result in times for events of +0, +4, +8, +12.
-    clock_config = TestingClockConfig(item_incr=timedelta(seconds=4), start_at=start_at)
-    # And since the window is +10, we should get a window with value
-    # of 3 and then 1.
+    clock_config = TestingClockConfig(clock)
     window_config = TumblingWindowConfig(
         length=timedelta(seconds=10), start_at=start_at
     )
@@ -40,47 +46,57 @@ def test_tumbling_window():
 
 
 def test_fold_window():
-    def gen():
-        yield from [
-            {"user": "a", "type": "login"},
-            {"user": "a", "type": "post"},
-            {"user": "a", "type": "post"},
-            {"user": "b", "type": "login"},
-            {"user": "a", "type": "post"},
-            {"user": "b", "type": "post"},
-            {"user": "b", "type": "post"},
-        ]
-
-    def extract_id(event):
-        return (event["user"], event)
-
-    def build():
-        return defaultdict(lambda: 0)
-
-    def count(results, event):
-        results[event["type"]] += 1
-        return results
-
     start_at = datetime(2022, 1, 1)
-    # This will result in times for events of +0, +4, +8, +12.
-    clock_config = TestingClockConfig(
-        item_incr=timedelta(seconds=4), start_at=start_at
-    )
-    # And since the window is +10, we should get a window with value
-    # of 3 and then 1.
-    window_config = TumblingWindowConfig(length=timedelta(seconds=10), start_at=start_at)
+    clock = TestingClock(start_at)
 
     flow = Dataflow()
+
+    def gen():
+        yield {"user": "a", "type": "login"}  # +0 sec
+        clock.now += timedelta(seconds=4)
+        yield {"user": "a", "type": "post"}  # +4 sec
+        clock.now += timedelta(seconds=4)
+        yield {"user": "a", "type": "post"}  # +8 sec
+        # First 10 sec window closes.
+        clock.now += timedelta(seconds=4)
+        yield {"user": "b", "type": "login"}  # +12 sec
+        clock.now += timedelta(seconds=4)
+        yield {"user": "a", "type": "post"}  # +16 sec
+        clock.now += timedelta(seconds=4)
+        # Second 10 sec window closes.
+        yield {"user": "b", "type": "post"}  # +20 sec
+        clock.now += timedelta(seconds=4)
+        yield {"user": "b", "type": "post"}  # +24 sec
+        clock.now += timedelta(seconds=4)
+
     flow.input("inp", TestingInputConfig(gen()))
-    flow.map(extract_id)
-    flow.fold_window("sum", clock_config, window_config, build, count)
+
+    def key_off_user(event):
+        return (event["user"], event["type"])
+
+    flow.map(key_off_user)
+
+    clock_config = TestingClockConfig(clock)
+    window_config = TumblingWindowConfig(
+        length=timedelta(seconds=10), start_at=start_at
+    )
+
+    def count(counts, typ):
+        if typ not in counts:
+            counts[typ] = 0
+        counts[typ] += 1
+        return counts
+
+    flow.fold_window("sum", clock_config, window_config, dict, count)
 
     out = []
     flow.capture(TestingOutputConfig(out))
 
     run_main(flow)
 
-    assert len(out) == 3
-    assert ("a", {"login": 1, "post": 2}) in out
-    assert ("a", {"post": 1}) in out
-    assert ("b", {"login": 1, "post": 2}) in out
+    assert out == [
+        ("a", {"login": 1, "post": 2}),
+        ("b", {"login": 1}),
+        ("a", {"post": 1}),
+        ("b", {"post": 2}),
+    ]

--- a/src/pyo3_extensions/mod.rs
+++ b/src/pyo3_extensions/mod.rs
@@ -164,7 +164,7 @@ impl<'de> serde::Deserialize<'de> for TdPyAny {
 // well under pyenv-virtualenv. This test executes under the global pyenv
 // version, instead of the configured virtual environment.
 // Disabling this test for aarch64, as it fails in CI.
-#[cfg(not(target_arch="aarch64"))]
+#[cfg(not(target_arch = "aarch64"))]
 #[test]
 fn test_serde() {
     use serde_test::assert_tokens;

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -50,7 +50,7 @@ pub(crate) mod testing_clock;
 pub(crate) mod tumbling_window;
 
 use self::system_clock::{SystemClock, SystemClockConfig};
-use self::testing_clock::{TestingClock, TestingClockConfig};
+use self::testing_clock::{PyTestingClock, TestingClock, TestingClockConfig};
 use self::tumbling_window::{TumblingWindowConfig, TumblingWindower};
 
 /// Base class for a clock config.
@@ -105,10 +105,9 @@ pub(crate) fn build_clock_builder<V: 'static>(
     if let Ok(testing_clock_config) = clock_config.downcast::<PyCell<TestingClockConfig>>() {
         let testing_clock_config = testing_clock_config.borrow();
 
-        let item_incr = testing_clock_config.item_incr.0;
-        let start_at = testing_clock_config.start_at.0;
+        let clock = testing_clock_config.clock.clone_ref(py);
 
-        let builder = TestingClock::builder(item_incr, start_at);
+        let builder = TestingClock::builder(clock);
         Ok(Box::new(builder))
     } else if let Ok(system_clock_config) = clock_config.downcast::<PyCell<SystemClockConfig>>() {
         let _system_clock_config = system_clock_config.borrow();
@@ -545,6 +544,7 @@ where
 pub(crate) fn register(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<ClockConfig>()?;
     m.add_class::<TestingClockConfig>()?;
+    m.add_class::<PyTestingClock>()?;
     m.add_class::<SystemClockConfig>()?;
     m.add_class::<WindowConfig>()?;
     m.add_class::<TumblingWindowConfig>()?;

--- a/src/window/testing_clock.rs
+++ b/src/window/testing_clock.rs
@@ -1,13 +1,83 @@
 use std::task::Poll;
 
-use chrono::{Duration, NaiveDateTime};
+use chrono::NaiveDateTime;
 use pyo3::{exceptions::PyValueError, prelude::*};
 
 use super::{Clock, ClockConfig};
 use crate::recovery::StateBytes;
 
-/// Use to simulate system time in tests. Increment "now" after each
-/// item.
+/// Encapsulates and allows modifyingt the "now" when using
+/// `bytewax.window.TestingClockConfig`.
+///
+/// Args:
+///
+///     init_datetime (datetime.datetime): Initial "now".
+///
+/// Returns:
+///
+///     Testing clock object. Pass this as the `clock` parameter to
+///     `bytewax.window.TestingClockConfig`.
+#[pyclass(module = "bytewax.testing", name = "TestingClock")]
+#[pyo3(text_signature = "(init_datetime)")]
+pub(crate) struct PyTestingClock {
+    /// Modify this to change the current "now".
+    #[pyo3(get, set)]
+    now: pyo3_chrono::NaiveDateTime,
+}
+
+impl PyTestingClock {
+    /// Create an "empty" [`Self`] just for use in `__getnewargs__`.
+    #[allow(dead_code)]
+    pub(crate) fn pickle_new(py: Python) -> Py<Self> {
+        PyCell::new(
+            py,
+            PyTestingClock {
+                now: pyo3_chrono::NaiveDateTime(chrono::naive::MIN_DATETIME),
+            },
+        )
+        .unwrap()
+        .into()
+    }
+}
+
+#[pymethods]
+impl PyTestingClock {
+    /// Tell pytest to ignore this class, even though it starts with
+    /// the name "Test".
+    #[allow(non_upper_case_globals)]
+    #[classattr]
+    const __test__: bool = false;
+
+    #[new]
+    #[args(init_datetime)]
+    fn new(init_datetime: pyo3_chrono::NaiveDateTime) -> Self {
+        Self { now: init_datetime }
+    }
+
+    /// Pickle as a tuple.
+    fn __getstate__(&self) -> (&str, pyo3_chrono::NaiveDateTime) {
+        ("TestingClock", self.now)
+    }
+
+    /// Egregious hack see [`SqliteRecoveryConfig::__getnewargs__`].
+    fn __getnewargs__(&self) -> (pyo3_chrono::NaiveDateTime,) {
+        (pyo3_chrono::NaiveDateTime(chrono::naive::MIN_DATETIME),)
+    }
+
+    /// Unpickle from tuple of arguments.
+    fn __setstate__(&mut self, state: &PyAny) -> PyResult<()> {
+        if let Ok(("TestingClock", now)) = state.extract() {
+            self.now = now;
+            Ok(())
+        } else {
+            Err(PyValueError::new_err(format!(
+                "bad pickle contents for TestingClock: {state:?}"
+            )))
+        }
+    }
+}
+
+/// Use to simulate system time in tests.
 ///
 /// If the dataflow has no more input, all windows are closed.
 ///
@@ -15,23 +85,18 @@ use crate::recovery::StateBytes;
 ///
 /// Args:
 ///
-///   item_incr (datetime.timedelta): Amount to increment "now"
-///       after each item.
-///
-///   start_at (datetime.datetime): Initial "now" / time of first
-///       item. If you set this and use a window config
+///   clock (TestingClock): Query this `TestingClock` for the current
+///       "now".
 ///
 /// Returns:
 ///
 ///   Config object. Pass this as the `clock_config` parameter to
 ///   your windowing operator.
 #[pyclass(module="bytewax.window", extends=ClockConfig)]
-#[pyo3(text_signature = "(item_incr)")]
+#[pyo3(text_signature = "(clock)")]
 pub(crate) struct TestingClockConfig {
     #[pyo3(get)]
-    pub(crate) item_incr: pyo3_chrono::Duration,
-    #[pyo3(get)]
-    pub(crate) start_at: pyo3_chrono::NaiveDateTime,
+    pub(crate) clock: Py<PyTestingClock>,
 }
 
 #[pymethods]
@@ -44,37 +109,24 @@ impl TestingClockConfig {
 
     #[new]
     #[args(item_incr, start_at)]
-    fn new(
-        item_incr: pyo3_chrono::Duration,
-        start_at: pyo3_chrono::NaiveDateTime,
-    ) -> (Self, ClockConfig) {
-        (
-            Self {
-                item_incr,
-                start_at,
-            },
-            ClockConfig {},
-        )
+    fn new(clock: Py<PyTestingClock>) -> (Self, ClockConfig) {
+        (Self { clock }, ClockConfig {})
     }
 
     /// Pickle as a tuple.
-    fn __getstate__(&self) -> (&str, pyo3_chrono::Duration, pyo3_chrono::NaiveDateTime) {
-        ("TestingClockConfig", self.item_incr, self.start_at)
+    fn __getstate__(&self, py: Python) -> (&str, Py<PyTestingClock>) {
+        ("TestingClockConfig", self.clock.clone_ref(py))
     }
 
     /// Egregious hack see [`SqliteRecoveryConfig::__getnewargs__`].
-    fn __getnewargs__(&self) -> (pyo3_chrono::Duration, pyo3_chrono::NaiveDateTime) {
-        (
-            pyo3_chrono::Duration(Duration::zero()),
-            pyo3_chrono::NaiveDateTime(chrono::naive::MAX_DATETIME),
-        )
+    fn __getnewargs__(&self, py: Python) -> (Py<PyTestingClock>,) {
+        (PyTestingClock::pickle_new(py),)
     }
 
     /// Unpickle from tuple of arguments.
     fn __setstate__(&mut self, state: &PyAny) -> PyResult<()> {
-        if let Ok(("TestingClockConfig", item_incr, start_at)) = state.extract() {
-            self.item_incr = item_incr;
-            self.start_at = start_at;
+        if let Ok(("TestingClockConfig", clock)) = state.extract() {
+            self.clock = clock;
             Ok(())
         } else {
             Err(PyValueError::new_err(format!(
@@ -84,24 +136,29 @@ impl TestingClockConfig {
     }
 }
 
-/// Simulate system time for tests. Increment "now" after each item.
+/// Simulate system time for tests. Call upon [`PyTestingClock`] for
+/// the current time.
 pub(crate) struct TestingClock {
-    item_incr: Duration,
-    current_time: NaiveDateTime,
+    py_clock: Py<PyTestingClock>,
 }
 
 impl TestingClock {
     pub(crate) fn builder<V>(
-        item_incr: Duration,
-        start_at: NaiveDateTime,
+        py_clock: Py<PyTestingClock>,
     ) -> impl Fn(Option<StateBytes>) -> Box<dyn Clock<V>> {
         move |resume_state_bytes: Option<StateBytes>| {
-            let current_time = resume_state_bytes.map(StateBytes::de).unwrap_or(start_at);
+            // All instances of this [`TestingClock`] will reference
+            // the same [`PyTestingClock`] so modifications increment
+            // all windows' times.
+            let py_clock = py_clock.clone();
 
-            Box::new(Self {
-                item_incr,
-                current_time,
-            })
+            if let Some(now) = resume_state_bytes.map(StateBytes::de::<NaiveDateTime>) {
+                Python::with_gil(|py| {
+                    py_clock.borrow_mut(py).now = pyo3_chrono::NaiveDateTime(now);
+                })
+            }
+
+            Box::new(Self { py_clock })
         }
     }
 }
@@ -111,51 +168,19 @@ impl<V> Clock<V> for TestingClock {
         match next_value {
             // If there will be no more values, close out all windows.
             Poll::Ready(None) => chrono::naive::MAX_DATETIME,
-            _ => self.current_time,
+            _ => Python::with_gil(|py| {
+                let py_clock = self.py_clock.borrow(py);
+                py_clock.now.0.clone()
+            }),
         }
     }
 
-    fn time_for(&mut self, _item: &V) -> NaiveDateTime {
-        let item_time = self.current_time;
-        self.current_time += self.item_incr;
-        item_time
+    fn time_for(&mut self, item: &V) -> NaiveDateTime {
+        self.watermark(&Poll::Ready(Some(item)))
     }
 
     fn snapshot(&self) -> StateBytes {
-        StateBytes::ser(&self.current_time)
+        let now = Python::with_gil(|py| self.py_clock.borrow(py).now.0);
+        StateBytes::ser::<NaiveDateTime>(&now)
     }
-}
-
-#[test]
-fn test_testing_clock() {
-    use chrono::{NaiveDate, NaiveTime};
-
-    let mut clock = TestingClock {
-        item_incr: Duration::seconds(1),
-        current_time: NaiveDateTime::new(
-            NaiveDate::from_ymd(2022, 1, 1),
-            NaiveTime::from_hms_milli(0, 0, 0, 0),
-        ),
-    };
-    assert_eq!(
-        clock.time_for(&"x"),
-        NaiveDateTime::new(
-            NaiveDate::from_ymd(2022, 1, 1),
-            NaiveTime::from_hms_milli(0, 0, 0, 0)
-        )
-    );
-    assert_eq!(
-        clock.time_for(&"y"),
-        NaiveDateTime::new(
-            NaiveDate::from_ymd(2022, 1, 1),
-            NaiveTime::from_hms_milli(0, 0, 1, 0)
-        )
-    );
-    assert_eq!(
-        clock.time_for(&"z"),
-        NaiveDateTime::new(
-            NaiveDate::from_ymd(2022, 1, 1),
-            NaiveTime::from_hms_milli(0, 0, 2, 0)
-        )
-    );
 }

--- a/src/window/testing_clock.rs
+++ b/src/window/testing_clock.rs
@@ -11,12 +11,12 @@ use crate::recovery::StateBytes;
 ///
 /// Args:
 ///
-///     init_datetime (datetime.datetime): Initial "now".
+///   init_datetime (datetime.datetime): Initial "now".
 ///
 /// Returns:
 ///
-///     Testing clock object. Pass this as the `clock` parameter to
-///     `bytewax.window.TestingClockConfig`.
+///   Testing clock object. Pass this as the `clock` parameter to
+///   `bytewax.window.TestingClockConfig`.
 #[pyclass(module = "bytewax.testing", name = "TestingClock")]
 #[pyo3(text_signature = "(init_datetime)")]
 pub(crate) struct PyTestingClock {


### PR DESCRIPTION
For more complicated windowing tests, we need more control over the
way that the `TestingClock` determines the current time. Instead of
incrementing after each item, allow you to modify the current time
Python-side.

Has the `python.window.TestingClockConfig` take a wrapper Python class
called `bytewax.testing.TestingClock` which lets you modify a
`datetime.datetime` however you need after each item of input.

Modifies our two tests to demonstrate this.
