### PR TITLE
Fix issue with resume state not being routed to correct worker

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,8 @@ jobs:
       run: |
         WHEEL_FILE=$(ls ./dist/*.whl)
         pip install $WHEEL_FILE'[dev]' -v
-        pytest
+        pytest pytests
+        pytest docs
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:
@@ -79,7 +80,8 @@ jobs:
         pip -V
         WHEEL_FILE=$(ls ./dist/*.whl)
         pip install $WHEEL_FILE'[dev]' -v
-        pytest
+        pytest pytests
+        pytest docs
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:
@@ -122,7 +124,8 @@ jobs:
       run: |
         WHEEL_FILE=$(ls ./dist/*.whl)
         pip install $WHEEL_FILE'[dev]' -v
-        pytest
+        pytest pytests
+        pytest docs
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:
@@ -162,7 +165,8 @@ jobs:
         pyenv activate bytewax-${{ matrix.python-version }}
         WHEEL_FILE=$(ls ./dist/*.whl)
         pip install $WHEEL_FILE'[dev]' -v --force-reinstall
-        pytest
+        pytest pytests
+        pytest docs
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -1,7 +1,62 @@
 from multiprocess import get_context
 from pytest import fixture
 
+from bytewax.execution import cluster_main, run_main, spawn_cluster
+
 
 @fixture
 def mp_ctx():
     return get_context("spawn")
+
+
+@fixture(params=["run_main", "spawn_cluster", "cluster_main"])
+def entry_point_name(request):
+    return request.param
+
+
+@fixture
+def entry_point(entry_point_name):
+    if entry_point_name == "run_main":
+        return run_main
+    elif entry_point_name == "spawn_cluster":
+
+        def wrapped(*args, **kwargs):
+            return spawn_cluster(*args, proc_count=2, worker_count_per_proc=2, **kwargs)
+
+        return wrapped
+    elif entry_point_name == "cluster_main":
+
+        def wrapped(*args, **kwargs):
+            return cluster_main(*args, [], 0, worker_count_per_proc=2, **kwargs)
+
+        return wrapped
+    else:
+        raise ValueError("unknown entry point name: {request.param!r}")
+
+
+@fixture
+def out(entry_point_name, request):
+    if entry_point_name == "run_main":
+        yield []
+    elif entry_point_name == "spawn_cluster":
+        mp_ctx = request.getfixturevalue("mp_ctx")
+        with mp_ctx.Manager() as man:
+            yield man.list()
+    elif entry_point_name == "cluster_main":
+        yield []
+    else:
+        raise ValueError("unknown entry point name: {request.param!r}")
+
+
+@fixture
+def inp(entry_point_name, request):
+    if entry_point_name == "run_main":
+        yield []
+    elif entry_point_name == "spawn_cluster":
+        mp_ctx = request.getfixturevalue("mp_ctx")
+        with mp_ctx.Manager() as man:
+            yield man.list()
+    elif entry_point_name == "cluster_main":
+        yield []
+    else:
+        raise ValueError("unknown entry point name: {request.param!r}")

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -9,40 +9,40 @@ def mp_ctx():
     return get_context("spawn")
 
 
-@fixture(params=["run_main", "spawn_cluster", "cluster_main"])
+@fixture(params=["run_main", "spawn_cluster-2proc-2thread", "cluster_main-2thread"])
 def entry_point_name(request):
     return request.param
+
+
+def _wrapped_spawn_cluster2x2(*args, **kwargs):
+    return spawn_cluster(*args, proc_count=2, worker_count_per_proc=2, **kwargs)
+
+
+def _wrapped_cluster_main1x2(*args, **kwargs):
+    return cluster_main(*args, [], 0, worker_count_per_proc=2, **kwargs)
 
 
 @fixture
 def entry_point(entry_point_name):
     if entry_point_name == "run_main":
         return run_main
-    elif entry_point_name == "spawn_cluster":
-
-        def wrapped(*args, **kwargs):
-            return spawn_cluster(*args, proc_count=2, worker_count_per_proc=2, **kwargs)
-
-        return wrapped
-    elif entry_point_name == "cluster_main":
-
-        def wrapped(*args, **kwargs):
-            return cluster_main(*args, [], 0, worker_count_per_proc=2, **kwargs)
-
-        return wrapped
+    elif entry_point_name == "spawn_cluster-2proc-2thread":
+        return _wrapped_spawn_cluster2x2
+    elif entry_point_name == "cluster_main-2thread":
+        return _wrapped_cluster_main1x2
     else:
         raise ValueError("unknown entry point name: {request.param!r}")
 
 
 @fixture
 def out(entry_point_name, request):
-    if entry_point_name == "run_main":
+    if entry_point_name.startswith("run_main"):
         yield []
-    elif entry_point_name == "spawn_cluster":
+    elif entry_point_name.startswith("spawn_cluster"):
         mp_ctx = request.getfixturevalue("mp_ctx")
         with mp_ctx.Manager() as man:
             yield man.list()
-    elif entry_point_name == "cluster_main":
+    elif entry_point_name.startswith("cluster_main"):
         yield []
     else:
         raise ValueError("unknown entry point name: {request.param!r}")
@@ -50,13 +50,13 @@ def out(entry_point_name, request):
 
 @fixture
 def inp(entry_point_name, request):
-    if entry_point_name == "run_main":
+    if entry_point_name.startswith("run_main"):
         yield []
-    elif entry_point_name == "spawn_cluster":
+    elif entry_point_name.startswith("spawn_cluster"):
         mp_ctx = request.getfixturevalue("mp_ctx")
         with mp_ctx.Manager() as man:
             yield man.list()
-    elif entry_point_name == "cluster_main":
+    elif entry_point_name.startswith("cluster_main"):
         yield []
     else:
         raise ValueError("unknown entry point name: {request.param!r}")

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -2,43 +2,11 @@ import os
 import signal
 from sys import exit
 
-from pytest import fixture, mark, raises, skip
+from pytest import mark, raises, skip
 
 from bytewax.dataflow import Dataflow
-from bytewax.execution import cluster_main, run_main, spawn_cluster
 from bytewax.inputs import TestingInputConfig
 from bytewax.outputs import TestingOutputConfig
-
-
-@fixture(params=["run_main", "spawn_cluster", "cluster_main"])
-def entry_point_name(request):
-    return request.param
-
-
-@fixture
-def entry_point(entry_point_name):
-    if entry_point_name == "run_main":
-        return run_main
-    elif entry_point_name == "spawn_cluster":
-        return lambda flow: spawn_cluster(flow, proc_count=2, worker_count_per_proc=2)
-    elif entry_point_name == "cluster_main":
-        return lambda flow: cluster_main(flow, [], 0, worker_count_per_proc=2)
-    else:
-        raise ValueError("unknown entry point name: {request.param!r}")
-
-
-@fixture
-def out(entry_point_name, request):
-    if entry_point_name == "run_main":
-        yield []
-    elif entry_point_name == "spawn_cluster":
-        mp_ctx = request.getfixturevalue("mp_ctx")
-        with mp_ctx.Manager() as man:
-            yield man.list()
-    elif entry_point_name == "cluster_main":
-        yield []
-    else:
-        raise ValueError("unknown entry point name: {request.param!r}")
 
 
 def test_run(entry_point, out):

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -22,7 +22,7 @@ def test_run(entry_point, out):
 
 
 def test_reraises_exception(entry_point, out, entry_point_name):
-    if entry_point_name == "spawn_cluster":
+    if entry_point_name.startswith("spawn_cluster"):
         skip(
             "Timely is currently double panicking in cluster mode and that causes"
             " pool.join() to hang; it can be ctrl-c'd though"

--- a/pytests/test_recovery.py
+++ b/pytests/test_recovery.py
@@ -5,7 +5,7 @@ from pytest import fixture, raises
 from bytewax.dataflow import Dataflow
 from bytewax.execution import run_main, TestingEpochConfig
 from bytewax.inputs import TestingInputConfig
-from bytewax.outputs import TestingEpochOutputConfig
+from bytewax.outputs import TestingEpochOutputConfig, TestingOutputConfig
 from bytewax.recovery import SqliteRecoveryConfig
 
 epoch_config = TestingEpochConfig()
@@ -55,10 +55,7 @@ def build_keep_max_dataflow(armed, inp):
 
     flow.stateful_map("keep_max", lambda: None, keep_max)
 
-    out = []
-    flow.capture(TestingEpochOutputConfig(out))
-
-    return flow, out
+    return flow
 
 
 def test_recover_with_latest_state(recovery_config):
@@ -78,7 +75,9 @@ def test_recover_with_latest_state(recovery_config):
         # Epoch 3
         ("b", 1, False),
     ]
-    flow, out = build_keep_max_dataflow(armed, inp)
+    out = []
+    flow = build_keep_max_dataflow(armed, inp)
+    flow.capture(TestingEpochOutputConfig(out))
 
     # First pass.
     with raises(RuntimeError):
@@ -132,7 +131,9 @@ def test_recover_doesnt_gc_last_write(recovery_config):
         # Epoch 6
         ("a", 1, False),
     ]
-    flow, out = build_keep_max_dataflow(armed, inp)
+    out = []
+    flow = build_keep_max_dataflow(armed, inp)
+    flow.capture(TestingEpochOutputConfig(out))
 
     # First pass.
     with raises(RuntimeError):
@@ -188,7 +189,9 @@ def test_recover_respects_delete(recovery_config):
         # Should be max for "a" on resume.
         ("a", 2, False),
     ]
-    flow, out = build_keep_max_dataflow(armed, inp)
+    out = []
+    flow = build_keep_max_dataflow(armed, inp)
+    flow.capture(TestingEpochOutputConfig(out))
 
     # First pass.
     with raises(RuntimeError):
@@ -216,5 +219,54 @@ def test_recover_respects_delete(recovery_config):
             (4, ("b", 5)),
             # Notice not 4.
             (5, ("a", 2)),
+        ]
+    )
+
+
+def test_continuation(entry_point, inp, out, recovery_config):
+    # Not used for continuation, but we want to re-use
+    # build_keep_max_dataflow.
+    armed = Event()
+
+    # Since we're modifying the input, use the fixture so it works
+    # across processes.
+    inp.extend(
+        [
+            ("a", 4, False),
+            ("b", 4, False),
+        ]
+    )
+    flow = build_keep_max_dataflow(armed, inp)
+    flow.capture(TestingOutputConfig(out))
+
+    entry_point(flow, epoch_config=epoch_config, recovery_config=recovery_config)
+
+    assert sorted(out) == sorted(
+        [
+            ("a", 4),
+            ("b", 4),
+        ]
+    )
+
+    # Add new input. Don't clear because `TestingInputConfig` needs
+    # the initial items so the resume epoch skips to here.
+    inp.extend(
+        [
+            ("a", 1, False),
+            ("b", 5, False),
+        ]
+    )
+    # Unfortunately `ListProxy`, which we'd use in the cluster entry
+    # point, does not have `clear`.
+    del out[:]
+
+    # Continue.
+    entry_point(flow, epoch_config=epoch_config, recovery_config=recovery_config)
+
+    # Incorporates new input.
+    assert sorted(out) == sorted(
+        [
+            ("a", 4),
+            ("b", 5),
         ]
     )

--- a/pytests/test_recovery.py
+++ b/pytests/test_recovery.py
@@ -239,7 +239,7 @@ def test_continuation(entry_point, inp, out, recovery_config):
     flow = build_keep_max_dataflow(armed, inp)
     flow.capture(TestingOutputConfig(out))
 
-    entry_point(flow, epoch_config=epoch_config, recovery_config=recovery_config)
+    entry_point(flow, recovery_config=recovery_config)
 
     assert sorted(out) == sorted(
         [
@@ -261,7 +261,7 @@ def test_continuation(entry_point, inp, out, recovery_config):
     del out[:]
 
     # Continue.
-    entry_point(flow, epoch_config=epoch_config, recovery_config=recovery_config)
+    entry_point(flow, recovery_config=recovery_config)
 
     # Incorporates new input.
     assert sorted(out) == sorted(

--- a/src/execution/epoch/mod.rs
+++ b/src/execution/epoch/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     inputs::InputReader,
     operators::stateful_unary::{FlowChangeStream, StepId},
     pyo3_extensions::{PyConfigClass, TdPyAny},
-    recovery::model::state::StateKey,
+    recovery::model::{progress::ResumeEpoch, state::StateKey},
 };
 
 use self::{periodic_epoch::PeriodicEpochConfig, testing_epoch::TestingEpochConfig};
@@ -63,7 +63,7 @@ pub(crate) trait EpochBuilder<S: Scope<Timestamp = u64>> {
         step_id: StepId,
         key: StateKey,
         reader: Box<dyn InputReader<TdPyAny>>,
-        start_at: S::Timestamp,
+        start_at: ResumeEpoch<S::Timestamp>,
         probe: &ProbeHandle<S::Timestamp>,
     ) -> StringResult<(Stream<S, TdPyAny>, FlowChangeStream<S>)>;
 }
@@ -79,7 +79,7 @@ where
         step_id: StepId,
         key: StateKey,
         reader: Box<dyn InputReader<TdPyAny>>,
-        start_at: S::Timestamp,
+        start_at: ResumeEpoch<S::Timestamp>,
         probe: &ProbeHandle<S::Timestamp>,
     ) -> StringResult<(Stream<S, TdPyAny>, FlowChangeStream<S>)> {
         self.downcast(py)?

--- a/src/execution/epoch/periodic_epoch.rs
+++ b/src/execution/epoch/periodic_epoch.rs
@@ -80,7 +80,7 @@ where
         step_id: StepId,
         state_key: StateKey,
         mut reader: Box<dyn InputReader<crate::pyo3_extensions::TdPyAny>>,
-        start_at: S::Timestamp,
+        start_at: ResumeEpoch<u64>,
         probe: &ProbeHandle<S::Timestamp>,
     ) -> StringResult<(
         Stream<S, crate::pyo3_extensions::TdPyAny>,
@@ -103,8 +103,8 @@ where
         let flow_key = FlowKey(step_id.clone(), state_key);
 
         op_builder.build(move |mut init_caps| {
-            let change_cap = init_caps.pop().map(|cap| cap.delayed(&start_at)).unwrap();
-            let output_cap = init_caps.pop().map(|cap| cap.delayed(&start_at)).unwrap();
+            let change_cap = init_caps.pop().map(|cap| cap.delayed(&start_at.0)).unwrap();
+            let output_cap = init_caps.pop().map(|cap| cap.delayed(&start_at.0)).unwrap();
 
             let mut caps = Some((output_cap, change_cap));
             let mut epoch_started = Instant::now();

--- a/src/execution/epoch/testing_epoch.rs
+++ b/src/execution/epoch/testing_epoch.rs
@@ -81,50 +81,63 @@ where
         let info = op_builder.operator_info();
         let activator = scope.activator_for(&info.address[..]);
 
-        let flow_key = FlowKey(step_id, state_key);
+        let flow_key = FlowKey(step_id.clone(), state_key);
 
         op_builder.build(move |mut init_caps| {
-            let mut change_cap = init_caps.pop().map(|cap| cap.delayed(&start_at));
-            let mut output_cap = init_caps.pop().map(|cap| cap.delayed(&start_at));
+            let change_cap = init_caps.pop().map(|cap| cap.delayed(&start_at)).unwrap();
+            let output_cap = init_caps.pop().map(|cap| cap.delayed(&start_at)).unwrap();
 
-            let mut eof = false;
+            let mut caps = Some((output_cap, change_cap));
 
             move |_input_frontiers| {
-                if let (Some(output_cap), Some(change_cap)) =
-                    (output_cap.as_mut(), change_cap.as_mut())
-                {
+                caps = if let Some((output_cap, change_cap)) = caps.clone() {
                     assert!(output_cap.time() == change_cap.time());
                     let epoch = output_cap.time();
+
+                    let mut eof = false;
+                    let mut advance = false;
 
                     if !probe.less_than(epoch) {
                         match reader.next() {
                             Poll::Pending => {}
                             Poll::Ready(None) => {
                                 eof = true;
+                                advance = true;
                             }
                             Poll::Ready(Some(item)) => {
                                 output_wrapper.activate().session(&output_cap).give(item);
-
-                                // Snapshot just before incrementing epoch
-                                // to get the "end of the epoch" state.
-                                change_wrapper.activate().session(&change_cap).give(KChange(
-                                    flow_key.clone(),
-                                    Change::Upsert(reader.snapshot()),
-                                ));
-
-                                let next_epoch = epoch + 1;
-
-                                output_cap.downgrade(&next_epoch);
-                                change_cap.downgrade(&next_epoch);
+                                advance = true;
                             }
                         }
                     }
-                }
 
-                if eof {
-                    output_cap = None;
-                    change_cap = None;
+                    // If the the current epoch will be over, snapshot
+                    // to get "end of the epoch state".
+                    if advance || eof {
+                        let kchange = KChange(flow_key.clone(), Change::Upsert(reader.snapshot()));
+                        change_wrapper.activate().session(&change_cap).give(kchange);
+                    }
+
+                    if eof {
+                        tracing::trace!("Input {step_id:?} reached EOF");
+                        None
+                    } else if advance {
+                        let next_epoch = epoch + 1;
+                        tracing::trace!("Input {step_id:?} advancing to epoch {next_epoch:?}");
+                        Some((
+                            output_cap.delayed(&next_epoch),
+                            change_cap.delayed(&next_epoch),
+                        ))
+                    } else {
+                        Some((output_cap, change_cap))
+                    }
                 } else {
+                    None
+                };
+
+                // Wake up constantly, because we never know when
+                // input will have new data.
+                if caps.is_some() {
                     activator.activate();
                 }
             }

--- a/src/execution/epoch/testing_epoch.rs
+++ b/src/execution/epoch/testing_epoch.rs
@@ -66,7 +66,7 @@ where
         step_id: StepId,
         state_key: StateKey,
         mut reader: Box<dyn InputReader<crate::pyo3_extensions::TdPyAny>>,
-        start_at: S::Timestamp,
+        start_at: ResumeEpoch<S::Timestamp>,
         probe: &ProbeHandle<S::Timestamp>,
     ) -> StringResult<(
         Stream<S, crate::pyo3_extensions::TdPyAny>,
@@ -84,8 +84,8 @@ where
         let flow_key = FlowKey(step_id.clone(), state_key);
 
         op_builder.build(move |mut init_caps| {
-            let change_cap = init_caps.pop().map(|cap| cap.delayed(&start_at)).unwrap();
-            let output_cap = init_caps.pop().map(|cap| cap.delayed(&start_at)).unwrap();
+            let change_cap = init_caps.pop().map(|cap| cap.delayed(&start_at.0)).unwrap();
+            let output_cap = init_caps.pop().map(|cap| cap.delayed(&start_at.0)).unwrap();
 
             let mut caps = Some((output_cap, change_cap));
 

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -109,7 +109,7 @@ fn build_production_dataflow<A, PW, SW>(
     worker: &mut Worker<A>,
     flow: Py<Dataflow>,
     epoch_config: Py<EpochConfig>,
-    resume_epoch: u64,
+    resume_epoch: ResumeEpoch<u64>,
     mut resume_state: FlowStateBytes,
     store_summary: StoreSummary<u64>,
     progress_writer: PW,
@@ -365,7 +365,7 @@ fn build_and_run_resume_epoch_calc_dataflow<A, R>(
     worker: &mut Worker<A>,
     interrupt_flag: &AtomicBool,
     progress_reader: R,
-) -> StringResult<u64>
+) -> StringResult<ResumeEpoch<u64>>
 where
     A: Allocate,
     R: ProgressReader<u64> + 'static,
@@ -386,7 +386,7 @@ where
 fn build_and_run_state_loading_dataflow<A, T, R>(
     worker: &mut Worker<A>,
     interrupt_flag: &AtomicBool,
-    resume_epoch: T,
+    resume_epoch: ResumeEpoch<T>,
     state_reader: R,
 ) -> StringResult<(FlowStateBytes, StoreSummary<T>)>
 where
@@ -415,7 +415,7 @@ fn build_and_run_production_dataflow<A, PW, SW>(
     interrupt_flag: &AtomicBool,
     flow: Py<Dataflow>,
     epoch_config: Py<EpochConfig>,
-    resume_epoch: u64,
+    resume_epoch: ResumeEpoch<u64>,
     resume_state: FlowStateBytes,
     store_summary: StoreSummary<u64>,
     progress_writer: PW,

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -361,15 +361,14 @@ fn run_until_done<A: Allocate, T: Timestamp>(
     }
 }
 
-fn build_and_run_resume_epoch_calc_dataflow<A, T, R>(
+fn build_and_run_resume_epoch_calc_dataflow<A, R>(
     worker: &mut Worker<A>,
     interrupt_flag: &AtomicBool,
     progress_reader: R,
-) -> StringResult<T>
+) -> StringResult<u64>
 where
     A: Allocate,
-    T: Timestamp + Debug,
-    R: ProgressReader<T> + 'static,
+    R: ProgressReader<u64> + 'static,
 {
     let (probe, cluster_progress) = build_resume_epoch_calc_dataflow(worker, progress_reader)?;
 
@@ -378,7 +377,7 @@ where
     let resume_epoch = Rc::try_unwrap(cluster_progress)
         .expect("Resume epoch dataflow still has reference to cluster_progress")
         .into_inner()
-        .frontier();
+        .resume_epoch();
     tracing::debug!("Calculated resume epoch {resume_epoch:?}");
 
     Ok(resume_epoch)

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -43,7 +43,7 @@ use crate::pyo3_extensions::{extract_state_pair, wrap_state_pair};
 use crate::recovery::dataflows::*;
 use crate::recovery::model::*;
 use crate::recovery::python::*;
-use crate::recovery::store::in_mem::StoreSummary;
+use crate::recovery::store::in_mem::{InMemProgress, StoreSummary};
 use crate::webserver::run_webserver;
 use crate::window::WindowBuilder;
 use crate::window::{clock::ClockBuilder, StatefulWindowUnary};
@@ -111,6 +111,7 @@ fn build_production_dataflow<A, PW, SW>(
     epoch_config: Py<EpochConfig>,
     resume_epoch: ResumeEpoch<u64>,
     mut resume_state: FlowStateBytes,
+    resume_progress: InMemProgress<u64>,
     store_summary: StoreSummary<u64>,
     progress_writer: PW,
     state_writer: SW,
@@ -306,6 +307,7 @@ where
         attach_recovery_to_dataflow(
             &mut probe,
             worker_key,
+            resume_progress,
             store_summary,
             progress_writer,
             state_writer,
@@ -361,26 +363,24 @@ fn run_until_done<A: Allocate, T: Timestamp>(
     }
 }
 
-fn build_and_run_resume_epoch_calc_dataflow<A, R>(
+fn build_and_run_progress_loading_dataflow<A, R>(
     worker: &mut Worker<A>,
     interrupt_flag: &AtomicBool,
     progress_reader: R,
-) -> StringResult<ResumeEpoch<u64>>
+) -> StringResult<InMemProgress<u64>>
 where
     A: Allocate,
     R: ProgressReader<u64> + 'static,
 {
-    let (probe, cluster_progress) = build_resume_epoch_calc_dataflow(worker, progress_reader)?;
+    let (probe, progress_store) = build_progress_loading_dataflow(worker, progress_reader)?;
 
     run_until_done(worker, interrupt_flag, probe);
 
-    let resume_epoch = Rc::try_unwrap(cluster_progress)
-        .expect("Resume epoch dataflow still has reference to cluster_progress")
-        .into_inner()
-        .resume_epoch();
-    tracing::debug!("Calculated resume epoch {resume_epoch:?}");
+    let resume_progress = Rc::try_unwrap(progress_store)
+        .expect("Resume epoch dataflow still has reference to progress_store")
+        .into_inner();
 
-    Ok(resume_epoch)
+    Ok(resume_progress)
 }
 
 fn build_and_run_state_loading_dataflow<A, T, R>(
@@ -417,6 +417,7 @@ fn build_and_run_production_dataflow<A, PW, SW>(
     epoch_config: Py<EpochConfig>,
     resume_epoch: ResumeEpoch<u64>,
     resume_state: FlowStateBytes,
+    resume_progress: InMemProgress<u64>,
     store_summary: StoreSummary<u64>,
     progress_writer: PW,
     state_writer: SW,
@@ -448,6 +449,7 @@ where
             epoch_config,
             resume_epoch,
             resume_state,
+            resume_progress,
             store_summary,
             progress_writer,
             state_writer,
@@ -493,9 +495,11 @@ fn worker_main<A: Allocate>(
     })?;
 
     let span = tracing::trace_span!("Resume epoch").entered();
-    let resume_epoch =
-        build_and_run_resume_epoch_calc_dataflow(worker, interrupt_flag, progress_reader)?;
+    let resume_progress =
+        build_and_run_progress_loading_dataflow(worker, interrupt_flag, progress_reader)?;
     span.exit();
+    let resume_epoch = resume_progress.resume_epoch();
+    tracing::info!("Calculated resume epoch {resume_epoch:?}");
 
     let span = tracing::trace_span!("State loading").entered();
     let (resume_state, store_summary) =
@@ -509,6 +513,7 @@ fn worker_main<A: Allocate>(
         epoch_config,
         resume_epoch,
         resume_state,
+        resume_progress,
         store_summary,
         progress_writer,
         state_writer,

--- a/src/outputs/manual_epoch_output.rs
+++ b/src/outputs/manual_epoch_output.rs
@@ -64,7 +64,7 @@ impl ManualEpochOutputConfig {
         Python::with_gil(|py| {
             HashMap::from([
                 ("type", "ManualEpochOutputConfig".into_py(py)),
-                ("input_builder", self.output_builder.clone().into_py(py)),
+                ("output_builder", self.output_builder.clone().into_py(py)),
             ])
         })
     }

--- a/src/recovery/dataflows.rs
+++ b/src/recovery/dataflows.rs
@@ -138,7 +138,7 @@ where
 pub(crate) fn build_state_loading_dataflow<A, T, R>(
     timely_worker: &mut Worker<A>,
     reader: R,
-    resume_epoch: T,
+    resume_epoch: ResumeEpoch<T>,
 ) -> StringResult<(
     ProbeHandle<T>,
     Rc<RefCell<FlowStateBytes>>,
@@ -160,7 +160,7 @@ where
             // The resume epoch is the epoch we are starting at,
             // so only load state from before < that point. Not
             // <=.
-            .filter(move |KChange(StoreKey(epoch, _flow_key), _change)| epoch < &resume_epoch)
+            .filter(move |KChange(StoreKey(epoch, _flow_key), _change)| *epoch < resume_epoch.0)
             .recover()
             .write(resume_state.clone())
             .probe_with(&mut probe);

--- a/src/recovery/mod.rs
+++ b/src/recovery/mod.rs
@@ -25,9 +25,10 @@
 //! which allows us to recover to a synchronized point in time (the
 //! beginning of an epoch) across workers.
 //!
-//! We also snapshot the frontier of each worker as the dataflow
-//! executes. The **worker frontier** represents the oldest epoch on a
-//! given worker for which output or state backup is still pending.
+//! We also snapshot the **finalized epoch** of each worker as the
+//! dataflow executes. The finalized epoch is the newest epoch on a
+//! given worker for which output or state backup is no longer
+//! pending.
 //!
 //! See [`model`] for the specifics of what is stored for [`model::state`] and
 //! [`model::progress`].

--- a/src/recovery/model/progress.rs
+++ b/src/recovery/model/progress.rs
@@ -1,8 +1,8 @@
 //! Data model representing progress in the dataflow and the recovery
 //! system.
 //!
-//! A progress store is a K-V mapping from [`WorkerKey`] to a frontier
-//! epoch `T`.
+//! A progress store is a K-V mapping from [`WorkerKey`] to a
+//! finalized epoch `T`.
 
 use super::change::*;
 use serde::Deserialize;
@@ -21,7 +21,7 @@ pub(crate) struct WorkerKey(pub(crate) WorkerIndex);
 
 /// A change to the progress store.
 ///
-/// Notes that a worker's frontier changed.
+/// Notes that a worker's finalized epoch has changed.
 pub(crate) type ProgressChange<T> = KChange<WorkerKey, T>;
 
 /// All progress stores have to implement this writer.

--- a/src/recovery/model/progress.rs
+++ b/src/recovery/model/progress.rs
@@ -16,19 +16,31 @@ pub(crate) use crate::execution::WorkerIndex;
 pub(crate) type Tick = ();
 
 /// Unique ID for a worker.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct WorkerKey(pub(crate) WorkerIndex);
+
+/// The newest epoch for which all work has been completed.
+///
+/// The epoch just before the frontier.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub(crate) struct BorderEpoch<T>(pub(crate) T);
+
+/// The epoch we should resume from the beginning of.
+///
+/// This will be the dataflow frontier of the last execution.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) struct ResumeEpoch<T>(pub(crate) T);
 
 /// A change to the progress store.
 ///
 /// Notes that a worker's finalized epoch has changed.
-pub(crate) type ProgressChange<T> = KChange<WorkerKey, T>;
+pub(crate) type ProgressChange<T> = KChange<WorkerKey, BorderEpoch<T>>;
 
 /// All progress stores have to implement this writer.
 ///
 /// Since trait aliases don't work in stable, don't actually `impl`
 /// this, but it's used for bounds.
-pub(crate) trait ProgressWriter<T>: KWriter<WorkerKey, T> {}
+pub(crate) trait ProgressWriter<T>: KWriter<WorkerKey, BorderEpoch<T>> {}
 
 impl<T, P> ProgressWriter<T> for Box<P> where P: ProgressWriter<T> + ?Sized {}
 
@@ -36,6 +48,6 @@ impl<T, P> ProgressWriter<T> for Box<P> where P: ProgressWriter<T> + ?Sized {}
 ///
 /// Since trait aliases don't work in stable, don't actually `impl`
 /// this, but it's used for bounds.
-pub(crate) trait ProgressReader<T>: KReader<WorkerKey, T> {}
+pub(crate) trait ProgressReader<T>: KReader<WorkerKey, BorderEpoch<T>> {}
 
 impl<T, P> ProgressReader<T> for Box<P> where P: ProgressReader<T> + ?Sized {}

--- a/src/recovery/operators.rs
+++ b/src/recovery/operators.rs
@@ -54,48 +54,39 @@ pub(crate) type StoreSummaryStream<S> =
     Stream<S, StoreChangeSummary<<S as ScopeParent>::Timestamp>>;
 
 /// A stream of changes to a progress store.
-pub(crate) type ProgressStream<S> = Stream<S, ProgressChange<<S as ScopeParent>::Timestamp>>;
+pub(crate) type ProgressStream<S> = Stream<S, ProgressChange<u64>>;
 
-impl<K, V> KChange<K, V>
-where
-    K: Hash,
-{
-    fn route_by_key() -> impl Fn(&Self) -> u64 {
-        |Self(key, _value)| {
-            let mut hasher = DefaultHasher::new();
-            key.hash(&mut hasher);
-            hasher.finish()
-        }
-    }
+pub(crate) trait Route {
+    /// Hash this key for Timely.
+    ///
+    /// Timely uses the result here to decide which worker to send
+    /// this data.
+    fn route(&self) -> u64;
 }
 
-impl<T, V> KChange<StoreKey<T>, V> {
-    fn route_by_flow_key() -> impl Fn(&Self) -> u64 {
-        |Self(StoreKey(_epoch, flow_key), _value)| {
-            let mut hasher = DefaultHasher::new();
-            flow_key.hash(&mut hasher);
-            hasher.finish()
-        }
-    }
-}
-
-impl WorkerIndex {
+impl Route for WorkerIndex {
     /// Tell Timely to route to this worker.
     // My read of
     // https://github.com/TimelyDataflow/timely-dataflow/blob/v0.12.0/timely/src/dataflow/channels/pushers/exchange.rs#L61-L90
     // says that if you return the worker index, it'll be
     // routed to that worker.
-    pub(crate) fn route(&self) -> u64 {
+    fn route(&self) -> u64 {
         self.0 as u64
     }
 }
 
-impl StateKey {
-    /// Hash this key for Timely.
-    ///
-    /// Timely uses the result here to decide which worker to send
-    /// this data.
-    pub(crate) fn route(&self) -> u64 {
+impl Route for WorkerKey {
+    /// As this is the key into the progress store during backup, this
+    /// can be evenly distributed.
+    fn route(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+impl Route for StateKey {
+    fn route(&self) -> u64 {
         match self {
             Self::Hash(key) => {
                 let mut hasher = DefaultHasher::new();
@@ -104,6 +95,29 @@ impl StateKey {
             }
             Self::Worker(index) => index.route(),
         }
+    }
+}
+
+impl<T> Route for StoreKey<T>
+where
+    T: Hash,
+{
+    /// As this is the key into the progress store during backup, this
+    /// can be evenly distributed.
+    fn route(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+impl Route for FlowKey {
+    /// This is hacky, but whenever we're writing by FlowKey, it's
+    /// actually for recovering operator state which is routed by
+    /// StateKey, so we have to really route there.
+    fn route(&self) -> u64 {
+        let FlowKey(_step_id, state_key) = self;
+        state_key.route()
     }
 }
 
@@ -166,8 +180,7 @@ where
 
 impl<S, D> Progress<S, D> for Stream<S, D>
 where
-    S: Scope,
-    S::Timestamp: TotalOrder,
+    S: Scope<Timestamp = u64>,
     D: Data,
 {
     fn progress(&self, worker_key: WorkerKey) -> ProgressStream<S> {
@@ -198,7 +211,7 @@ where
 pub(crate) trait Write<S, K, V, W>
 where
     S: Scope,
-    K: ExchangeData + Hash,
+    K: ExchangeData + Route,
     V: ExchangeData,
     W: KWriter<K, V> + 'static,
 {
@@ -212,7 +225,7 @@ where
 impl<S, K, V, W> Write<S, K, V, W> for KChangeStream<S, K, V>
 where
     S: Scope,
-    K: ExchangeData + Hash,
+    K: ExchangeData + Route,
     V: ExchangeData,
     W: KWriter<K, V> + 'static,
 {
@@ -224,7 +237,7 @@ where
         // V)`. It's just slightly longer, but clearer to write it out
         // ourselves.
         self.unary_notify(
-            Exchange::new(KChange::route_by_key()),
+            Exchange::new(|KChange(key, _change): &KChange<K, V>| key.route()),
             "write",
             None,
             move |input, output, ncater| {
@@ -256,6 +269,59 @@ where
                 });
             },
         )
+    }
+}
+
+pub(crate) trait BroadcastWrite<S, K, V, W>
+where
+    S: Scope,
+    K: ExchangeData,
+    V: ExchangeData,
+    W: KWriter<K, V> + 'static,
+{
+    /// This is identical to [`Write::write`] but because of how
+    /// exchange pacts work, we have to manually insert broadcast.
+    fn broadcast_write(&self, writer: W) -> ClockStream<S>;
+}
+
+impl<S, K, V, W> BroadcastWrite<S, K, V, W> for KChangeStream<S, K, V>
+where
+    S: Scope,
+    K: ExchangeData,
+    V: ExchangeData,
+    W: KWriter<K, V> + 'static,
+{
+    fn broadcast_write(&self, mut writer: W) -> ClockStream<S> {
+        let mut tmp_incoming = Vec::new();
+        let mut incoming_buffer = HashMap::new();
+
+        self.broadcast()
+            .unary_notify(Pipeline, "write", None, move |input, output, ncater| {
+                input.for_each(|cap, incoming| {
+                    let epoch = cap.time();
+
+                    assert!(tmp_incoming.is_empty());
+                    incoming.swap(&mut tmp_incoming);
+
+                    incoming_buffer
+                        .entry(epoch.clone())
+                        .or_insert_with(Vec::new)
+                        .append(&mut tmp_incoming);
+
+                    ncater.notify_at(cap.retain());
+                });
+
+                ncater.for_each(|cap, _count, _ncater| {
+                    let epoch = cap.time();
+
+                    if let Some(incoming) = incoming_buffer.remove(epoch) {
+                        writer.write_many(incoming);
+
+                        let mut session = output.session(&cap);
+                        session.give(());
+                    }
+                });
+            })
     }
 }
 
@@ -316,7 +382,7 @@ where
         let mut state = InMemStore::new();
 
         self.unary_notify(
-            Exchange::new(KChange::route_by_flow_key()),
+            Exchange::new(|KChange(StoreKey(_epoch, flow_key), _change)| flow_key.route()),
             "recover",
             None,
             move |input, output, ncater| {
@@ -354,7 +420,7 @@ where
     S: Scope,
 {
     fn summary(&self) -> StoreSummaryStream<S> {
-        self.map(|KChange(key, change)| KChange(key, change.map(|c| c.typ())))
+        self.map(|KChange(store_key, change)| KChange(store_key, change.map(|c| c.typ())))
     }
 }
 
@@ -380,6 +446,7 @@ where
     fn garbage_collect(
         &self,
         progress_stream: ProgressStream<S>,
+        cluster_progress: InMemProgress<S::Timestamp>,
         summary: StoreSummary<S::Timestamp>,
     ) -> StoreChangeStream<S>;
 }
@@ -391,6 +458,7 @@ where
     fn garbage_collect(
         &self,
         progress_stream: ProgressStream<S>,
+        mut cluster_progress: InMemProgress<S::Timestamp>,
         mut summary: StoreSummary<S::Timestamp>,
     ) -> StoreChangeStream<S> {
         let mut tmp_summary = Vec::new();
@@ -399,13 +467,11 @@ where
         let mut store_buffer = HashMap::new();
         let mut progress_buffer = HashMap::new();
 
-        let mut cluster_progress = InMemProgress::new();
-
         // This is effectively "binary aggregate with epoch" but Timely
         // doesn't give us that.
         self.binary_notify(
             &progress_stream,
-            Exchange::new(KChange::route_by_flow_key()),
+            Exchange::new(|KChange(StoreKey(_epoch, flow_key), _change)| flow_key.route()),
             Pipeline,
             "garbage_collect",
             None,

--- a/src/recovery/operators.rs
+++ b/src/recovery/operators.rs
@@ -187,8 +187,8 @@ where
             });
 
             ncater.for_each(|cap, _count, _ncater| {
-                let epoch = cap.time();
-                let kchange = KChange(worker_key.clone(), Change::Upsert(epoch.clone()));
+                let epoch = BorderEpoch(cap.time().clone());
+                let kchange = KChange(worker_key.clone(), Change::Upsert(epoch));
                 output.session(&cap).give(kchange);
             });
         })

--- a/src/recovery/store/kafka.rs
+++ b/src/recovery/store/kafka.rs
@@ -215,5 +215,8 @@ impl<T> StateReader<T> for KafkaReader<StoreKey<T>, Change<StateBytes>> where
     T: DeserializeOwned + Debug
 {
 }
-impl<T> ProgressWriter<T> for KafkaWriter<WorkerKey, T> where T: Serialize + Debug {}
-impl<T> ProgressReader<T> for KafkaReader<WorkerKey, T> where T: DeserializeOwned + Debug {}
+impl<T> ProgressWriter<T> for KafkaWriter<WorkerKey, BorderEpoch<T>> where T: Serialize + Debug {}
+impl<T> ProgressReader<T> for KafkaReader<WorkerKey, BorderEpoch<T>> where
+    T: DeserializeOwned + Debug
+{
+}


### PR DESCRIPTION
## Add resume continuation test; currently fails

Since throwing exceptions while executing a dataflow in a multi-worker context causes Timely to panic and abort the process, that means that Python's multiprocessing wigs out and hangs. This makes it hard to use our convenient `spawn_cluster` to run tests. So instead of testing recovery via the "fail and resume" case, we'll test it via the "finish and continue" case. We want to allow someone to run a dataflow on a finite input, have the state of all operators be persisted, and then allow **continuing** the dataflow when the input has more data from the previous end.

So we start by writing a test for this behavior.

## Makes EOF end current epoch and tests continuation

Turns out the way we were managing epochs if the input finishes was incompatible with dataflow continuation. We were previously backing up the current frontier of each worker as time progressed, but ignoring the empty frontier of EOF on input and not writing that out. That means that the resume epoch calculated on continuation would be last in-flight epoch. That results in the dataflow resuming from the beginning of that epoch, which means re-processing the last epoch's worth of data unnecessarily.

To clarify what's going on here, I introduce the concept of the border epoch which is in contrast to the frontier epoch. The **border epoch** is what we've previously been verbosely calling the "newest / largest closed epoch". It'll be the epoch just before the frontier epoch. The recovery system progress tracking feels a little more intuitive if we write out the border epoch as it advances ("each worker: save the epoch you just finished working on") rather than writing out the frontier ("each worker: save the current unfinished epoch"). The latter definition is tough in the continuation context because the frontier is empty, so you have to special case writing out that concept. The former seems more straightforward.

Once we know all the border epochs from the previous execution, the resume epoch has the same interpretation ("what epoch should the cluster resume from the beginning of?") and is the epoch right after the minimum border over all workers in the previous execution.

As part of that, I wrap our previous bare `u64` epochs in formal `ResumeEpoch` and `BorderEpoch` newtypes to prevent confusion and make sure each component knows what kind of epoch interpretation it expects.

## Hack to run docs tests and Python tests separately to avoid pickling / multiprocess bug

Utter madness here but something about importing `redirect_stdout` in our Markdown tests runner breaks multiprocessing suddenly. So to hack around this we run our tests in two different pytest invocations in CI: `pytest pytests/` for the Python tests, and separately `pytest docs/` for the Markdown tests. Unclear what dragons would emerge if one of our Markdown tests wanted to use `spawn_cluster`. Really we got to move onto something more robust.

## Add explicit Route trait for data. Fixes issue with resume state not being routed to the correct worker.

Alright, now we can get to our original bug: During execution of the production dataflow, we route data based on the `StateKey`. We also need to route the final deserialized version of resume state in the same way. Previously I did not, and instead routed on one of the recovery system keys, either `StoreKey` or `FlowKey` and thus resume state was loaded onto a worker that would never actually see new data for that state key.

Goes through and implements a new `Route` trait for each "key" that we might need to route on and thinks about which worker will need this data. This still feels fragile because it's a little tricky to double check your routing between backup, resume, and production parts of the dataflows.

Also also, calculation of the resume epoch was incorrect, as the dataflow to calculate it was "un-broadcasting" progress changes during the write to the `InMemProgress`. Whenever we want to do a "broadcast write" we need to have a custom operator because the exchange is different. Copies and modifies `Write` into a separate `BroadcastWrite` to do that.