### PR TITLE
Replace generic epoch with explicit u64

### DIFF
--- a/src/execution/epoch/mod.rs
+++ b/src/execution/epoch/mod.rs
@@ -63,8 +63,8 @@ pub(crate) trait EpochBuilder<S: Scope<Timestamp = u64>> {
         step_id: StepId,
         key: StateKey,
         reader: Box<dyn InputReader<TdPyAny>>,
-        start_at: ResumeEpoch<S::Timestamp>,
-        probe: &ProbeHandle<S::Timestamp>,
+        start_at: ResumeEpoch,
+        probe: &ProbeHandle<u64>,
     ) -> StringResult<(Stream<S, TdPyAny>, FlowChangeStream<S>)>;
 }
 
@@ -79,8 +79,8 @@ where
         step_id: StepId,
         key: StateKey,
         reader: Box<dyn InputReader<TdPyAny>>,
-        start_at: ResumeEpoch<S::Timestamp>,
-        probe: &ProbeHandle<S::Timestamp>,
+        start_at: ResumeEpoch,
+        probe: &ProbeHandle<u64>,
     ) -> StringResult<(Stream<S, TdPyAny>, FlowChangeStream<S>)> {
         self.downcast(py)?
             .build(py, scope, step_id, key, reader, start_at, probe)

--- a/src/execution/epoch/periodic_epoch.rs
+++ b/src/execution/epoch/periodic_epoch.rs
@@ -80,8 +80,8 @@ where
         step_id: StepId,
         state_key: StateKey,
         mut reader: Box<dyn InputReader<crate::pyo3_extensions::TdPyAny>>,
-        start_at: ResumeEpoch<u64>,
-        probe: &ProbeHandle<S::Timestamp>,
+        start_at: ResumeEpoch,
+        probe: &ProbeHandle<u64>,
     ) -> StringResult<(
         Stream<S, crate::pyo3_extensions::TdPyAny>,
         FlowChangeStream<S>,

--- a/src/execution/epoch/testing_epoch.rs
+++ b/src/execution/epoch/testing_epoch.rs
@@ -66,8 +66,8 @@ where
         step_id: StepId,
         state_key: StateKey,
         mut reader: Box<dyn InputReader<crate::pyo3_extensions::TdPyAny>>,
-        start_at: ResumeEpoch<S::Timestamp>,
-        probe: &ProbeHandle<S::Timestamp>,
+        start_at: ResumeEpoch,
+        probe: &ProbeHandle<u64>,
     ) -> StringResult<(
         Stream<S, crate::pyo3_extensions::TdPyAny>,
         FlowChangeStream<S>,

--- a/src/recovery/model/progress.rs
+++ b/src/recovery/model/progress.rs
@@ -2,7 +2,7 @@
 //! system.
 //!
 //! A progress store is a K-V mapping from [`WorkerKey`] to a
-//! finalized epoch `T`.
+//! finalized `Epoch`.
 
 use super::change::*;
 use serde::Deserialize;
@@ -23,31 +23,31 @@ pub(crate) struct WorkerKey(pub(crate) WorkerIndex);
 ///
 /// The epoch just before the frontier.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub(crate) struct BorderEpoch<T>(pub(crate) T);
+pub(crate) struct BorderEpoch(pub(crate) u64);
 
 /// The epoch we should resume from the beginning of.
 ///
 /// This will be the dataflow frontier of the last execution.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(crate) struct ResumeEpoch<T>(pub(crate) T);
+pub(crate) struct ResumeEpoch(pub(crate) u64);
 
 /// A change to the progress store.
 ///
 /// Notes that a worker's finalized epoch has changed.
-pub(crate) type ProgressChange<T> = KChange<WorkerKey, BorderEpoch<T>>;
+pub(crate) type ProgressChange = KChange<WorkerKey, BorderEpoch>;
 
 /// All progress stores have to implement this writer.
 ///
 /// Since trait aliases don't work in stable, don't actually `impl`
 /// this, but it's used for bounds.
-pub(crate) trait ProgressWriter<T>: KWriter<WorkerKey, BorderEpoch<T>> {}
+pub(crate) trait ProgressWriter: KWriter<WorkerKey, BorderEpoch> {}
 
-impl<T, P> ProgressWriter<T> for Box<P> where P: ProgressWriter<T> + ?Sized {}
+impl<P> ProgressWriter for Box<P> where P: ProgressWriter + ?Sized {}
 
 /// All progress stores have to implement this reader.
 ///
 /// Since trait aliases don't work in stable, don't actually `impl`
 /// this, but it's used for bounds.
-pub(crate) trait ProgressReader<T>: KReader<WorkerKey, BorderEpoch<T>> {}
+pub(crate) trait ProgressReader: KReader<WorkerKey, BorderEpoch> {}
 
-impl<T, P> ProgressReader<T> for Box<P> where P: ProgressReader<T> + ?Sized {}
+impl<P> ProgressReader for Box<P> where P: ProgressReader + ?Sized {}

--- a/src/recovery/model/state.rs
+++ b/src/recovery/model/state.rs
@@ -54,9 +54,13 @@ pub(crate) enum StateKey {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct FlowKey(pub(crate) StepId, pub(crate) StateKey);
 
+///
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub(crate) struct SnapshotEpoch(pub(crate) u64);
+
 /// Key to route state within the state store.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct StoreKey<T>(pub(crate) T, pub(crate) FlowKey);
+pub(crate) struct StoreKey(pub(crate) SnapshotEpoch, pub(crate) FlowKey);
 
 /// A snapshot of state for a specific key within a step.
 ///
@@ -93,25 +97,25 @@ impl StateBytes {
 pub(crate) type FlowChange = KChange<FlowKey, StateBytes>;
 
 /// A change to the state store.
-pub(crate) type StoreChange<T> = KChange<StoreKey<T>, Change<StateBytes>>;
+pub(crate) type StoreChange = KChange<StoreKey, Change<StateBytes>>;
 
 /// All state stores have to implement this writer.
-pub(crate) trait StateWriter<T>: KWriter<StoreKey<T>, Change<StateBytes>> {}
+pub(crate) trait StateWriter: KWriter<StoreKey, Change<StateBytes>> {}
 
-impl<T, P> StateWriter<T> for Box<P> where P: StateWriter<T> + ?Sized {}
-impl<T, P> StateWriter<T> for Rc<RefCell<P>> where P: StateWriter<T> + ?Sized {}
+impl<P> StateWriter for Box<P> where P: StateWriter + ?Sized {}
+impl<P> StateWriter for Rc<RefCell<P>> where P: StateWriter + ?Sized {}
 
 /// All state stores have to implement this reader.
-pub(crate) trait StateReader<T>: KReader<StoreKey<T>, Change<StateBytes>> {}
+pub(crate) trait StateReader: KReader<StoreKey, Change<StateBytes>> {}
 
-impl<T, P> StateReader<T> for Box<P> where P: StateReader<T> + ?Sized {}
+impl<P> StateReader for Box<P> where P: StateReader + ?Sized {}
 
 /// A change to the state store, but elide the actual state change
 /// within the dataflow and only keep the "type" of change.
 ///
 /// This is used to allow the GC component to not need to store full
 /// state snapshots.
-pub(crate) type StoreChangeSummary<T> = KChange<StoreKey<T>, ChangeType>;
+pub(crate) type StoreChangeSummary = KChange<StoreKey, ChangeType>;
 
 /// A snapshot of all state within a step.
 ///

--- a/src/recovery/python.rs
+++ b/src/recovery/python.rs
@@ -294,7 +294,7 @@ pub(crate) fn build_recovery_writers(
     worker_index: usize,
     worker_count: usize,
     config: Py<RecoveryConfig>,
-) -> StringResult<(Box<dyn ProgressWriter<u64>>, Box<dyn StateWriter<u64>>)> {
+) -> StringResult<(Box<dyn ProgressWriter>, Box<dyn StateWriter>)> {
     // Horrible news: we have to be very studious and release the GIL
     // any time we know we have it and we call into complex Rust
     // libraries because internally it might call log!() on a
@@ -369,7 +369,7 @@ pub(crate) fn build_recovery_readers(
     worker_index: usize,
     worker_count: usize,
     config: Py<RecoveryConfig>,
-) -> StringResult<(Box<dyn ProgressReader<u64>>, Box<dyn StateReader<u64>>)> {
+) -> StringResult<(Box<dyn ProgressReader>, Box<dyn StateReader>)> {
     // See comment about the GIL in
     // [`build_recovery_writers`].
     let config = config.as_ref(py);

--- a/src/recovery/store/kafka.rs
+++ b/src/recovery/store/kafka.rs
@@ -210,13 +210,7 @@ where
     }
 }
 
-impl<T> StateWriter<T> for KafkaWriter<StoreKey<T>, Change<StateBytes>> where T: Serialize + Debug {}
-impl<T> StateReader<T> for KafkaReader<StoreKey<T>, Change<StateBytes>> where
-    T: DeserializeOwned + Debug
-{
-}
-impl<T> ProgressWriter<T> for KafkaWriter<WorkerKey, BorderEpoch<T>> where T: Serialize + Debug {}
-impl<T> ProgressReader<T> for KafkaReader<WorkerKey, BorderEpoch<T>> where
-    T: DeserializeOwned + Debug
-{
-}
+impl StateWriter for KafkaWriter<StoreKey, Change<StateBytes>> {}
+impl StateReader for KafkaReader<StoreKey, Change<StateBytes>> {}
+impl ProgressWriter for KafkaWriter<WorkerKey, BorderEpoch> {}
+impl ProgressReader for KafkaReader<WorkerKey, BorderEpoch> {}

--- a/src/recovery/store/noop.rs
+++ b/src/recovery/store/noop.rs
@@ -28,7 +28,7 @@ impl<K, V> KReader<K, V> for NoOpStore {
     }
 }
 
-impl<T> StateWriter<T> for NoOpStore where T: Debug {}
-impl<T> StateReader<T> for NoOpStore {}
-impl<T> ProgressWriter<T> for NoOpStore where T: Debug {}
-impl<T> ProgressReader<T> for NoOpStore {}
+impl StateWriter for NoOpStore {}
+impl StateReader for NoOpStore {}
+impl ProgressWriter for NoOpStore {}
+impl ProgressReader for NoOpStore {}


### PR DESCRIPTION
We had a ton of generic `<T>` which I originally thought we might want
to use in case we wanted to swithc the type of our epochs. But it
turns out for recovery we have to do some epoch arithmetic so we were
effetively pinning it to `u64` anyway. This gets rid of that
complexity and hard codes that type.
