### PR TITLE
Adding manylinux_2_27 wheel building to CI

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Check the Version and Quantity of Wheel files
         env:
           NEEDED_VERSION: ${{steps.get-info.outputs.bytewax-version}}
-          WHEELS: 12
+          WHEELS: 13
         run: |
           cat << EOF > ./check_versions.sh
           #!/bin/bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,6 +53,31 @@ jobs:
         name: wheels
         path: dist
 
+  linux_glibc_227_colab:
+    runs-on: ubuntu-latest
+    container: bytewax/glib-2.27-builder:v0
+    steps:
+    - uses: actions/checkout@v2
+    - name: Rust Toolchain
+      run: |
+        rustup default 1.61
+    - name: Cargo Test
+      run: |
+        cargo test --no-default-features
+    - name: Build wheel
+      run: |
+        maturin build --release -o dist
+    - name: Pytest
+      run: |
+        WHEEL_FILE=$(ls ./dist/*.whl)
+        pip install $WHEEL_FILE'[dev]' -v
+        pytest
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheels
+        path: dist
+
   macos_x86:
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -165,7 +165,7 @@ jobs:
     name: Store wheels in S3
     runs-on: ubuntu-latest
     if: "github.ref == 'refs/heads/main'"
-    needs: [ linux, macos_x86, macos_arm64 ]
+    needs: [ linux, linux_glibc_227_colab, macos_x86, macos_arm64 ]
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/CI.md
+++ b/CI.md
@@ -1,0 +1,23 @@
+# Notes about Bytewax CI
+
+## Setup for Colab Support
+
+To provide [Google Colab](https://colab.research.google.com/) support we need to build wheels compatible with GLIBC 2.27.  
+For that, we use a [custom docker image](Dockerfile.Colab) in the `linux_glibc_227_colab` job of our CI:
+
+```yaml
+...
+  linux_glibc_227_colab:
+    runs-on: ubuntu-latest
+    container: bytewax/glib-2.27-builder:v0
+    steps:
+...
+```
+
+The steps made to build and push that custom image were as follows:
+
+```sh
+$ docker build -t bytewax/glib-2.27-builder:v0 -f Dockerfile.Colab .
+$ docker login -u $BYTEWAX_DOCKERHUB_USER -p $BYTEWAX_DOCKERHUB_PASSWORD
+$ docker push bytewax/glib-2.27-builder:v0
+```

--- a/Dockerfile.Colab
+++ b/Dockerfile.Colab
@@ -1,0 +1,47 @@
+FROM ubuntu:18.04
+
+# Install Python 3.7
+RUN apt update
+RUN apt install software-properties-common -y
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt install python3.7 -y
+RUN python3.7 --version
+
+# Install pip and venv
+RUN apt install python3-pip -y
+RUN apt-get install python3.7-venv -y
+
+# Install cargo
+RUN apt install curl -y
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN cargo --version
+
+# Install maturin in environment
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3.7 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip install maturin
+RUN python3.7 -m pip install --upgrade pip
+RUN maturin --help
+
+# Install cmake
+RUN apt install wget -y
+RUN wget https://cmake.org/files/v3.22/cmake-3.22.1.tar.gz
+RUN tar -xvf cmake-3.22.1.tar.gz
+RUN apt install libssl-dev libsasl2-dev pkg-config openssl protobuf-compiler -y
+RUN cd cmake-3.22.1/ && ./bootstrap && make && make install
+RUN cmake --version
+
+# Install patchelf
+RUN wget https://github.com/NixOS/patchelf/releases/download/0.14.5/patchelf-0.14.5-x86_64.tar.gz
+RUN mkdir patchelf-0.14.5-x86_64
+RUN tar -xvf patchelf-0.14.5-x86_64.tar.gz -C ./patchelf-0.14.5-x86_64
+RUN cd patchelf-0.14.5-x86_64 && cp ./bin/patchelf /usr/local/bin/
+RUN patchelf --version
+
+# Install CI needed libraries
+RUN apt-get install librdkafka-dev -y
+RUN apt install python3.7-dev -y
+RUN pip install dill
+RUN apt install git -y


### PR DESCRIPTION
This PR automates the building of compatible wheels with Google Colab environments which have the `2.27` version of `GLIBC`.