### PR TITLE
Better recovery tests

### DIFF
--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from bytewax.dataflow import Dataflow
 from bytewax.execution import run_main
-from bytewax.inputs import TestingInputConfig
+from bytewax.inputs import TestingBuilderInputConfig
 from bytewax.outputs import TestingOutputConfig
 from bytewax.testing import TestingClock
 from bytewax.window import TestingClockConfig, TumblingWindowConfig
@@ -15,17 +15,18 @@ def test_tumbling_window():
     flow = Dataflow()
 
     def gen():
+        clock.now = start_at  # +0 sec
         yield ("ALL", 1)
-        clock.now += timedelta(seconds=4)
+        clock.now += timedelta(seconds=4)  # +4 sec
         yield ("ALL", 1)
-        clock.now += timedelta(seconds=4)
+        clock.now += timedelta(seconds=4)  # +8 sec
         yield ("ALL", 1)
-        # Window should close here.
-        clock.now += timedelta(seconds=4)
+        clock.now += timedelta(seconds=4)  # + 12 sec
+        # First 10 second window should close just before processing this item.
         yield ("ALL", 1)
-        clock.now += timedelta(seconds=4)
+        clock.now += timedelta(seconds=4)  # +16 sec
 
-    flow.input("inp", TestingInputConfig(gen()))
+    flow.input("inp", TestingBuilderInputConfig(gen))
 
     clock_config = TestingClockConfig(clock)
     window_config = TumblingWindowConfig(
@@ -43,60 +44,3 @@ def test_tumbling_window():
     run_main(flow)
 
     assert sorted(out) == sorted([("ALL", 3), ("ALL", 1)])
-
-
-def test_fold_window():
-    start_at = datetime(2022, 1, 1)
-    clock = TestingClock(start_at)
-
-    flow = Dataflow()
-
-    def gen():
-        yield {"user": "a", "type": "login"}  # +0 sec
-        clock.now += timedelta(seconds=4)
-        yield {"user": "a", "type": "post"}  # +4 sec
-        clock.now += timedelta(seconds=4)
-        yield {"user": "a", "type": "post"}  # +8 sec
-        # First 10 sec window closes.
-        clock.now += timedelta(seconds=4)
-        yield {"user": "b", "type": "login"}  # +12 sec
-        clock.now += timedelta(seconds=4)
-        yield {"user": "a", "type": "post"}  # +16 sec
-        clock.now += timedelta(seconds=4)
-        # Second 10 sec window closes.
-        yield {"user": "b", "type": "post"}  # +20 sec
-        clock.now += timedelta(seconds=4)
-        yield {"user": "b", "type": "post"}  # +24 sec
-        clock.now += timedelta(seconds=4)
-
-    flow.input("inp", TestingInputConfig(gen()))
-
-    def key_off_user(event):
-        return (event["user"], event["type"])
-
-    flow.map(key_off_user)
-
-    clock_config = TestingClockConfig(clock)
-    window_config = TumblingWindowConfig(
-        length=timedelta(seconds=10), start_at=start_at
-    )
-
-    def count(counts, typ):
-        if typ not in counts:
-            counts[typ] = 0
-        counts[typ] += 1
-        return counts
-
-    flow.fold_window("sum", clock_config, window_config, dict, count)
-
-    out = []
-    flow.capture(TestingOutputConfig(out))
-
-    run_main(flow)
-
-    assert out == [
-        ("a", {"login": 1, "post": 2}),
-        ("b", {"login": 1}),
-        ("a", {"post": 1}),
-        ("b", {"post": 2}),
-    ]

--- a/src/inputs/kafka_input.rs
+++ b/src/inputs/kafka_input.rs
@@ -47,8 +47,8 @@ use super::{distribute, InputConfig, InputReader};
 ///
 /// Returns:
 ///
-///   Config object. Pass this as the `input_config` argument to the
-///   `bytewax.dataflow.Dataflow.input`.
+///   Config object. Pass this as the `input_config` argument of the
+///   `bytewax.dataflow.Dataflow.input` operator.
 #[pyclass(module = "bytewax.inputs", extends = InputConfig)]
 #[pyo3(text_signature = "(brokers, topic, tail, starting_offset, additional_properties)")]
 pub(crate) struct KafkaInputConfig {

--- a/src/inputs/manual_input.rs
+++ b/src/inputs/manual_input.rs
@@ -8,6 +8,70 @@ use pyo3::prelude::*;
 
 use super::{InputConfig, InputReader};
 
+/// Use a user-defined function that returns an iterable as the input
+/// source.
+///
+/// Because Bytewax's execution is cooperative, the resulting
+/// iterators _must not block_ waiting for new data, otherwise pending
+/// execution of other steps in the dataflow will be delayed an
+/// throughput will be reduced. If you are using a generator and no
+/// data is ready yet, have it `yield None` or just `yield` to signal
+/// this.
+///
+/// Args:
+///
+///   input_builder: `input_builder(worker_index: int, worker_count:
+///       int, resume_state: Option[Any]) => Iterator[Tuple[Any,
+///       Any]]` Builder function which returns an iterator of
+///       2-tuples of `(state, item)`. `item` is the input that
+///       worker should introduce into the dataflow. `state` is a
+///       snapshot of any internal state it will take to resume this
+///       input from its current position _after the current
+///       item_. Note that e.g. returning the same list from each
+///       worker will result in duplicate data in the dataflow.
+///
+/// Returns:
+///
+///   Config object. Pass this as the `input_config` argument of the
+///   `bytewax.dataflow.Dataflow.input` operator.
+#[pyclass(module = "bytewax.inputs", extends = InputConfig)]
+#[pyo3(text_signature = "(input_builder)", subclass)]
+pub(crate) struct ManualInputConfig {
+    #[pyo3(get)]
+    pub(crate) input_builder: TdPyCallable,
+}
+
+#[pymethods]
+impl ManualInputConfig {
+    #[new]
+    #[args(input_builder)]
+    pub(crate) fn new(input_builder: TdPyCallable) -> (Self, InputConfig) {
+        (Self { input_builder }, InputConfig {})
+    }
+
+    /// Pickle as a tuple.
+    fn __getstate__(&self) -> (&str, TdPyCallable) {
+        ("ManualInputConfig", self.input_builder.clone())
+    }
+
+    /// Egregious hack see [`SqliteRecoveryConfig::__getnewargs__`].
+    fn __getnewargs__(&self, py: Python) -> (TdPyCallable,) {
+        (TdPyCallable::pickle_new(py),)
+    }
+
+    /// Unpickle from tuple of arguments.
+    fn __setstate__(&mut self, state: &PyAny) -> PyResult<()> {
+        if let Ok(("ManualInputConfig", input_builder)) = state.extract() {
+            self.input_builder = input_builder;
+            Ok(())
+        } else {
+            Err(PyValueError::new_err(format!(
+                "bad pickle contents for ManualInputConfig: {state:?}"
+            )))
+        }
+    }
+}
+
 /// Construct a Python iterator for each worker from a builder
 /// function.
 pub(crate) struct ManualInput {
@@ -61,69 +125,5 @@ impl InputReader<TdPyAny> for ManualInput {
 
     fn snapshot(&self) -> StateBytes {
         StateBytes::ser::<TdPyAny>(&self.last_state)
-    }
-}
-
-/// Use a user-defined function that returns an iterable as the input
-/// source.
-///
-/// Because Bytewax's execution is cooperative, the resulting
-/// iterators _must not block_ waiting for new data, otherwise pending
-/// execution of other steps in the dataflow will be delayed an
-/// throughput will be reduced. If you are using a generator and no
-/// data is ready yet, have it `yield None` or just `yield` to signal
-/// this.
-///
-/// Args:
-///
-///   input_builder: `input_builder(worker_index: int, worker_count:
-///       int, resume_state: Option[Any]) => Iterator[Tuple[Any,
-///       Any]]` Builder function which returns an iterator of
-///       2-tuples of `(state, item)`. `item` is the input that
-///       worker should introduce into the dataflow. `state` is a
-///       snapshot of any internal state it will take to resume this
-///       input from its current position _after the current
-///       item_. Note that e.g. returning the same list from each
-///       worker will result in duplicate data in the dataflow.
-///
-/// Returns:
-///
-///   Config object. Pass this as the `input_config` argument to the
-///   `bytewax.dataflow.Dataflow.input`.
-#[pyclass(module = "bytewax.inputs", extends = InputConfig)]
-#[pyo3(text_signature = "(input_builder)", subclass)]
-pub(crate) struct ManualInputConfig {
-    #[pyo3(get)]
-    pub(crate) input_builder: TdPyCallable,
-}
-
-#[pymethods]
-impl ManualInputConfig {
-    #[new]
-    #[args(input_builder)]
-    pub(crate) fn new(input_builder: TdPyCallable) -> (Self, InputConfig) {
-        (Self { input_builder }, InputConfig {})
-    }
-
-    /// Pickle as a tuple.
-    fn __getstate__(&self) -> (&str, TdPyCallable) {
-        ("ManualInputConfig", self.input_builder.clone())
-    }
-
-    /// Egregious hack see [`SqliteRecoveryConfig::__getnewargs__`].
-    fn __getnewargs__(&self, py: Python) -> (TdPyCallable,) {
-        (TdPyCallable::pickle_new(py),)
-    }
-
-    /// Unpickle from tuple of arguments.
-    fn __setstate__(&mut self, state: &PyAny) -> PyResult<()> {
-        if let Ok(("ManualInputConfig", input_builder)) = state.extract() {
-            self.input_builder = input_builder;
-            Ok(())
-        } else {
-            Err(PyValueError::new_err(format!(
-                "bad pickle contents for ManualInputConfig: {state:?}"
-            )))
-        }
     }
 }


### PR DESCRIPTION
As part of testing the functionality of recoverable operators, we
should actually do a recovery to ensure serde is correct. This
modifies the operator tests to do that (and moves an operator test out
of `test_window` into `test_operator`).

When using `TestingClockConfig`, you have to use a generator to ensure
the input code is modifying the state of the global clock. But! We
need to make sure that the generator is re-initialized upon the second
startup of the dataflow. Otherwise, since the test is happening with a
single `Dataflow` instance and the process wasn't restarted, the
generator is half-consumed upon recovery loading and you don't get the
correct behavior. To facilitate this, adds a
`TestingBuilderInputConfig` which re-builds the generator on each
start so it'll be re-run from top to bottom.

Also fixes some minor docstring issues.

And moves `ManualInputConfig` to the top of the module source to match
all the other PyO3 containing files.
