### PR TITLE
Adding 3.8, 3.9, and 3.10 python versions to colab CI job

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Check the Version and Quantity of Wheel files
         env:
           NEEDED_VERSION: ${{steps.get-info.outputs.bytewax-version}}
-          WHEELS: 13
+          WHEELS: 16
         run: |
           cat << EOF > ./check_versions.sh
           #!/bin/bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,10 @@ jobs:
 
   linux_glibc_227_colab:
     runs-on: ubuntu-latest
-    container: bytewax/glib-2.27-builder:v0
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+    container: bytewax/glib-2.27-builder:v1
     steps:
     - uses: actions/checkout@v2
     - name: Rust Toolchain
@@ -66,9 +69,14 @@ jobs:
         cargo test --no-default-features
     - name: Build wheel
       run: |
-        maturin build --release -o dist
+        maturin build --release -o dist --interpreter python${{ matrix.python-version }}
     - name: Pytest
       run: |
+        PATH=`echo $PATH | sed -e "s/3.7/${{ matrix.python-version }}/g"`
+        echo $PATH
+        which python
+        python -V
+        pip -V
         WHEEL_FILE=$(ls ./dist/*.whl)
         pip install $WHEEL_FILE'[dev]' -v
         pytest

--- a/CI.md
+++ b/CI.md
@@ -17,7 +17,7 @@ For that, we use a [custom docker image](Dockerfile.Colab) in the `linux_glibc_2
 The steps made to build and push that custom image were as follows:
 
 ```sh
-$ docker build -t bytewax/glib-2.27-builder:v0 -f Dockerfile.Colab .
+$ docker build -t bytewax/glib-2.27-builder:v1 -f Dockerfile.Colab .
 $ docker login -u $BYTEWAX_DOCKERHUB_USER -p $BYTEWAX_DOCKERHUB_PASSWORD
-$ docker push bytewax/glib-2.27-builder:v0
+$ docker push bytewax/glib-2.27-builder:v1
 ```


### PR DESCRIPTION
This PR adds `3.8`, `3.9`, and `3.10` versions of python to the existing `linux_glibc_227_colab` CI job.

With those changes the CI will generate wheels compatible with `manylinux_2_27` for the following python versions:
- 3.7
- 3.8
- 3.9
- 3.10

