### PR TITLE
Fixes recovery serde

### DIFF
--- a/src/inputs/kafka_input.rs
+++ b/src/inputs/kafka_input.rs
@@ -213,8 +213,8 @@ impl KafkaInput {
         worker_count: usize,
         resume_state_bytes: Option<StateBytes>,
     ) -> Self {
-        let mut positions: HashMap<KafkaPartition, KafkaPosition> = resume_state_bytes
-            .map(|resume_state_bytes| resume_state_bytes.de())
+        let mut positions = resume_state_bytes
+            .map(StateBytes::de::<HashMap<KafkaPartition, KafkaPosition>>)
             .unwrap_or_default();
 
         let eof = !tail;
@@ -310,6 +310,6 @@ impl InputReader<TdPyAny> for KafkaInput {
     }
 
     fn snapshot(&self) -> StateBytes {
-        StateBytes::ser(&self.positions)
+        StateBytes::ser::<HashMap<KafkaPartition, KafkaPosition>>(&self.positions)
     }
 }

--- a/src/inputs/manual_input.rs
+++ b/src/inputs/manual_input.rs
@@ -24,7 +24,7 @@ impl ManualInput {
         resume_state_bytes: Option<StateBytes>,
     ) -> Self {
         let resume_state: TdPyAny = resume_state_bytes
-            .map(|resume_state_bytes| resume_state_bytes.de())
+            .map(StateBytes::de::<TdPyAny>)
             .unwrap_or_else(|| py.None().into());
 
         let pyiter: TdPyCoroIterator = try_unwrap!(input_builder
@@ -60,7 +60,7 @@ impl InputReader<TdPyAny> for ManualInput {
     }
 
     fn snapshot(&self) -> StateBytes {
-        StateBytes::ser(&self.last_state)
+        StateBytes::ser::<TdPyAny>(&self.last_state)
     }
 }
 

--- a/src/operators/fold_window.rs
+++ b/src/operators/fold_window.rs
@@ -24,7 +24,9 @@ impl FoldWindowLogic {
         folder: TdPyCallable,
     ) -> impl Fn(Option<StateBytes>) -> Self {
         move |resume_acc_bytes| {
-            let acc = resume_acc_bytes.map(|resume_acc_bytes| resume_acc_bytes.de());
+            let acc = resume_acc_bytes
+                .map(StateBytes::de::<Option<TdPyAny>>)
+                .flatten();
             Python::with_gil(|py| Self {
                 builder: builder.clone_ref(py),
                 folder: folder.clone_ref(py),
@@ -61,6 +63,6 @@ impl WindowLogic<TdPyAny, TdPyAny, Option<TdPyAny>> for FoldWindowLogic {
     }
 
     fn snapshot(&self) -> StateBytes {
-        StateBytes::ser(&self.acc)
+        StateBytes::ser::<Option<TdPyAny>>(&self.acc)
     }
 }

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -28,7 +28,7 @@ impl ReduceLogic {
         is_complete: TdPyCallable,
     ) -> impl Fn(Option<StateBytes>) -> Self {
         move |resume_acc_bytes| {
-            let acc = resume_acc_bytes.map(|resume_acc_bytes| resume_acc_bytes.de());
+            let acc = resume_acc_bytes.map(StateBytes::de::<TdPyAny>);
             Python::with_gil(|py| Self {
                 reducer: reducer.clone_ref(py),
                 is_complete: is_complete.clone_ref(py),
@@ -95,7 +95,7 @@ impl StatefulLogic<TdPyAny, TdPyAny, Option<TdPyAny>> for ReduceLogic {
 
     fn snapshot(&self) -> StateUpdate {
         match &self.acc {
-            Some(acc) => StateUpdate::Upsert(StateBytes::ser(acc)),
+            Some(acc) => StateUpdate::Upsert(StateBytes::ser::<TdPyAny>(acc)),
             None => StateUpdate::Reset,
         }
     }

--- a/src/operators/reduce_window.rs
+++ b/src/operators/reduce_window.rs
@@ -20,7 +20,9 @@ pub(crate) struct ReduceWindowLogic {
 impl ReduceWindowLogic {
     pub(crate) fn builder(reducer: TdPyCallable) -> impl Fn(Option<StateBytes>) -> Self {
         move |resume_acc_bytes| {
-            let acc = resume_acc_bytes.map(|resume_acc_bytes| resume_acc_bytes.de());
+            let acc = resume_acc_bytes
+                .map(StateBytes::de::<Option<TdPyAny>>)
+                .flatten();
             Python::with_gil(|py| Self {
                 reducer: reducer.clone_ref(py),
                 acc,
@@ -60,6 +62,6 @@ impl WindowLogic<TdPyAny, TdPyAny, Option<TdPyAny>> for ReduceWindowLogic {
     }
 
     fn snapshot(&self) -> StateBytes {
-        StateBytes::ser(&self.acc)
+        StateBytes::ser::<Option<TdPyAny>>(&self.acc)
     }
 }

--- a/src/operators/stateful_map.rs
+++ b/src/operators/stateful_map.rs
@@ -29,7 +29,7 @@ impl StatefulMapLogic {
         move |resume_state_bytes| {
             let state = Some(
                 resume_state_bytes
-                    .map(|resume_state_bytes| resume_state_bytes.de())
+                    .map(StateBytes::de::<TdPyAny>)
                     .unwrap_or_else(|| {
                         Python::with_gil(|py| {
                             let initial_state: TdPyAny = unwrap_any!(builder.call1(py, ())).into();
@@ -94,7 +94,7 @@ impl StatefulLogic<TdPyAny, TdPyAny, Option<TdPyAny>> for StatefulMapLogic {
 
     fn snapshot(&self) -> StateUpdate {
         match &self.state {
-            Some(state) => StateUpdate::Upsert(StateBytes::ser(state)),
+            Some(state) => StateUpdate::Upsert(StateBytes::ser::<TdPyAny>(state)),
             None => StateUpdate::Reset,
         }
     }

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -480,15 +480,6 @@ pub(crate) enum StateUpdate {
     Reset,
 }
 
-impl<T: Serialize> From<Option<T>> for StateUpdate {
-    fn from(updated_state: Option<T>) -> Self {
-        match updated_state {
-            Some(state) => Self::Upsert(StateBytes::ser(&state)),
-            None => Self::Reset,
-        }
-    }
-}
-
 /// Impl this trait to create an operator which maintains recoverable
 /// state.
 ///

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -348,7 +348,8 @@ where
                 StateBytes,
                 StateBytes,
                 HashMap<WindowKey, StateBytes>,
-            )> = resume_state_bytes.map(|state_bytes| state_bytes.de());
+            )> = resume_state_bytes
+                .map(StateBytes::de::<(StateBytes, StateBytes, HashMap<WindowKey, StateBytes>)>);
             let (clock_resume_state_bytes, windower_resume_state_bytes, key_to_resume_state_bytes) =
                 match resume_state_bytes {
                     Some((c, w, l)) => (Some(c), Some(w), Some(l)),
@@ -450,7 +451,11 @@ where
             self.windower.snapshot(),
             window_to_logic_resume_state_bytes,
         );
-        StateUpdate::Upsert(StateBytes::ser(&state))
+        StateUpdate::Upsert(StateBytes::ser::<(
+            StateBytes,
+            StateBytes,
+            HashMap<WindowKey, StateBytes>,
+        )>(&state))
     }
 }
 

--- a/src/window/system_clock.rs
+++ b/src/window/system_clock.rs
@@ -69,6 +69,6 @@ impl<V> Clock<V> for SystemClock {
     }
 
     fn snapshot(&self) -> StateBytes {
-        StateBytes::ser(&())
+        StateBytes::ser::<()>(&())
     }
 }

--- a/src/window/tumbling_window.rs
+++ b/src/window/tumbling_window.rs
@@ -83,7 +83,9 @@ impl TumblingWindower {
         start_at: NaiveDateTime,
     ) -> impl Fn(Option<StateBytes>) -> Box<dyn Windower> {
         move |resume_state_bytes| {
-            let close_times = resume_state_bytes.map(StateBytes::de).unwrap_or_default();
+            let close_times = resume_state_bytes
+                .map(StateBytes::de::<HashMap<WindowKey, NaiveDateTime>>)
+                .unwrap_or_default();
 
             Box::new(Self {
                 length,
@@ -141,6 +143,6 @@ impl Windower for TumblingWindower {
     }
 
     fn snapshot(&self) -> StateBytes {
-        StateBytes::ser(&self.close_times)
+        StateBytes::ser::<HashMap<WindowKey, NaiveDateTime>>(&self.close_times)
     }
 }


### PR DESCRIPTION
Makes all types for recovery serialization and deserialization
explicit and fixes them to match each other for each recoverable
operator.

This will fix panics during recovery loading.

This was also fixed in https://github.com/bytewax/bytewax/pull/137/
but I'm breaking it out here separately because I keep discoverying
smaller recovery bugs and am fixing them separately.
