### PR TITLE
Added EXPOSE command in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,7 @@ COPY ./entrypoint.sh .
 
 ENV BYTEWAX_WORKDIR=/bytewax
 
+# Ports that needs to be exposed
+EXPOSE 9999 3030
+
 ENTRYPOINT ["/bin/sh", "-c", "./entrypoint.sh"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -18,4 +18,7 @@ COPY ./entrypoint.sh .
 
 ENV BYTEWAX_WORKDIR=/bytewax
 
+# Ports that needs to be exposed
+EXPOSE 9999 3030
+
 ENTRYPOINT ["/bin/sh", "-c", "./entrypoint.sh"]


### PR DESCRIPTION
Added an `EXPOSE` line in Dockerfiles to document which ports we need to expose from inside the container.

I also made a small fix in how we get the port from the env var, since previously it accepted an entire url.
I'm not sure we need to use anything else than "0.0.0.0:PORT", but if we do I can change it back to accept the entire url.