### PR TITLE
Docs v0.11.2 - update link schema

### DIFF
--- a/docs/articles/deployment/k8s-ecosystem.md
+++ b/docs/articles/deployment/k8s-ecosystem.md
@@ -1,4 +1,4 @@
-As we mentioned in our [Execution section](https://docs.bytewax.io/getting-started/execution/#multiple-workers-manual-cluster). Bytewax allows you to run a dataflow program in a coordinated set of processes if you use the `bytewax.cluster_main()` entry point.
+As we mentioned in our [Execution section](/docs/getting-started/execution#multiple-workers-manual-cluster). Bytewax allows you to run a dataflow program in a coordinated set of processes if you use the `bytewax.cluster_main()` entry point.
 
 That entry point requires the addresses of all the processes and assign them each a unique ID.
 
@@ -81,7 +81,7 @@ In the above diagram, the application container has these environment variables:
           value: my-dataflow
 ```
 
-Some of those were already covered in the [How Bytewax Image Works](/deployment/container/#how-the-bytewax-image-works) section.
+Some of those were already covered in the [How Bytewax Image Works](/docs/deployment/container/#how-the-bytewax-image-works) section.
 
 The environment variables can be grouped into two groups: 
 
@@ -136,7 +136,7 @@ We use this Kubernetes object to give access to the Registry Credentials Secrets
 
 ## Next Steps
 
-If you want to deploy this stack in your Kubernetes cluster we invite you to read our [next section](/deployment/waxctl) where we use the Bytewax CLI, `waxctl`, to do that.
+If you want to deploy this stack in your Kubernetes cluster we invite you to read our [next section](/docs/deployment/waxctl) where we use the Bytewax CLI, `waxctl`, to do that.
 
 ## Example Manifests
 

--- a/docs/articles/deployment/waxctl.md
+++ b/docs/articles/deployment/waxctl.md
@@ -5,7 +5,7 @@ Check `kubectl` documentation [here](https://kubernetes.io/docs/tasks/tools/#kub
 
 ## Installation
 
-Installing `waxctl` is very simple. You just need to download the binary corresponding to your operating system and architecture [here](https://bytewax.io/downloads).
+Installing `waxctl` is very simple. You just need to download the binary corresponding to your operating system and architecture [here](/downloads/).
 
 ## Dataflow Lifecycle
 

--- a/docs/articles/deployment/waxctl.md
+++ b/docs/articles/deployment/waxctl.md
@@ -221,7 +221,7 @@ Dataflow my-dataflow deleted.
 
 `waxctl` uses a compiled-in [Bytewax helm chart](https://github.com/bytewax/helm-charts) to generate all the manifests except the Namespace and ConfigMap which are created by making calls to Kubernetes API directly. 
 
-You can check the entire architecture that `waxctl` deploys in our [Bytewax Ecosystem on Kubernetes](/deployment/k8s-ecosystem/) section.
+You can check the entire architecture that `waxctl` deploys in our [Bytewax Ecosystem on Kubernetes](/docs/deployment/k8s-ecosystem/) section.
 
 ## More Examples
 
@@ -276,7 +276,7 @@ And if you need to apply the output manifests to Kubernetes you could run the fo
 
 ### Using a Custom Image from a Private Registry
 
-In our [Including Custom Dependencies in an Image](/deployment/container/#including-custom-dependencies-in-an-image) section we describe how to create your own Docker image using a Bytewax image as base.
+In our [Including Custom Dependencies in an Image](/docs/deployment/container#including-custom-dependencies-in-an-image) section we describe how to create your own Docker image using a Bytewax image as base.
 
 Let's assume you created a custom image that you pushed to a private image registry in GitLab. In our example the image URL is:
 

--- a/docs/articles/getting-started/execution.md
+++ b/docs/articles/getting-started/execution.md
@@ -134,7 +134,7 @@ spawn_cluster(
 ```
 ## Multiple Workers Cluster Main
 
-The final entry point, `bytewax.execution.cluster_main()` is the most flexible. It allows you to start up a single process within a cluster of processes that you are manually coordinating. We recommend you checkout the documentation for [waxctl](/deployment/waxctl) our command line tool which facilitates running a dataflow on kubernetes.
+The final entry point, `bytewax.execution.cluster_main()` is the most flexible. It allows you to start up a single process within a cluster of processes that you are manually coordinating. We recommend you checkout the documentation for [waxctl](/docs/deployment/waxctl/) our command line tool which facilitates running a dataflow on kubernetes.
 
 `cluster_main()` takes in a list of hostname and port of all workers (including itself). Each worker must be given a unique process ID.
 

--- a/docs/articles/getting-started/operators.md
+++ b/docs/articles/getting-started/operators.md
@@ -20,4 +20,4 @@ In order to coordinate this state in a multiple-worker execution, all stateful o
 
 ### Stateful Operators and Recovery
 
-When a Bytewax dataflow is configured with recovery, state for operators can be periodically persisted. In the event of a crash or a restart, stateful operators can recover their internal state from a recovery store. For more information, see the documentation on [recovery](/getting-started/recovery/).
+When a Bytewax dataflow is configured with recovery, state for operators can be periodically persisted. In the event of a crash or a restart, stateful operators can recover their internal state from a recovery store. For more information, see the documentation on [recovery](/docs/getting-started/recovery/).

--- a/docs/articles/getting-started/recovery.md
+++ b/docs/articles/getting-started/recovery.md
@@ -29,7 +29,7 @@ requirements:
 Your dataflow needs a few features to enable recovery on Bytewax:
 
 1. You must design your [input
-   builder](/getting-started/ins_and_outs) to be able to resume
+   builder](/docs/getting-started/ins_and_outs) to be able to resume
    and replay all data from the `resume_state` onwards. Do not
    ignore this argument!
 
@@ -39,7 +39,7 @@ Your dataflow needs a few features to enable recovery on Bytewax:
    on our supported options.
 
 3. Pass the recovery config as the `recovery_config` argument to
-   whatever execution [entry point](/getting-started/execution)
+   whatever execution [entry point](/docs/getting-started/execution/)
    (e.g. `cluster_main()`) you are using.
 
 4. Run the dataflow! Bytewax will automatically snapshots of state and

--- a/docs/articles/getting-started/simple-example.md
+++ b/docs/articles/getting-started/simple-example.md
@@ -124,9 +124,9 @@ flow = Dataflow()
 flow.input("input", ManualInputConfig(input_builder))
 ```
 
-To receive input, our program needs an **input iterator**. We've defined a [Python generator](https://docs.python.org/3/glossary.html#term-generator) that will read our input file. There are also more advanced ways to provide input, which you can read about later when we talk about [execution modes](/getting-started/execution/).
+To receive input, our program needs an **input iterator**. We've defined a [Python generator](https://docs.python.org/3/glossary.html#term-generator) that will read our input file. There are also more advanced ways to provide input, which you can read about later when we talk about [execution modes](/docs/getting-started/execution/).
 
-This generator yields two-tuples of `resume_state` and a line from our file. The `resume_state` in this example is significant, but we'll talk more about it when we discuss [recovery](/getting-started/recovery/).
+This generator yields two-tuples of `resume_state` and a line from our file. The `resume_state` in this example is significant, but we'll talk more about it when we discuss [recovery](/docs/getting-started/recovery/).
 
 We then initialize a `ManualInputConfig` with the `input_builder` function.
 Now we can introduce our first operator, [input](/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow.input), that will generate the data for the flow.
@@ -272,4 +272,4 @@ Here is the complete output when running the example:
 ('fortune', 1)
 ```
 
-To learn more about possible modes of execution, [read our page on execution](/getting-started/execution/).
+To learn more about possible modes of execution, [read our page on execution](/docs/getting-started/execution/).

--- a/docs/articles/reference/changes-in-v11.md
+++ b/docs/articles/reference/changes-in-v11.md
@@ -125,7 +125,7 @@ def input_builder(worker_index, worker_count, resume_state):
         yield state, line
 ```
 
-So instead of manually yielding the `epoch` in the input function, we can either ignore it (passing `None` as state), or handle the value to implement recovery (see the [recovery chapter](/getting-started/recovery)).
+So instead of manually yielding the `epoch` in the input function, we can either ignore it (passing `None` as state), or handle the value to implement recovery (see the [recovery chapter](/docs/getting-started/recovery)).
 
 Then we need to wrap the `input_builder` with `ManualInputConfig`, give it a name ("file_input" here) and pass it to the `input` operator (rather than the `run` function):
 

--- a/docs/examples/cart-join.md
+++ b/docs/examples/cart-join.md
@@ -172,7 +172,7 @@ future!
 ## Recovery Prep
 
 Following our checklist in [Bytewax's documentation on
-recovery](/getting-started/recovery/) we need to enhance our input
+recovery](/docs/getting-started/recovery/) we need to enhance our input
 builder with a few things.
 
 First, we need the ability to resume our input from where we left off.

--- a/docs/examples/crypto-sockets.md
+++ b/docs/examples/crypto-sockets.md
@@ -32,7 +32,7 @@ Alright, let's get started!
 Inputs & Outputs
 ----------------
 
-We are going to eventually create a cluster of dataflows where we could have multiple currency pairs running in parallel on different workers. In order to follow this approach, we will use the [`spawn_cluster`](https://docs.bytewax.io/apidocs#bytewax.spawn_cluster) method of kicking off our dataflow. To start, we will build a websocket input function that will use the coinbase pro websocket url (`wss://ws-feed.pro.coinbase.com`) and the Python websocket library to create a connection. Once connected we can send a message to the websocket subscribing to product_ids (pairs of currencies - USD-BTC for this example) and channels (level2 order book data). Finally since we know there will be some sort of acknowledgement message we can grab that with `ws.recv()` and print it out.
+We are going to eventually create a cluster of dataflows where we could have multiple currency pairs running in parallel on different workers. In order to follow this approach, we will use the [`spawn_cluster`](/apidocs#bytewax.spawn_cluster) method of kicking off our dataflow. To start, we will build a websocket input function that will use the coinbase pro websocket url (`wss://ws-feed.pro.coinbase.com`) and the Python websocket library to create a connection. Once connected we can send a message to the websocket subscribing to product_ids (pairs of currencies - USD-BTC for this example) and channels (level2 order book data). Finally since we know there will be some sort of acknowledgement message we can grab that with `ws.recv()` and print it out.
 
 ```python
 import json
@@ -146,7 +146,7 @@ The data from the coinbase pro websocket is first a snapshot of the current orde
 }
 ```
 
-To maintain an order book in real time, we will first need to construct an object to hold the orders from the snapshot and then update that object with each additional update. This is a good use case for the [`stateful_map`](https://docs.bytewax.io/apidocs#bytewax.Dataflow.stateful_map) operator, which can aggregate by key. `Stateful_map` will aggregate data based on a function (mapper), into an object that you define. The object must be defined via a builder, because it will create a new object via this builder for each new key received. The mapper must return the object so that it can be updated.
+To maintain an order book in real time, we will first need to construct an object to hold the orders from the snapshot and then update that object with each additional update. This is a good use case for the [`stateful_map`](/apidocs#bytewax.Dataflow.stateful_map) operator, which can aggregate by key. `Stateful_map` will aggregate data based on a function (mapper), into an object that you define. The object must be defined via a builder, because it will create a new object via this builder for each new key received. The mapper must return the object so that it can be updated.
 
 Below we have the code for the OrderBook object that has a bids and asks dictionary. These will be used to first create the order book from the snapshot and once created we can attain the first bid price and ask price. The bid price is the highest buy order placed and the ask price is the lowest sell order places. Once we have determined the bid and ask prices, we will be able to calculate the spread and track that as well.
 
@@ -224,7 +224,7 @@ flow.filter(lambda x: x[-1]['spread'] / x[-1]['ask'] > 0.0001)
 flow.capture(ManualOutputConfig(output_builder))
 ```
 
-[Bytewax provides a few different entry points for executing a dataflow](/getting-started/execution/).
+[Bytewax provides a few different entry points for executing a dataflow](/docs/getting-started/execution/).
 That's it, let's run it and verify our output:
 
 ```python

--- a/docs/examples/search-session.md
+++ b/docs/examples/search-session.md
@@ -128,7 +128,7 @@ Now that we have a Dataflow, and some input, we can add a series of **steps**
 to the dataflow. Steps are made up of **operators**, that provide a "shape"
 of transformation, and **logic functions**, that you supply to do your specific
 transformation. [You can read more about all the operators in our
-documentation.](/getting-started/operators)
+documentation.](/docs/getting-started/operators/)
 
 Our first task is to make sure to group incoming events by user since
 no session deals with multiple users.
@@ -274,7 +274,7 @@ Execution
 ---------
 
 [Bytewax provides a few different entry points for executing your
-dataflow](/getting-started/execution/), but because we're focusing on the dataflow in
+dataflow](/docs/getting-started/execution/), but because we're focusing on the dataflow in
 this example, we're going to use `bytewax.execution.run_main` which is the most basic
 execution mode.
 


### PR DESCRIPTION
Once we deploy our new website application to production, we'll have to update the internal links schema from `docs.bytewax.io/category/article` to `/docs/category/article`. 

This PR updates links in articles from v0.11.2. 