### PR TITLE
Persist awake times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Fixes bug where window is never closed if recovery occurs after last
+  item but before window close.
+
+- Recovery logging is reduced.
+
+- Recovery format has been changed for all recovery stores. You cannot
+  resume from recovery data written with an older version.
+
 ## 0.11.2
 
 - Performance improvements.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ scopeguard = { version = "1.1.0" }
 send_wrapper = { version = "0.6.0" }
 serde = { version = "1.0.134" }
 serde_test = { version = "1.0.134" }
-sqlx = { version = "0.6.1", features = [ "runtime-tokio-rustls", "postgres", "sqlite" ] }
+sqlx = { version = "0.6.1", features = [ "runtime-tokio-rustls", "postgres", "sqlite", "chrono" ] }
 timely = { version = "0.12.0", features = [ "bincode" ] }
 tokio = { version = "1.20.1", features = [ "full" ] }
 

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -1,7 +1,5 @@
 from datetime import datetime, timedelta, timezone
 
-from pytest import mark
-
 from bytewax.dataflow import Dataflow
 from bytewax.execution import run_main
 from bytewax.inputs import TestingBuilderInputConfig
@@ -10,10 +8,6 @@ from bytewax.testing import TestingClock
 from bytewax.window import TestingClockConfig, TumblingWindowConfig
 
 
-@mark.skip(
-    "This test will not work with system time consistently until we mock the awaken "
-    "times in StatefulUnary."
-)
 def test_tumbling_window():
     start_at = datetime(2022, 1, 1, tzinfo=timezone.utc)
     clock = TestingClock(start_at)

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -39,7 +39,7 @@ use crate::operators::*;
 use crate::outputs::build_output_writer;
 use crate::outputs::capture;
 use crate::pyo3_extensions::{extract_state_pair, wrap_state_pair, TdPyAny};
-use crate::recovery::StatefulUnary;
+use crate::recovery::StateReader;
 use crate::recovery::WriteProgress;
 use crate::recovery::WriteState;
 use crate::recovery::{
@@ -52,7 +52,7 @@ use crate::recovery::{ProgressReader, StateCollector};
 use crate::recovery::{RecoveryConfig, StepId};
 use crate::recovery::{RecoveryStoreSummary, StateWriter};
 use crate::recovery::{StateBytes, StateKey};
-use crate::recovery::{StateReader, StateUpdate};
+use crate::recovery::{StateUpdateStream, StatefulUnary};
 use crate::window::{build_clock_builder, build_windower_builder, StatefulWindowUnary};
 use crate::StringResult;
 use log::debug;
@@ -177,7 +177,7 @@ fn build_source<S>(
     reader: Box<dyn InputReader<TdPyAny>>,
     start_at: S::Timestamp,
     probe: &ProbeHandle<S::Timestamp>,
-) -> StringResult<(Stream<S, TdPyAny>, Stream<S, StateUpdate<S::Timestamp>>)>
+) -> StringResult<(Stream<S, TdPyAny>, StateUpdateStream<S>)>
 where
     S: Scope<Timestamp = u64>,
 {

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -523,11 +523,7 @@ fn build_and_run_state_loading_dataflow<A: Allocate>(
 
     run_until_done(worker, interrupt_flag, probe);
 
-    let mut step_to_key_to_resume_state = HashMap::new();
-    while let Ok((step_id, key_to_resume_state_bytes)) = step_to_key_to_resume_state_rx.recv() {
-        step_to_key_to_resume_state.insert(step_id, key_to_resume_state_bytes);
-    }
-
+    let step_to_key_to_resume_state = step_to_key_to_resume_state_rx.into_iter().collect();
     let recovery_store_summary = recovery_store_summary_rx
         .recv()
         .expect("Recovery store summary not returned from loading dataflow");

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -156,7 +156,6 @@ impl IntoPy<PyObject> for WorkerIndex {
 /// determine if there's any resume state.
 fn resume_input_state(
     worker_index: WorkerIndex,
-    _worker_count: usize,
     mut key_to_resume_state: HashMap<StateKey, State>,
 ) -> (Option<StateBytes>, StateKey) {
     let key = StateKey::Worker(worker_index);
@@ -261,7 +260,6 @@ fn build_production_dataflow<A: Allocate>(
                 } => {
                     let (resume_state, recovery_key) = resume_input_state(
                         worker_index,
-                        worker_count,
                         step_to_key_to_resume_state
                             .remove(&step_id)
                             .unwrap_or_default(),

--- a/src/execution/periodic_epoch.rs
+++ b/src/execution/periodic_epoch.rs
@@ -112,14 +112,14 @@ where
                     if epoch_started.elapsed() > epoch_length {
                         // Snapshot just before incrementing epoch to
                         // get the "end of the epoch state".
-                        let state_bytes = reader.snapshot();
+                        let snapshot = reader.snapshot();
                         let recovery_key = StateRecoveryKey {
                             step_id: step_id.clone(),
                             state_key: state_key.clone(),
                             epoch: epoch.clone(),
                         };
                         let op = StateOp::Upsert(State {
-                            state_bytes,
+                            snapshot,
                             next_awake: None,
                         });
                         let update = StateUpdate(recovery_key, op);

--- a/src/execution/periodic_epoch.rs
+++ b/src/execution/periodic_epoch.rs
@@ -12,9 +12,9 @@ use timely::dataflow::Stream;
 use timely::Data;
 
 use crate::inputs::InputReader;
-use crate::recovery::StateRecoveryKey;
 use crate::recovery::{State, StateOp, StepId};
 use crate::recovery::{StateKey, StateUpdate};
+use crate::recovery::{StateRecoveryKey, StateUpdateStream};
 
 use super::EpochConfig;
 
@@ -80,7 +80,7 @@ pub(crate) fn periodic_epoch_source<S, D>(
     start_at: S::Timestamp,
     probe: &ProbeHandle<S::Timestamp>,
     epoch_length: Duration,
-) -> (Stream<S, D>, Stream<S, StateUpdate<S::Timestamp>>)
+) -> (Stream<S, D>, StateUpdateStream<S>)
 where
     S: Scope<Timestamp = u64>,
     D: Data + Debug,

--- a/src/execution/testing_epoch.rs
+++ b/src/execution/testing_epoch.rs
@@ -111,14 +111,14 @@ where
 
                             // Snapshot just before incrementing epoch
                             // to get the "end of the epoch" state.
-                            let state_bytes = reader.snapshot();
+                            let snapshot = reader.snapshot();
                             let recovery_key = StateRecoveryKey {
                                 step_id: step_id.clone(),
                                 state_key: state_key.clone(),
                                 epoch: epoch.clone(),
                             };
                             let op = StateOp::Upsert(State {
-                                state_bytes,
+                                snapshot,
                                 next_awake: None,
                             });
                             let update = StateUpdate(recovery_key, op);

--- a/src/execution/testing_epoch.rs
+++ b/src/execution/testing_epoch.rs
@@ -10,7 +10,9 @@ use timely::{
 
 use crate::{
     inputs::InputReader,
-    recovery::{State, StateKey, StateOp, StateRecoveryKey, StateUpdate, StepId},
+    recovery::{
+        State, StateKey, StateOp, StateRecoveryKey, StateUpdate, StateUpdateStream, StepId,
+    },
 };
 
 use super::EpochConfig;
@@ -71,7 +73,7 @@ pub(crate) fn testing_epoch_source<S, D>(
     mut reader: Box<dyn InputReader<D>>,
     start_at: S::Timestamp,
     probe: &ProbeHandle<S::Timestamp>,
-) -> (Stream<S, D>, Stream<S, StateUpdate<S::Timestamp>>)
+) -> (Stream<S, D>, StateUpdateStream<S>)
 where
     S: Scope<Timestamp = u64>,
     D: Data + Debug,

--- a/src/execution/testing_epoch.rs
+++ b/src/execution/testing_epoch.rs
@@ -10,7 +10,7 @@ use timely::{
 
 use crate::{
     inputs::InputReader,
-    recovery::{EpochData, StateKey, StateUpdate, StepId},
+    recovery::{State, StateKey, StateOp, StateRecoveryKey, StateUpdate, StepId},
 };
 
 use super::EpochConfig;
@@ -64,14 +64,18 @@ impl TestingEpochConfig {
 }
 
 /// Input source that increments the epoch after each item.
-pub(crate) fn testing_epoch_source<S: Scope<Timestamp = u64>, D: Data + Debug>(
+pub(crate) fn testing_epoch_source<S, D>(
     scope: &S,
     step_id: StepId,
-    key: StateKey,
+    state_key: StateKey,
     mut reader: Box<dyn InputReader<D>>,
     start_at: S::Timestamp,
     probe: &ProbeHandle<S::Timestamp>,
-) -> (Stream<S, D>, Stream<S, EpochData>) {
+) -> (Stream<S, D>, Stream<S, StateUpdate<S::Timestamp>>)
+where
+    S: Scope<Timestamp = u64>,
+    D: Data + Debug,
+{
     let mut op_builder = OperatorBuilder::new(format!("{step_id}"), scope.clone());
 
     let (mut output_wrapper, output_stream) = op_builder.new_output();
@@ -106,10 +110,16 @@ pub(crate) fn testing_epoch_source<S: Scope<Timestamp = u64>, D: Data + Debug>(
                             // Snapshot just before incrementing epoch
                             // to get the "end of the epoch" state.
                             let state_bytes = reader.snapshot();
-                            let update = (
-                                key.clone(),
-                                (step_id.clone(), StateUpdate::Upsert(state_bytes)),
-                            );
+                            let recovery_key = StateRecoveryKey {
+                                step_id: step_id.clone(),
+                                state_key: state_key.clone(),
+                                epoch: epoch.clone(),
+                            };
+                            let op = StateOp::Upsert(State {
+                                state_bytes,
+                                next_awake: None,
+                            });
+                            let update = StateUpdate(recovery_key, op);
                             state_update_wrapper
                                 .activate()
                                 .session(&state_update_cap)

--- a/src/inputs/kafka_input.rs
+++ b/src/inputs/kafka_input.rs
@@ -15,6 +15,7 @@ use rdkafka::{Offset, TopicPartitionList};
 
 use serde::{Deserialize, Serialize};
 
+use crate::execution::WorkerIndex;
 use crate::pyo3_extensions::TdPyAny;
 use crate::recovery::StateBytes;
 
@@ -209,7 +210,7 @@ impl KafkaInput {
         tail: bool,
         starting_offset: Offset,
         additional_properties: &Option<HashMap<String, String>>,
-        worker_index: usize,
+        worker_index: WorkerIndex,
         worker_count: usize,
         resume_state_bytes: Option<StateBytes>,
     ) -> Self {
@@ -243,7 +244,7 @@ impl KafkaInput {
         }
 
         let mut partitions = TopicPartitionList::new();
-        for partition in distribute(0..partition_count, worker_index, worker_count) {
+        for partition in distribute(0..partition_count, worker_index.0, worker_count) {
             let partition = KafkaPartition(partition);
             let resume_offset: Option<Offset> =
                 (*positions.entry(partition).or_insert(KafkaPosition::Default)).into();

--- a/src/inputs/kafka_input.rs
+++ b/src/inputs/kafka_input.rs
@@ -212,9 +212,9 @@ impl KafkaInput {
         additional_properties: &Option<HashMap<String, String>>,
         worker_index: WorkerIndex,
         worker_count: usize,
-        resume_state_bytes: Option<StateBytes>,
+        resume_snapshot: Option<StateBytes>,
     ) -> Self {
-        let mut positions = resume_state_bytes
+        let mut positions = resume_snapshot
             .map(StateBytes::de::<HashMap<KafkaPartition, KafkaPosition>>)
             .unwrap_or_default();
 

--- a/src/inputs/manual_input.rs
+++ b/src/inputs/manual_input.rs
@@ -1,5 +1,6 @@
 use std::task::Poll;
 
+use crate::execution::WorkerIndex;
 use crate::pyo3_extensions::{TdPyAny, TdPyCallable, TdPyCoroIterator};
 use crate::recovery::StateBytes;
 use crate::{py_unwrap, try_unwrap};
@@ -83,7 +84,7 @@ impl ManualInput {
     pub(crate) fn new(
         py: Python,
         input_builder: TdPyCallable,
-        worker_index: usize,
+        worker_index: WorkerIndex,
         worker_count: usize,
         resume_state_bytes: Option<StateBytes>,
     ) -> Self {

--- a/src/inputs/manual_input.rs
+++ b/src/inputs/manual_input.rs
@@ -86,9 +86,9 @@ impl ManualInput {
         input_builder: TdPyCallable,
         worker_index: WorkerIndex,
         worker_count: usize,
-        resume_state_bytes: Option<StateBytes>,
+        resume_snapshot: Option<StateBytes>,
     ) -> Self {
-        let resume_state: TdPyAny = resume_state_bytes
+        let resume_state: TdPyAny = resume_snapshot
             .map(StateBytes::de::<TdPyAny>)
             .unwrap_or_else(|| py.None().into());
 

--- a/src/inputs/mod.rs
+++ b/src/inputs/mod.rs
@@ -20,6 +20,7 @@
 //! want. E.g. [`KafkaInputConfig`] represents a token in Python for
 //! how to create a [`KafkaInput`].
 
+use crate::execution::WorkerIndex;
 use crate::pyo3_extensions::TdPyAny;
 use crate::recovery::StateBytes;
 use crate::StringResult;
@@ -108,7 +109,7 @@ pub(crate) trait InputReader<D> {
 pub(crate) fn build_input_reader(
     py: Python,
     config: Py<InputConfig>,
-    worker_index: usize,
+    worker_index: WorkerIndex,
     worker_count: usize,
     resume_state_bytes: Option<StateBytes>,
 ) -> StringResult<Box<dyn InputReader<TdPyAny>>> {

--- a/src/inputs/mod.rs
+++ b/src/inputs/mod.rs
@@ -111,7 +111,7 @@ pub(crate) fn build_input_reader(
     config: Py<InputConfig>,
     worker_index: WorkerIndex,
     worker_count: usize,
-    resume_state_bytes: Option<StateBytes>,
+    resume_snapshot: Option<StateBytes>,
 ) -> StringResult<Box<dyn InputReader<TdPyAny>>> {
     // See comment in [`crate::recovery::build_recovery_writers`]
     // about releasing the GIL during IO class building.
@@ -129,7 +129,7 @@ pub(crate) fn build_input_reader(
             input_builder,
             worker_index,
             worker_count,
-            resume_state_bytes,
+            resume_snapshot,
         );
 
         Ok(Box::new(reader))
@@ -157,7 +157,7 @@ pub(crate) fn build_input_reader(
                 additional_properties,
                 worker_index,
                 worker_count,
-                resume_state_bytes,
+                resume_snapshot,
             ))
         });
 

--- a/src/operators/fold_window.rs
+++ b/src/operators/fold_window.rs
@@ -24,9 +24,7 @@ impl FoldWindowLogic {
         folder: TdPyCallable,
     ) -> impl Fn(Option<StateBytes>) -> Self {
         move |resume_snapshot| {
-            let acc = resume_snapshot
-                .map(StateBytes::de::<Option<TdPyAny>>)
-                .flatten();
+            let acc = resume_snapshot.and_then(StateBytes::de::<Option<TdPyAny>>);
             Python::with_gil(|py| Self {
                 builder: builder.clone_ref(py),
                 folder: folder.clone_ref(py),

--- a/src/operators/fold_window.rs
+++ b/src/operators/fold_window.rs
@@ -23,8 +23,8 @@ impl FoldWindowLogic {
         builder: TdPyCallable,
         folder: TdPyCallable,
     ) -> impl Fn(Option<StateBytes>) -> Self {
-        move |resume_state| {
-            let acc = resume_state
+        move |resume_snapshot| {
+            let acc = resume_snapshot
                 .map(StateBytes::de::<Option<TdPyAny>>)
                 .flatten();
             Python::with_gil(|py| Self {

--- a/src/operators/fold_window.rs
+++ b/src/operators/fold_window.rs
@@ -23,8 +23,8 @@ impl FoldWindowLogic {
         builder: TdPyCallable,
         folder: TdPyCallable,
     ) -> impl Fn(Option<StateBytes>) -> Self {
-        move |resume_acc_bytes| {
-            let acc = resume_acc_bytes
+        move |resume_state| {
+            let acc = resume_state
                 .map(StateBytes::de::<Option<TdPyAny>>)
                 .flatten();
             Python::with_gil(|py| Self {

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -28,8 +28,8 @@ impl ReduceLogic {
         reducer: TdPyCallable,
         is_complete: TdPyCallable,
     ) -> impl Fn(Option<StateBytes>) -> Self {
-        move |resume_acc_bytes| {
-            let acc = resume_acc_bytes
+        move |resume_state| {
+            let acc = resume_state
                 .map(StateBytes::de::<Option<TdPyAny>>)
                 .flatten();
             Python::with_gil(|py| Self {

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -29,9 +29,7 @@ impl ReduceLogic {
         is_complete: TdPyCallable,
     ) -> impl Fn(Option<StateBytes>) -> Self {
         move |resume_snapshot| {
-            let acc = resume_snapshot
-                .map(StateBytes::de::<Option<TdPyAny>>)
-                .flatten();
+            let acc = resume_snapshot.and_then(StateBytes::de::<Option<TdPyAny>>);
             Python::with_gil(|py| Self {
                 reducer: reducer.clone_ref(py),
                 is_complete: is_complete.clone_ref(py),

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -28,8 +28,8 @@ impl ReduceLogic {
         reducer: TdPyCallable,
         is_complete: TdPyCallable,
     ) -> impl Fn(Option<StateBytes>) -> Self {
-        move |resume_state| {
-            let acc = resume_state
+        move |resume_snapshot| {
+            let acc = resume_snapshot
                 .map(StateBytes::de::<Option<TdPyAny>>)
                 .flatten();
             Python::with_gil(|py| Self {

--- a/src/operators/reduce_window.rs
+++ b/src/operators/reduce_window.rs
@@ -19,8 +19,8 @@ pub(crate) struct ReduceWindowLogic {
 
 impl ReduceWindowLogic {
     pub(crate) fn builder(reducer: TdPyCallable) -> impl Fn(Option<StateBytes>) -> Self {
-        move |resume_state| {
-            let acc = resume_state
+        move |resume_snapshot| {
+            let acc = resume_snapshot
                 .map(StateBytes::de::<Option<TdPyAny>>)
                 .flatten();
             Python::with_gil(|py| Self {

--- a/src/operators/reduce_window.rs
+++ b/src/operators/reduce_window.rs
@@ -20,9 +20,7 @@ pub(crate) struct ReduceWindowLogic {
 impl ReduceWindowLogic {
     pub(crate) fn builder(reducer: TdPyCallable) -> impl Fn(Option<StateBytes>) -> Self {
         move |resume_snapshot| {
-            let acc = resume_snapshot
-                .map(StateBytes::de::<Option<TdPyAny>>)
-                .flatten();
+            let acc = resume_snapshot.and_then(StateBytes::de::<Option<TdPyAny>>);
             Python::with_gil(|py| Self {
                 reducer: reducer.clone_ref(py),
                 acc,

--- a/src/operators/reduce_window.rs
+++ b/src/operators/reduce_window.rs
@@ -19,8 +19,8 @@ pub(crate) struct ReduceWindowLogic {
 
 impl ReduceWindowLogic {
     pub(crate) fn builder(reducer: TdPyCallable) -> impl Fn(Option<StateBytes>) -> Self {
-        move |resume_acc_bytes| {
-            let acc = resume_acc_bytes
+        move |resume_state| {
+            let acc = resume_state
                 .map(StateBytes::de::<Option<TdPyAny>>)
                 .flatten();
             Python::with_gil(|py| Self {

--- a/src/operators/stateful_map.rs
+++ b/src/operators/stateful_map.rs
@@ -27,8 +27,8 @@ impl StatefulMapLogic {
         builder: TdPyCallable,
         mapper: TdPyCallable,
     ) -> impl Fn(Option<StateBytes>) -> Self {
-        move |resume_state| {
-            let state = resume_state
+        move |resume_snapshot| {
+            let state = resume_snapshot
                 .map(StateBytes::de::<Option<TdPyAny>>)
                 .unwrap_or_else(|| {
                     Python::with_gil(|py| {

--- a/src/operators/stateful_map.rs
+++ b/src/operators/stateful_map.rs
@@ -27,8 +27,8 @@ impl StatefulMapLogic {
         builder: TdPyCallable,
         mapper: TdPyCallable,
     ) -> impl Fn(Option<StateBytes>) -> Self {
-        move |resume_state_bytes| {
-            let state = resume_state_bytes
+        move |resume_state| {
+            let state = resume_state
                 .map(StateBytes::de::<Option<TdPyAny>>)
                 .unwrap_or_else(|| {
                     Python::with_gil(|py| {

--- a/src/outputs/manual_epoch_output.rs
+++ b/src/outputs/manual_epoch_output.rs
@@ -1,4 +1,5 @@
 use crate::{
+    execution::WorkerIndex,
     pyo3_extensions::{TdPyAny, TdPyCallable},
     unwrap_any,
 };
@@ -71,7 +72,7 @@ impl ManualEpochOutput {
     pub(crate) fn new(
         py: Python,
         output_builder: TdPyCallable,
-        worker_index: usize,
+        worker_index: WorkerIndex,
         worker_count: usize,
     ) -> Self {
         let pyfunc: TdPyCallable = output_builder

--- a/src/outputs/manual_output.rs
+++ b/src/outputs/manual_output.rs
@@ -1,6 +1,7 @@
 use pyo3::{exceptions::PyValueError, prelude::*};
 
 use crate::{
+    execution::WorkerIndex,
     pyo3_extensions::{TdPyAny, TdPyCallable},
     unwrap_any,
 };
@@ -68,7 +69,7 @@ impl ManualOutput {
     pub(crate) fn new(
         py: Python,
         output_builder: TdPyCallable,
-        worker_index: usize,
+        worker_index: WorkerIndex,
         worker_count: usize,
     ) -> Self {
         let pyfunc: TdPyCallable = output_builder

--- a/src/outputs/mod.rs
+++ b/src/outputs/mod.rs
@@ -15,6 +15,7 @@
 //! want. E.g. [`StdOutputConfig`] represents a token in Python for
 //! how to create a [`StdOutput`].
 
+use crate::execution::WorkerIndex;
 use crate::{pyo3_extensions::TdPyAny, StringResult};
 use pyo3::{exceptions::PyValueError, prelude::*};
 use send_wrapper::SendWrapper;
@@ -80,7 +81,7 @@ pub(crate) trait OutputWriter<T, D> {
 pub(crate) fn build_output_writer(
     py: Python,
     config: Py<OutputConfig>,
-    worker_index: usize,
+    worker_index: WorkerIndex,
     worker_count: usize,
 ) -> StringResult<Box<dyn OutputWriter<u64, TdPyAny>>> {
     // See comment in [`crate::recovery::build_recovery_writers`]

--- a/src/pyo3_extensions/mod.rs
+++ b/src/pyo3_extensions/mod.rs
@@ -224,17 +224,17 @@ pub(crate) fn extract_state_pair(key_value_pytuple: TdPyAny) -> (StateKey, TdPyA
             key_value_pytuple.extract(py),
             format!(
                 "Dataflow requires a `(key, value)` 2-tuple as input to \
-                    every stateful operator; got `{key_value_pytuple:?}` instead"
+                    every stateful operator for routing; got `{key_value_pytuple:?}` instead"
             )
         );
-        let key: String = py_unwrap!(
+        let key: StateKey = py_unwrap!(
             key.extract(py),
             format!(
-                "Stateful logic functions must return string keys \
+                "Stateful logic functions must return string or integer keys \
                     in `(key, value)`; got `{key:?}` instead"
             )
         );
-        (StateKey::Hash(key), value)
+        (key, value)
     })
 }
 

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -1254,7 +1254,7 @@ where
         &self,
         step_id: StepId,
         logic_builder: LB,
-        key_to_resume_state: HashMap<StateKey, State>,
+        resume_state: HashMap<StateKey, State>,
     ) -> (StatefulStream<S, R>, StateUpdateStream<S>)
     where
         R: Data,                                   // Output value type

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -1313,22 +1313,16 @@ where
             // awake time.
             let mut current_next_awake: HashMap<StateKey, DateTime<Utc>> = HashMap::new();
 
-            for (
-                key,
-                State {
+            for (key, state) in resume_state {
+                let State {
                     snapshot,
                     next_awake,
-                },
-            ) in resume_state
-            {
+                } = state;
                 current_logic.insert(key.clone(), logic_builder(Some(snapshot)));
-                match next_awake {
-                    Some(next_awake) => {
-                        current_next_awake.insert(key.clone(), next_awake);
-                    }
-                    None => {
-                        current_next_awake.remove(&key);
-                    }
+                if let Some(next_awake) = next_awake {
+                    current_next_awake.insert(key.clone(), next_awake);
+                } else {
+                    current_next_awake.remove(&key);
                 }
             }
 
@@ -1552,16 +1546,14 @@ where
                                         let snapshot = logic.snapshot();
                                         let next_awake = logic.next_awake();
 
-                                        current_logic.insert(state_key.clone(), logic);
-                                        match next_awake {
-                                            Some(next_awake) => {
-                                                current_next_awake
-                                                    .insert(state_key.clone(), next_awake);
-                                            }
-                                            None => {
-                                                current_next_awake.remove(&state_key);
-                                            }
+                                        if let Some(next_awake) = next_awake {
+                                            current_next_awake
+                                                .insert(state_key.clone(), next_awake);
+                                        } else {
+                                            current_next_awake.remove(&state_key);
                                         }
+
+                                        current_logic.insert(state_key.clone(), logic);
 
                                         StateOp::Upsert(State {
                                             snapshot,

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -1101,11 +1101,11 @@ where
 
                 // Tell the notificator to trigger on dataflow
                 // frontier advance.
-                dataflow_frontier_input.for_each(|cap, incomfing| {
+                dataflow_frontier_input.for_each(|cap, incoming| {
                     assert!(tmp_incoming_frontier.is_empty());
                     // Drain the dataflow frontier input so the
                     // frontier advances.
-                    incomfing.swap(&mut tmp_incoming_frontier);
+                    incoming.swap(&mut tmp_incoming_frontier);
                     tmp_incoming_frontier.drain(..);
 
                     fncater.notify_at(cap.retain());

--- a/src/recovery/sqlite.rs
+++ b/src/recovery/sqlite.rs
@@ -4,11 +4,10 @@ use std::path::PathBuf;
 
 use futures::StreamExt;
 use log::debug;
+use log::trace;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-use serde::Deserialize;
-use serde::Serialize;
 use sqlx::encode::IsNull;
 use sqlx::error::BoxDynError;
 use sqlx::query;
@@ -26,18 +25,25 @@ use sqlx::SqliteConnection;
 use sqlx::Type;
 use tokio::runtime::Runtime;
 
-use super::FrontierBackup;
+use crate::recovery::Progress;
+use crate::recovery::ProgressOp;
+use crate::recovery::ProgressRecoveryKey;
+use crate::recovery::State;
+use crate::recovery::StateOp;
+
 use super::ProgressReader;
+use super::ProgressUpdate;
 use super::ProgressWriter;
 use super::RecoveryConfig;
-use super::StateBackup;
+use super::StateBytes;
 use super::StateCollector;
 use super::StateKey;
 use super::StateReader;
+use super::StateRecoveryKey;
 use super::StateUpdate;
 use super::StateWriter;
 use super::StepId;
-use super::{from_bytes, to_bytes, RecoveryKey};
+use super::WorkerIndex;
 
 /// Use [SQLite](https://sqlite.org/index.html) to store recovery
 /// data.
@@ -152,7 +158,7 @@ impl SqliteStateWriter {
         // because this value is not from items in the dataflow
         // stream, but from the config which should be under
         // developer control.
-        let sql = format!("CREATE TABLE IF NOT EXISTS {table_name} (step_id, key, epoch INTEGER, state, PRIMARY KEY (step_id, key, epoch));");
+        let sql = format!("CREATE TABLE IF NOT EXISTS {table_name} (step_id TEXT, state_key TEXT, epoch INTEGER, state_bytes BLOB, next_awake TEXT, PRIMARY KEY (step_id, state_key, epoch));");
         let future = query(&sql).execute(&mut conn);
         rt.block_on(future).unwrap();
 
@@ -191,107 +197,150 @@ impl<'r> Decode<'r, Sqlite> for StepId {
 
 impl Type<Sqlite> for StateKey {
     fn type_info() -> SqliteTypeInfo {
-        <&[u8] as Type<Sqlite>>::type_info()
+        <String as Type<Sqlite>>::type_info()
     }
 }
 
+/// sqlx doesn't support the fact that SQLite lets you have weakly
+/// typed columns, so we can't store an int when it's worker index
+/// (for input component state) and a string when it's a generic
+/// hash. Instead do a light "encoding" of the type. We could break
+/// out full serde JSON for this, but it seems like overkill and would
+/// make querying the table via SQL harder.
 impl<'q> Encode<'q, Sqlite> for StateKey {
     fn encode_by_ref(&self, args: &mut Vec<SqliteArgumentValue<'q>>) -> IsNull {
-        let bytes = to_bytes(self);
-        args.push(SqliteArgumentValue::Blob(Cow::Owned(bytes)));
+        let value = match self {
+            Self::Hash(string) => {
+                format!("H:{string}")
+            }
+            Self::Worker(worker_index) => {
+                format!("W:{}", worker_index.0)
+            }
+        };
+        args.push(SqliteArgumentValue::Text(Cow::Owned(value)));
         IsNull::No
     }
 }
 
 impl<'r> Decode<'r, Sqlite> for StateKey {
     fn decode(value: SqliteValueRef<'r>) -> Result<Self, BoxDynError> {
-        let value = <&[u8] as Decode<Sqlite>>::decode(value)?;
-        Ok(from_bytes(value))
+        let value = <String as Decode<Sqlite>>::decode(value)?;
+        if let Some(string) = value.strip_prefix("H:") {
+            Ok(Self::Hash(string.to_string()))
+        } else if let Some(worker_index_str) = value.strip_prefix("W:") {
+            Ok(Self::Worker(WorkerIndex(worker_index_str.parse()?)))
+        } else {
+            panic!("Un-parseable state_key: {value:?}");
+        }
     }
 }
 
-impl Type<Sqlite> for StateUpdate {
+impl Type<Sqlite> for StateBytes {
     fn type_info() -> SqliteTypeInfo {
-        <&[u8] as Type<Sqlite>>::type_info()
+        <Vec<u8> as Type<Sqlite>>::type_info()
     }
 }
 
-impl<'q> Encode<'q, Sqlite> for StateUpdate {
+impl<'q> Encode<'q, Sqlite> for StateBytes {
+    fn encode(self, args: &mut Vec<SqliteArgumentValue<'q>>) -> IsNull {
+        args.push(SqliteArgumentValue::Blob(Cow::Owned(self.0)));
+        IsNull::No
+    }
+
     fn encode_by_ref(&self, args: &mut Vec<SqliteArgumentValue<'q>>) -> IsNull {
-        let bytes = to_bytes(self);
-        args.push(SqliteArgumentValue::Blob(Cow::Owned(bytes)));
+        args.push(SqliteArgumentValue::Blob(Cow::Owned(self.0.clone())));
         IsNull::No
     }
 }
 
-impl<'r> Decode<'r, Sqlite> for StateUpdate {
+impl<'r> Decode<'r, Sqlite> for StateBytes {
     fn decode(value: SqliteValueRef<'r>) -> Result<Self, BoxDynError> {
-        let value = <&[u8] as Decode<Sqlite>>::decode(value)?;
-        Ok(from_bytes(value))
+        let value = <Vec<u8> as Decode<Sqlite>>::decode(value)?;
+        Ok(Self(value))
     }
 }
 
-impl<T> Type<Sqlite> for FrontierBackup<T> {
+impl Type<Sqlite> for WorkerIndex {
     fn type_info() -> SqliteTypeInfo {
-        <&[u8] as Type<Sqlite>>::type_info()
+        // For some reason this does not like using i64 /
+        // SqliteArgumentValue::Int64. We get a similar error to
+        // https://github.com/launchbadge/sqlx/issues/2093. Maybe
+        // SQLite bug?
+        <i32 as Type<Sqlite>>::type_info()
     }
 }
 
-impl<'q, T: Serialize> Encode<'q, Sqlite> for FrontierBackup<T> {
+impl<'q> Encode<'q, Sqlite> for WorkerIndex {
     fn encode_by_ref(&self, args: &mut Vec<SqliteArgumentValue<'q>>) -> IsNull {
-        let bytes = to_bytes(self);
-        args.push(SqliteArgumentValue::Blob(Cow::Owned(bytes)));
+        args.push(SqliteArgumentValue::Int(self.0 as i32));
         IsNull::No
     }
 }
 
-impl<'r, T: Deserialize<'r>> Decode<'r, Sqlite> for FrontierBackup<T> {
+impl<'r> Decode<'r, Sqlite> for WorkerIndex {
     fn decode(value: SqliteValueRef<'r>) -> Result<Self, BoxDynError> {
-        let value = <&[u8] as Decode<Sqlite>>::decode(value)?;
-        Ok(from_bytes(value))
+        let value = <i32 as Decode<Sqlite>>::decode(value)?;
+        Ok(Self(value as usize))
     }
 }
 
 impl StateWriter<u64> for SqliteStateWriter {
-    fn write(&mut self, backup: &StateBackup<u64>) {
-        let StateBackup(recovery_key, state_update) = backup;
-        let RecoveryKey(step_id, key, epoch) = recovery_key;
-        let sql = format!("INSERT INTO {} (step_id, key, epoch, state) VALUES (?1, ?2, ?3, ?4) ON CONFLICT (step_id, key, epoch) DO UPDATE SET state = EXCLUDED.state", self.table_name);
+    fn write(&mut self, update: &StateUpdate<u64>) {
+        let StateUpdate(recovery_key, op) = update;
+        let StateRecoveryKey {
+            step_id,
+            state_key,
+            epoch,
+        } = recovery_key;
+        let (state_bytes, next_awake) = match op {
+            StateOp::Upsert(State {
+                state_bytes,
+                next_awake,
+            }) => (Some(state_bytes), next_awake.as_ref()),
+            StateOp::Discard => (None, None),
+        };
+
+        let sql = format!("INSERT INTO {} (step_id, state_key, epoch, state_bytes, next_awake) VALUES (?1, ?2, ?3, ?4, ?5) ON CONFLICT (step_id, state_key, epoch) DO UPDATE SET state_bytes = EXCLUDED.state_bytes, next_awake = EXCLUDED.next_awake", self.table_name);
         let future = query(&sql)
             .bind(step_id)
-            .bind(key)
+            .bind(state_key)
             .bind(<u64 as TryInto<i64>>::try_into(*epoch).expect("epoch can't fit into SQLite int"))
             // Remember, reset state is stored as an explicit NULL in the
             // DB.
-            .bind(state_update)
+            .bind(state_bytes)
+            .bind(next_awake)
             .execute(&mut self.conn);
         self.rt.block_on(future).unwrap();
 
-        debug!("sqlite state write backup={backup:?}");
+        trace!("Wrote state update {update:?}");
     }
 }
 
 impl StateCollector<u64> for SqliteStateWriter {
-    fn delete(&mut self, recovery_key: &RecoveryKey<u64>) {
-        let RecoveryKey(step_id, key, epoch) = recovery_key;
+    fn delete(&mut self, recovery_key: &StateRecoveryKey<u64>) {
+        let StateRecoveryKey {
+            step_id,
+            state_key,
+            epoch,
+        } = recovery_key;
         let sql = format!(
-            "DELETE FROM {} WHERE step_id = ?1 AND key = ?2 AND epoch = ?3",
+            "DELETE FROM {} WHERE step_id = ?1 AND state_key = ?2 AND epoch = ?3",
             self.table_name
         );
         let future = query(&sql)
             .bind(step_id)
-            .bind(key)
+            .bind(state_key)
             .bind(<u64 as TryInto<i64>>::try_into(*epoch).expect("epoch can't fit into SQLite int"))
             .execute(&mut self.conn);
         self.rt.block_on(future).unwrap();
 
-        debug!("sqlite state delete recovery_key={recovery_key:?}");
+        trace!("Deleted state for {recovery_key:?}");
     }
 }
 
 pub(crate) struct SqliteStateReader {
     rt: Runtime,
-    rx: tokio::sync::mpsc::Receiver<StateBackup<u64>>,
+    rx: tokio::sync::mpsc::Receiver<StateUpdate<u64>>,
 }
 
 impl SqliteStateReader {
@@ -306,24 +355,32 @@ impl SqliteStateReader {
         let (tx, rx) = tokio::sync::mpsc::channel(1);
 
         rt.spawn(async move {
-            let sql =
-                format!("SELECT step_id, key, epoch, state FROM {table_name} ORDER BY epoch ASC");
+            let sql = format!(
+                "SELECT step_id, state_key, epoch, state_bytes, next_awake FROM {table_name} ORDER BY epoch ASC"
+            );
             let mut stream = query(&sql)
                 .map(|row: SqliteRow| {
-                    let recovery_key = RecoveryKey(
-                        row.get(0),
-                        row.get(1),
-                        row.get::<i64, _>(2)
+                    let recovery_key = StateRecoveryKey {
+                        step_id: row.get(0),
+                        state_key: row.get(1),
+                        epoch: row
+                            .get::<i64, _>(2)
                             .try_into()
                             .expect("SQLite int can't fit into epoch; might be negative"),
-                    );
-                    StateBackup(recovery_key, row.get(3))
+                    };
+                    let op = match (row.get(3), row.get(4)) {
+                        (None, Some(_)) => panic!("Missing state_bytes in reading state SQLite table"),
+                        (Some(state_bytes), next_awake) => StateOp::Upsert(State { state_bytes, next_awake }),
+                        (None, None) => StateOp::Discard,
+                    };
+                    StateUpdate(recovery_key, op)
                 })
                 .fetch(&mut conn)
                 .map(|result| result.expect("Error selecting from SQLite"));
 
-            while let Some(backup) = stream.next().await {
-                tx.send(backup).await.unwrap();
+            while let Some(update) = stream.next().await {
+                trace!("Read state update {update:?}");
+                tx.send(update).await.unwrap();
             }
         });
 
@@ -332,7 +389,7 @@ impl SqliteStateReader {
 }
 
 impl StateReader<u64> for SqliteStateReader {
-    fn read(&mut self) -> Option<StateBackup<u64>> {
+    fn read(&mut self) -> Option<StateUpdate<u64>> {
         self.rt.block_on(self.rx.recv())
     }
 }
@@ -358,7 +415,9 @@ impl SqliteProgressWriter {
         let mut conn = rt.block_on(future).unwrap();
         debug!("Opened Sqlite connection to {db_file:?}");
 
-        let sql = format!("CREATE TABLE IF NOT EXISTS {table_name} (name PRIMARY KEY, antichain);");
+        let sql = format!(
+            "CREATE TABLE IF NOT EXISTS {table_name} (worker_index INTEGER PRIMARY KEY, frontier INTEGER);"
+        );
         let future = query(&sql).execute(&mut conn);
         rt.block_on(future).unwrap();
 
@@ -371,21 +430,27 @@ impl SqliteProgressWriter {
 }
 
 impl ProgressWriter<u64> for SqliteProgressWriter {
-    fn write(&mut self, backup: &FrontierBackup<u64>) {
-        let sql = format!("INSERT INTO {} (name, antichain) VALUES (?1, ?2) ON CONFLICT (name) DO UPDATE SET antichain = EXCLUDED.antichain", self.table_name);
+    fn write(&mut self, update: &ProgressUpdate<u64>) {
+        let ProgressUpdate(key, op) = update;
+        let ProgressRecoveryKey { worker_index } = key;
+        let ProgressOp::Upsert(Progress { frontier }) = op;
+        let sql = format!("INSERT INTO {} (worker_index, frontier) VALUES (?1, ?2) ON CONFLICT (worker_index) DO UPDATE SET frontier = EXCLUDED.frontier", self.table_name);
         let future = query(&sql)
-            .bind("worker_frontier")
-            .bind(backup)
+            .bind(worker_index)
+            .bind(
+                <u64 as TryInto<i64>>::try_into(*frontier)
+                    .expect("frontier can't fit into SQLite int"),
+            )
             .execute(&mut self.conn);
         self.rt.block_on(future).unwrap();
 
-        debug!("sqlite frontier write backup={backup:?}");
+        trace!("Wrote progress update {update:?}");
     }
 }
 
 pub(crate) struct SqliteProgressReader {
     rt: Runtime,
-    rx: tokio::sync::mpsc::Receiver<FrontierBackup<u64>>,
+    rx: tokio::sync::mpsc::Receiver<ProgressUpdate<u64>>,
 }
 
 impl SqliteProgressReader {
@@ -399,16 +464,26 @@ impl SqliteProgressReader {
         let (tx, rx) = tokio::sync::mpsc::channel(1);
 
         rt.spawn(async move {
-            let sql =
-                format!("SELECT antichain FROM {table_name} WHERE name = \"worker_frontier\"");
+            let sql = format!("SELECT worker_index, frontier FROM {table_name}");
             let mut stream = query(&sql)
-                .map(|row: SqliteRow| row.get::<FrontierBackup<u64>, _>(0))
+                .map(|row: SqliteRow| {
+                    let key = ProgressRecoveryKey {
+                        worker_index: row.get(0),
+                    };
+                    let op = ProgressOp::Upsert(Progress {
+                        frontier: row
+                            .get::<i64, _>(1)
+                            .try_into()
+                            .expect("SQLite int can't fit into frontier; might be negative"),
+                    });
+                    ProgressUpdate(key, op)
+                })
                 .fetch(&mut conn)
                 .map(|result| result.expect("Error selecting from SQLite"));
 
-            while let Some(backup) = stream.next().await {
-                debug!("sqlite frontier read backup={backup:?}");
-                tx.send(backup).await.unwrap();
+            while let Some(update) = stream.next().await {
+                trace!("Read progress update {update:?}");
+                tx.send(update).await.unwrap();
             }
         });
 
@@ -417,7 +492,7 @@ impl SqliteProgressReader {
 }
 
 impl ProgressReader<u64> for SqliteProgressReader {
-    fn read(&mut self) -> Option<FrontierBackup<u64>> {
+    fn read(&mut self) -> Option<ProgressUpdate<u64>> {
         self.rt.block_on(self.rx.recv())
     }
 }

--- a/src/window/event_time_clock.rs
+++ b/src/window/event_time_clock.rs
@@ -49,7 +49,7 @@ pub(crate) struct EventClockConfig {
 
 impl ClockBuilder<TdPyAny> for EventClockConfig {
     fn builder(self) -> Builder<TdPyAny> {
-        Box::new(move |resume_state_bytes: Option<StateBytes>| {
+        Box::new(move |resume_snapshot: Option<StateBytes>| {
             // Make the clock an InternalClock now, so we can retrieve
             // it's `time` to use as the default value.
             let mut clock = self
@@ -60,7 +60,7 @@ impl ClockBuilder<TdPyAny> for EventClockConfig {
 
             // Deserialize data if a snapshot existed
             let (latest_event_time, system_time_of_last_event, late_time, watermark) =
-                resume_state_bytes.map(StateBytes::de).unwrap_or_else(|| {
+                resume_snapshot.map(StateBytes::de).unwrap_or_else(|| {
                     // Defaults values
                     (
                         None,

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -29,7 +29,7 @@
 //! want. E.g. [`SystemClockConfig`] represents a token in Python for
 //! how to create a [`SystemClock`].
 use crate::pyo3_extensions::TdPyAny;
-use crate::recovery::{LogicFate, State, StateBytes, StateKey};
+use crate::recovery::{LogicFate, State, StateBytes, StateKey, StatefulStream};
 use crate::recovery::{StateUpdate, StepId};
 use crate::recovery::{StatefulLogic, StatefulUnary};
 use crate::StringResult;
@@ -511,7 +511,7 @@ where
         logic_builder: LB,
         resume_state: HashMap<StateKey, State>,
     ) -> (
-        Stream<S, (StateKey, Result<R, WindowError<V>>)>,
+        StatefulStream<S, Result<R, WindowError<V>>>,
         Stream<S, StateUpdate<S::Timestamp>>,
     )
     where
@@ -524,7 +524,7 @@ where
     ;
 }
 
-impl<S, V> StatefulWindowUnary<S, V> for Stream<S, (StateKey, V)>
+impl<S, V> StatefulWindowUnary<S, V> for StatefulStream<S, V>
 where
     S: Scope<Timestamp = u64>,
     V: ExchangeData + Debug,
@@ -537,7 +537,7 @@ where
         logic_builder: LB,
         resume_state: HashMap<StateKey, State>,
     ) -> (
-        Stream<S, (StateKey, Result<R, WindowError<V>>)>,
+        StatefulStream<S, Result<R, WindowError<V>>>,
         Stream<S, StateUpdate<S::Timestamp>>,
     )
     where

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -353,25 +353,22 @@ where
     ) -> impl Fn(Option<StateBytes>) -> Self {
         let logic_builder = Rc::new(logic_builder);
 
-        move |resume_state| {
-            let resume_state: Option<(StateBytes, StateBytes, HashMap<WindowKey, StateBytes>)> =
-                resume_state.map(
-                    StateBytes::de::<(StateBytes, StateBytes, HashMap<WindowKey, StateBytes>)>,
-                );
-            let (clock_resume_state, windower_resume_state, logic_resume_state) = match resume_state
-            {
-                Some((c, w, l)) => (Some(c), Some(w), Some(l)),
-                None => (None, None, None),
-            };
+        move |resume_snapshot| {
+            let resume_snapshot: Option<(StateBytes, StateBytes, HashMap<WindowKey, StateBytes>)> =
+                resume_snapshot
+                    .map(StateBytes::de::<(StateBytes, StateBytes, HashMap<WindowKey, StateBytes>)>);
+            let (clock_resume_snapshot, windower_resume_snapshot, logic_resume_snapshot) =
+                match resume_snapshot {
+                    Some((c, w, l)) => (Some(c), Some(w), Some(l)),
+                    None => (None, None, None),
+                };
 
-            let clock = clock_builder(clock_resume_state);
-            let windower = windower_builder(windower_resume_state);
-            let current_state = logic_resume_state
+            let clock = clock_builder(clock_resume_snapshot);
+            let windower = windower_builder(windower_resume_snapshot);
+            let current_state = logic_resume_snapshot
                 .unwrap_or_default()
                 .into_iter()
-                .map(|(window_key, window_resume_state)| {
-                    (window_key, logic_builder(Some(window_resume_state)))
-                })
+                .map(|(key, resume_snapshot)| (key, logic_builder(Some(resume_snapshot))))
                 .collect();
             let logic_builder = logic_builder.clone();
 

--- a/src/window/system_clock.rs
+++ b/src/window/system_clock.rs
@@ -6,7 +6,7 @@ use pyo3::{exceptions::PyValueError, PyResult};
 
 use crate::recovery::StateBytes;
 
-use super::{Clock, ClockBuilder, ClockConfig, Builder};
+use super::{Builder, Clock, ClockBuilder, ClockConfig};
 
 /// Use the system time inside the windowing operator to determine
 /// times.

--- a/src/window/system_clock.rs
+++ b/src/window/system_clock.rs
@@ -23,7 +23,7 @@ pub(crate) struct SystemClockConfig {}
 
 impl<V> ClockBuilder<V> for SystemClockConfig {
     fn builder(self) -> Builder<V> {
-        Box::new(move |_resume_state_bytes| Box::new(SystemClock::new()))
+        Box::new(move |_resume_snapshot| Box::new(SystemClock::new()))
     }
 }
 

--- a/src/window/testing_clock.rs
+++ b/src/window/testing_clock.rs
@@ -112,7 +112,7 @@ impl<V> ClockBuilder<V> for TestingClockConfig {
     fn builder(self) -> Builder<V> {
         // Do not restore state here since we don't store anything.
         // See note in the `snapshot` method implementation for TestingClock.
-        Box::new(move |_resume_state_bytes: Option<StateBytes>| {
+        Box::new(move |_resume_snapshot: Option<StateBytes>| {
             // All instances of this [`TestingClock`] will reference
             // the same [`PyTestingClock`] so modifications increment
             // all windows' times.

--- a/src/window/tumbling_window.rs
+++ b/src/window/tumbling_window.rs
@@ -75,8 +75,8 @@ impl TumblingWindower {
         length: Duration,
         start_at: DateTime<Utc>,
     ) -> impl Fn(Option<StateBytes>) -> Box<dyn Windower> {
-        move |resume_state_bytes| {
-            let close_times = resume_state_bytes
+        move |resume_snapshot| {
+            let close_times = resume_snapshot
                 .map(StateBytes::de::<HashMap<WindowKey, DateTime<Utc>>>)
                 .unwrap_or_default();
 


### PR DESCRIPTION
Prep
----

This turned into a sort of refresh of types used in the recovery
system to better match the model of what is actually happening.

The recovery store is modeled as two key-value DB tables, progress and
state, and the stateful operators generate CDC-style updates which are
applied to the tables. This PR renames the structs involved to match
that process. There's `ProgressUpdate` and `StateUpdate` which
correspond to KV changes. And each is a 2-tuple struct with 2 fields:
`ProgressRecoveryKey` and `ProgressOp` or `StateRecoveryKey` and
`StateOp`, with the `Op` enums representing what kind of change
happened to the value for each key (e.g. update or delete). Within
each `Op` is a `Progress` or `State` type that actually captures the
new value.

Stateful operators now emit fully formed `StateUpdate`s instead of the
difficult-to-name `EpochData`, which was the `(step_id, (state_key,
update))` tuple. This makes a nice symmetry between the backup phase
and the recovery loading, since everything uses the same types.

A lot of systemic renaming from `backup` to `update`, `update` to
`op`, and `state_bytes` to `state` to match this new convention.

Next Awake
----------

Now that we have a `State` type, we can add the `next_awake:
DateTime<Utc>` to that struct so we will save the next awake time for
each `StateKey`. Fills out that whenever we do a snapshot of the state
data in `StatefulUnary`.

Since all fields of `State` need to be written to each recovery store,
adds the `chrono` feature of `sqlx` to enable writing `DateTime` as a
row value. Updates the schema of the state table to add a `next_awake`
column.

Progress
--------

Makes both the SQLite and Kafka recovery stores actually store
progress data under the `ProgressRecoveryKey` to keep the parallel
construction between the state and progress recovery
tables. Previously, we were using the fixed string `"worker_frontier"`
which produces the same behavior when cluster size is static across
recovery, but this will set us up for our rescaling future where data
from multiple workers is mixed together. Instead the worker frontier
is one of the fields in the value (the only one as of now).

Adds a little `WorkerIndex` newtype to label when an int is meant to
be interpreted as the worker number.

As part of clarifying the datatypes needed to store progress, we don't
store the full antichain in the recovery store anymore; instead we
collapse the antichain into the minimum value during writing and only
store that single timestamp as the frontier. This helps with debugging
as you can now store the worker frontier as a single int, which is
much easier to parse out of the recovery store by hand rather than a
serde blob of bytes.

Reduces the logging level of recovery stores down to trace.
