### PR TITLE
Adds collect window operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Adds `collect_window` operator.
+
 ## 0.13.1
 
 - Added Google Colab support.

--- a/src/operators/collect_window.rs
+++ b/src/operators/collect_window.rs
@@ -1,0 +1,58 @@
+use chrono::{DateTime, Utc};
+use pyo3::prelude::*;
+use tracing::field::debug;
+
+use crate::{pyo3_extensions::TdPyAny, window::*};
+
+/// Implements the collect window operator.
+///
+/// Append values in a window onto a list. Emit the list when the
+/// window closes.
+pub(crate) struct CollectWindowLogic {
+    acc: Vec<(TdPyAny, DateTime<Utc>)>,
+}
+
+impl CollectWindowLogic {
+    pub(crate) fn builder() -> impl Fn(Option<StateBytes>) -> Self {
+        move |resume_snapshot| {
+            let acc = resume_snapshot
+                .map(StateBytes::de::<Vec<(TdPyAny, DateTime<Utc>)>>)
+                .unwrap_or_default();
+            Self { acc }
+        }
+    }
+}
+
+impl WindowLogic<TdPyAny, TdPyAny, Option<TdPyAny>> for CollectWindowLogic {
+    #[tracing::instrument(
+        name = "collect_window",
+        level = "trace",
+        skip(self),
+        fields(self.acc)
+    )]
+    fn with_next(&mut self, next_value: Option<(TdPyAny, DateTime<Utc>)>) -> Option<TdPyAny> {
+        match next_value {
+            Some((value, item_time)) => {
+                self.acc.push((value, item_time));
+                tracing::Span::current().record("self.acc", debug(&self.acc));
+                None
+            }
+            // Emit in item time order at end of window.
+            None => {
+                self.acc
+                    .sort_by_key(|(_value, item_time)| item_time.clone());
+                let new_acc = Vec::new();
+                let out_values: Vec<TdPyAny> = std::mem::replace(&mut self.acc, new_acc)
+                    .into_iter()
+                    .map(|(value, _item_time)| value)
+                    .collect();
+                Python::with_gil(|py| Some(out_values.into_py(py).into()))
+            }
+        }
+    }
+
+    #[tracing::instrument(name = "collect_window_snapshot", level = "trace", skip_all)]
+    fn snapshot(&self) -> StateBytes {
+        StateBytes::ser::<Vec<(TdPyAny, DateTime<Utc>)>>(&self.acc)
+    }
+}

--- a/src/operators/collect_window.rs
+++ b/src/operators/collect_window.rs
@@ -41,9 +41,9 @@ impl WindowLogic<TdPyAny, TdPyAny, Option<TdPyAny>> for CollectWindowLogic {
             None => {
                 self.acc
                     .sort_by_key(|(_value, item_time)| item_time.clone());
-                let new_acc = Vec::new();
-                let out_values: Vec<TdPyAny> = std::mem::replace(&mut self.acc, new_acc)
-                    .into_iter()
+                let out_values: Vec<TdPyAny> = self
+                    .acc
+                    .drain(..)
                     .map(|(value, _item_time)| value)
                     .collect();
                 Python::with_gil(|py| Some(out_values.into_py(py).into()))

--- a/src/operators/fold_window.rs
+++ b/src/operators/fold_window.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use pyo3::prelude::*;
 use tracing::field::debug;
 
@@ -40,9 +41,9 @@ impl WindowLogic<TdPyAny, TdPyAny, Option<TdPyAny>> for FoldWindowLogic {
         skip(self),
         fields(self.builder, self.folder, self.acc, updated_acc),
     )]
-    fn with_next(&mut self, next_value: Option<TdPyAny>) -> Option<TdPyAny> {
+    fn with_next(&mut self, next_value: Option<(TdPyAny, DateTime<Utc>)>) -> Option<TdPyAny> {
         match next_value {
-            Some(value) => Python::with_gil(|py| {
+            Some((value, _item_time)) => Python::with_gil(|py| {
                 let acc: TdPyAny = self
                     .acc
                     .take()

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -15,6 +15,7 @@ use crate::unwrap_any;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 
+pub(crate) mod collect_window;
 pub(crate) mod fold_window;
 pub(crate) mod reduce;
 pub(crate) mod reduce_window;

--- a/src/operators/reduce_window.rs
+++ b/src/operators/reduce_window.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use pyo3::prelude::*;
 use tracing::field::debug;
 
@@ -35,9 +36,9 @@ impl WindowLogic<TdPyAny, TdPyAny, Option<TdPyAny>> for ReduceWindowLogic {
         skip(self),
         fields(self.reducer, self.acc, updated_acc)
     )]
-    fn with_next(&mut self, next_value: Option<TdPyAny>) -> Option<TdPyAny> {
+    fn with_next(&mut self, next_value: Option<(TdPyAny, DateTime<Utc>)>) -> Option<TdPyAny> {
         match next_value {
-            Some(value) => {
+            Some((value, _item_time)) => {
                 Python::with_gil(|py| {
                     let updated_acc: TdPyAny = match &self.acc {
                         // If there's no previous state for this key,

--- a/src/window/tumbling_window.rs
+++ b/src/window/tumbling_window.rs
@@ -105,9 +105,9 @@ impl Windower for TumblingWindower {
     fn insert(
         &mut self,
         watermark: &DateTime<Utc>,
-        item_time: DateTime<Utc>,
+        item_time: &DateTime<Utc>,
     ) -> Vec<Result<WindowKey, InsertError>> {
-        let since_start_at = item_time - self.start_at;
+        let since_start_at = *item_time - self.start_at;
         let window_count = since_start_at.num_milliseconds() / self.length.num_milliseconds();
 
         let key = WindowKey(window_count);


### PR DESCRIPTION
Adds a new windowing operator that returns a time-sorted list of all
the values within a window.

Tests.

Had to thread through the `item_time` into the
`WindowLogic::with_next` to allow consistent sorting. We might want to
expose that to the custom `fold_window` and `reduce_window` operators
as of now they don't guarantee any order of items being aggregated.
