### PR TITLE
Store execution IDs and worker count for recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Fixes issue with multi-worker recovery. If the cluster crashed
+  before all workers had completed their first epoch, the cluster
+  would resume from the incorrect position. This requires a change to
+  the recovery store. You cannot resume from recovery data written
+  with an older version.
+
 ## 0.14.0
 
 - Dataflow continuation now works. If you run a dataflow over a finite

--- a/pytests/test_recovery.py
+++ b/pytests/test_recovery.py
@@ -229,7 +229,7 @@ def test_continuation(entry_point, inp, out, recovery_config):
     armed = Event()
 
     # Since we're modifying the input, use the fixture so it works
-    # across processes.
+    # across processes. Currently, `inp = []`.
     inp.extend(
         [
             ("a", 4, False),

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -123,7 +123,7 @@ fn build_production_dataflow<A, PW, SW>(
     epoch_config: Py<EpochConfig>,
     resume_from: ResumeFrom,
     mut resume_state: FlowStateBytes,
-    resume_progress: InMemProgress,
+    mut resume_progress: InMemProgress,
     store_summary: StoreSummary,
     mut progress_writer: PW,
     state_writer: SW,
@@ -140,10 +140,12 @@ where
 
     let worker_key = WorkerKey(ex, worker_index);
 
-    progress_writer.write(KChange(
+    let progress_init = KChange(
         worker_key.clone(),
         Change::Upsert(ProgressMsg::Init(worker_count, resume_epoch)),
-    ));
+    );
+    resume_progress.write(progress_init.clone());
+    progress_writer.write(progress_init);
 
     worker.dataflow(|scope| {
         let flow = flow.as_ref(py).borrow();

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -76,10 +76,23 @@ use self::epoch::{
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub(crate) struct WorkerIndex(pub(crate) usize);
 
-impl IntoPy<PyObject> for WorkerIndex {
-    fn into_py(self, py: Python) -> Py<PyAny> {
-        self.0.into_py(py)
+/// Integer representing the number of workers in a cluster.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct WorkerCount(pub(crate) usize);
+
+impl WorkerCount {
+    /// Iterate through all workers in this cluster.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = WorkerIndex> {
+        (0..self.0).map(WorkerIndex)
     }
+}
+
+#[test]
+fn worker_count_iter_works() {
+    let count = WorkerCount(3);
+    let found: Vec<_> = count.iter().collect();
+    let expected = vec![WorkerIndex(0), WorkerIndex(1), WorkerIndex(2)];
+    assert_eq!(found, expected);
 }
 
 /// Generate the [`StateKey`] that represents this worker and
@@ -108,11 +121,11 @@ fn build_production_dataflow<A, PW, SW>(
     worker: &mut Worker<A>,
     flow: Py<Dataflow>,
     epoch_config: Py<EpochConfig>,
-    resume_epoch: ResumeEpoch,
+    resume_from: ResumeFrom,
     mut resume_state: FlowStateBytes,
     resume_progress: InMemProgress,
     store_summary: StoreSummary,
-    progress_writer: PW,
+    mut progress_writer: PW,
     state_writer: SW,
 ) -> StringResult<ProbeHandle<u64>>
 where
@@ -120,10 +133,17 @@ where
     PW: ProgressWriter + 'static,
     SW: StateWriter + 'static,
 {
-    let worker_index = WorkerIndex(worker.index());
-    let worker_count = worker.peers();
+    let ResumeFrom(ex, resume_epoch) = resume_from;
 
-    let worker_key = WorkerKey(worker_index);
+    let worker_index = WorkerIndex(worker.index());
+    let worker_count = WorkerCount(worker.peers());
+
+    let worker_key = WorkerKey(ex, worker_index);
+
+    progress_writer.write(KChange(
+        worker_key.clone(),
+        Change::Upsert(ProgressMsg::Init(worker_count, resume_epoch)),
+    ));
 
     worker.dataflow(|scope| {
         let flow = flow.as_ref(py).borrow();
@@ -443,7 +463,7 @@ fn build_and_run_production_dataflow<A, PW, SW>(
     interrupt_flag: &AtomicBool,
     flow: Py<Dataflow>,
     epoch_config: Py<EpochConfig>,
-    resume_epoch: ResumeEpoch,
+    resume_from: ResumeFrom,
     resume_state: FlowStateBytes,
     resume_progress: InMemProgress,
     store_summary: StoreSummary,
@@ -475,7 +495,7 @@ where
             worker,
             flow,
             epoch_config,
-            resume_epoch,
+            resume_from,
             resume_state,
             resume_progress,
             store_summary,
@@ -509,11 +529,13 @@ fn worker_main<A: Allocate>(
     epoch_config: Option<Py<EpochConfig>>,
     recovery_config: Option<Py<RecoveryConfig>>,
 ) -> StringResult<()> {
-    let epoch_config = epoch_config.unwrap_or_else(default_epoch_config);
-    let recovery_config = recovery_config.unwrap_or_else(default_recovery_config);
-
     let worker_index = worker.index();
     let worker_count = worker.peers();
+
+    tracing::info!("Worker {worker_index:?} of {worker_count:?} starting up");
+
+    let epoch_config = epoch_config.unwrap_or_else(default_epoch_config);
+    let recovery_config = recovery_config.unwrap_or_else(default_recovery_config);
 
     let (progress_reader, state_reader) = Python::with_gil(|py| {
         build_recovery_readers(py, worker_index, worker_count, recovery_config.clone())
@@ -526,10 +548,11 @@ fn worker_main<A: Allocate>(
     let resume_progress =
         build_and_run_progress_loading_dataflow(worker, interrupt_flag, progress_reader)?;
     span.exit();
-    let resume_epoch = resume_progress.resume_epoch();
-    tracing::info!("Calculated resume epoch {resume_epoch:?}");
+    let resume_from = resume_progress.resume_from();
+    tracing::info!("Calculated {resume_from:?}");
 
     let span = tracing::trace_span!("State loading").entered();
+    let ResumeFrom(_ex, resume_epoch) = resume_from;
     let (resume_state, store_summary) =
         build_and_run_state_loading_dataflow(worker, interrupt_flag, resume_epoch, state_reader)?;
     span.exit();
@@ -539,7 +562,7 @@ fn worker_main<A: Allocate>(
         interrupt_flag,
         flow,
         epoch_config,
-        resume_epoch,
+        resume_from,
         resume_state,
         resume_progress,
         store_summary,
@@ -548,6 +571,8 @@ fn worker_main<A: Allocate>(
     )?;
 
     shutdown_worker(worker);
+
+    tracing::info!("Worker {worker_index:?} of {worker_count:?} shut down");
 
     Ok(())
 }

--- a/src/inputs/kafka_input.rs
+++ b/src/inputs/kafka_input.rs
@@ -16,7 +16,7 @@ use send_wrapper::SendWrapper;
 use serde::{Deserialize, Serialize};
 
 use crate::common::{pickle_extract, StringResult};
-use crate::execution::WorkerIndex;
+use crate::execution::{WorkerCount, WorkerIndex};
 use crate::pyo3_extensions::TdPyAny;
 use crate::recovery::model::StateBytes;
 
@@ -72,7 +72,7 @@ impl InputBuilder for KafkaInputConfig {
         &self,
         py: Python,
         worker_index: WorkerIndex,
-        worker_count: usize,
+        worker_count: WorkerCount,
         resume_snapshot: Option<StateBytes>,
     ) -> StringResult<Box<dyn InputReader<TdPyAny>>> {
         let starting_offset = match self.starting_offset.as_str() {
@@ -229,7 +229,7 @@ impl KafkaInput {
         starting_offset: Offset,
         additional_properties: &Option<HashMap<String, String>>,
         worker_index: WorkerIndex,
-        worker_count: usize,
+        worker_count: WorkerCount,
         resume_snapshot: Option<StateBytes>,
     ) -> Self {
         let mut positions = resume_snapshot
@@ -262,7 +262,7 @@ impl KafkaInput {
         }
 
         let mut partitions = TopicPartitionList::new();
-        for partition in distribute(0..partition_count, worker_index.0, worker_count) {
+        for partition in distribute(0..partition_count, worker_index.0, worker_count.0) {
             let partition = KafkaPartition(partition);
             let resume_offset: Option<Offset> =
                 (*positions.entry(partition).or_insert(KafkaPosition::Default)).into();

--- a/src/inputs/manual_input.rs
+++ b/src/inputs/manual_input.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::task::Poll;
 
-use crate::execution::WorkerIndex;
+use crate::execution::{WorkerCount, WorkerIndex};
 use crate::pyo3_extensions::{TdPyAny, TdPyCallable, TdPyCoroIterator};
 use crate::recovery::model::StateBytes;
 use crate::{
@@ -53,7 +53,7 @@ impl InputBuilder for ManualInputConfig {
         &self,
         py: Python,
         worker_index: WorkerIndex,
-        worker_count: usize,
+        worker_count: WorkerCount,
         resume_snapshot: Option<StateBytes>,
     ) -> StringResult<Box<dyn InputReader<TdPyAny>>> {
         Ok(Box::new(ManualInput::new(
@@ -109,7 +109,7 @@ impl ManualInput {
         py: Python,
         input_builder: TdPyCallable,
         worker_index: WorkerIndex,
-        worker_count: usize,
+        worker_count: WorkerCount,
         resume_snapshot: Option<StateBytes>,
     ) -> Self {
         let resume_state: TdPyAny = resume_snapshot
@@ -117,7 +117,10 @@ impl ManualInput {
             .unwrap_or_else(|| py.None().into());
 
         let pyiter: TdPyCoroIterator = try_unwrap!(input_builder
-            .call1(py, (worker_index, worker_count, resume_state.clone_ref(py)))?
+            .call1(
+                py,
+                (worker_index.0, worker_count.0, resume_state.clone_ref(py))
+            )?
             .extract(py));
 
         Self {

--- a/src/inputs/mod.rs
+++ b/src/inputs/mod.rs
@@ -21,7 +21,7 @@
 //! how to create a [`KafkaInput`].
 
 use crate::common::StringResult;
-use crate::execution::WorkerIndex;
+use crate::execution::{WorkerCount, WorkerIndex};
 use crate::pyo3_extensions::{PyConfigClass, TdPyAny};
 use crate::recovery::model::StateBytes;
 use pyo3::prelude::*;
@@ -77,7 +77,7 @@ pub(crate) trait InputBuilder {
         &self,
         py: Python,
         worker_index: WorkerIndex,
-        worker_count: usize,
+        worker_count: WorkerCount,
         resume_snapshot: Option<StateBytes>,
     ) -> StringResult<Box<dyn InputReader<TdPyAny>>>;
 }
@@ -101,7 +101,7 @@ impl InputBuilder for Py<InputConfig> {
         &self,
         py: Python,
         worker_index: WorkerIndex,
-        worker_count: usize,
+        worker_count: WorkerCount,
         resume_snapshot: Option<StateBytes>,
     ) -> StringResult<Box<dyn InputReader<TdPyAny>>> {
         self.downcast(py)?

--- a/src/outputs/kafka_output.rs
+++ b/src/outputs/kafka_output.rs
@@ -9,7 +9,10 @@ use rdkafka::{
 use send_wrapper::SendWrapper;
 use std::{collections::HashMap, time::Duration};
 
+use crate::execution::{WorkerCount, WorkerIndex};
+
 use super::{OutputBuilder, OutputConfig, OutputWriter};
+
 /// Use [Kafka](https://kafka.apache.org) as the output.
 ///
 /// A `capture` using KafkaOutput expects to receive data
@@ -48,8 +51,8 @@ impl OutputBuilder for KafkaOutputConfig {
     fn build(
         &self,
         py: Python,
-        _worker_index: crate::execution::WorkerIndex,
-        _worker_count: usize,
+        _worker_index: WorkerIndex,
+        _worker_count: WorkerCount,
     ) -> crate::common::StringResult<Box<dyn OutputWriter<u64, TdPyAny>>> {
         let writer = py.allow_threads(|| {
             SendWrapper::new(KafkaOutput::new(

--- a/src/outputs/manual_epoch_output.rs
+++ b/src/outputs/manual_epoch_output.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::{
     common::pickle_extract,
-    execution::WorkerIndex,
+    execution::{WorkerCount, WorkerIndex},
     pyo3_extensions::{TdPyAny, TdPyCallable},
     unwrap_any,
 };
@@ -40,7 +40,7 @@ impl OutputBuilder for ManualEpochOutputConfig {
         &self,
         py: Python,
         worker_index: WorkerIndex,
-        worker_count: usize,
+        worker_count: WorkerCount,
     ) -> crate::common::StringResult<Box<dyn OutputWriter<u64, TdPyAny>>> {
         Ok(Box::new(ManualEpochOutput::new(
             py,
@@ -93,10 +93,10 @@ impl ManualEpochOutput {
         py: Python,
         output_builder: TdPyCallable,
         worker_index: WorkerIndex,
-        worker_count: usize,
+        worker_count: WorkerCount,
     ) -> Self {
         let pyfunc: TdPyCallable = output_builder
-            .call1(py, (worker_index, worker_count))
+            .call1(py, (worker_index.0, worker_count.0))
             .unwrap()
             .extract(py)
             .unwrap();

--- a/src/outputs/manual_output.rs
+++ b/src/outputs/manual_output.rs
@@ -4,7 +4,7 @@ use pyo3::{prelude::*, types::PyDict};
 
 use crate::{
     common::pickle_extract,
-    execution::WorkerIndex,
+    execution::{WorkerCount, WorkerIndex},
     pyo3_extensions::{TdPyAny, TdPyCallable},
     unwrap_any,
 };
@@ -38,7 +38,7 @@ impl OutputBuilder for ManualOutputConfig {
         &self,
         py: Python,
         worker_index: WorkerIndex,
-        worker_count: usize,
+        worker_count: WorkerCount,
     ) -> crate::common::StringResult<Box<dyn OutputWriter<u64, TdPyAny>>> {
         Ok(Box::new(ManualOutput::new(
             py,
@@ -90,10 +90,10 @@ impl ManualOutput {
         py: Python,
         output_builder: TdPyCallable,
         worker_index: WorkerIndex,
-        worker_count: usize,
+        worker_count: WorkerCount,
     ) -> Self {
         let pyfunc: TdPyCallable = output_builder
-            .call1(py, (worker_index, worker_count))
+            .call1(py, (worker_index.0, worker_count.0))
             .unwrap()
             .extract(py)
             .unwrap();

--- a/src/outputs/mod.rs
+++ b/src/outputs/mod.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 
 use crate::{
     common::StringResult,
-    execution::WorkerIndex,
+    execution::{WorkerCount, WorkerIndex},
     pyo3_extensions::{PyConfigClass, TdPyAny},
 };
 use pyo3::prelude::*;
@@ -75,7 +75,7 @@ pub(crate) trait OutputBuilder {
         &self,
         py: Python,
         worker_index: WorkerIndex,
-        worker_count: usize,
+        worker_count: WorkerCount,
     ) -> StringResult<Box<dyn OutputWriter<u64, TdPyAny>>>;
 }
 
@@ -102,7 +102,7 @@ impl OutputBuilder for Py<OutputConfig> {
         &self,
         py: Python,
         worker_index: WorkerIndex,
-        worker_count: usize,
+        worker_count: WorkerCount,
     ) -> StringResult<Box<dyn OutputWriter<u64, TdPyAny>>> {
         self.downcast(py)?.build(py, worker_index, worker_count)
     }

--- a/src/outputs/std_output.rs
+++ b/src/outputs/std_output.rs
@@ -1,3 +1,4 @@
+use crate::execution::{WorkerCount, WorkerIndex};
 use pyo3::{ffi::PySys_WriteStdout, prelude::*};
 use std::{collections::HashMap, ffi::CString};
 
@@ -23,8 +24,8 @@ impl OutputBuilder for StdOutputConfig {
     fn build(
         &self,
         py: Python,
-        _worker_index: crate::execution::WorkerIndex,
-        _worker_count: usize,
+        _worker_index: WorkerIndex,
+        _worker_count: WorkerCount,
     ) -> crate::common::StringResult<Box<dyn OutputWriter<u64, TdPyAny>>> {
         Ok(Box::new(py.allow_threads(StdOutput::new)))
     }

--- a/src/recovery/model/progress.rs
+++ b/src/recovery/model/progress.rs
@@ -8,39 +8,64 @@ use super::change::*;
 use serde::Deserialize;
 use serde::Serialize;
 
-pub(crate) use crate::execution::WorkerIndex;
+/// Incrementing ID for a dataflow cluster.
+///
+/// This is used to ensure recovery progress information for a worker
+/// `3` is not mis-interpreted to belong to a different cluster.
+///
+/// As you resume a dataflow, this will increase by 1 each time.
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub(crate) struct Execution(pub(crate) u64);
+
+pub(crate) use crate::execution::{WorkerCount, WorkerIndex};
 
 /// Timely uses the unit type to represent a "tick" or "heartbeat" on
 /// a clock stream, a dataflow stream that you only care about the
 /// progress messages.
 pub(crate) type Tick = ();
 
-/// Unique ID for a worker.
+/// Key used to store progress information for a specific worker in
+/// the recovery store.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct WorkerKey(pub(crate) WorkerIndex);
+pub(crate) struct WorkerKey(pub(crate) Execution, pub(crate) WorkerIndex);
 
-/// The newest epoch for which all work has been completed.
-///
-/// The epoch just before the frontier.
+/// The oldest epoch for which work is still outstanding on a worker.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub(crate) struct BorderEpoch(pub(crate) u64);
+pub(crate) struct WorkerFrontier(pub(crate) u64);
 
-/// The epoch we should resume from the beginning of.
+/// The epoch a new dataflow execution should resume from the
+/// beginning of.
 ///
 /// This will be the dataflow frontier of the last execution.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ResumeEpoch(pub(crate) u64);
+
+/// To resume a dataflow execution, you need to know which epoch to
+/// resume for state, but also which execution to label progress data
+/// with.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) struct ResumeFrom(pub(crate) Execution, pub(crate) ResumeEpoch);
+
+/// Types of recovery data related to progress on a worker.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ProgressMsg {
+    /// Information about this execution. Applies during the entire
+    /// execution.
+    Init(WorkerCount, ResumeEpoch),
+    /// Progress made by this worker.
+    Advance(WorkerFrontier),
+}
 
 /// A change to the progress store.
 ///
 /// Notes that a worker's finalized epoch has changed.
-pub(crate) type ProgressChange = KChange<WorkerKey, BorderEpoch>;
+pub(crate) type ProgressChange = KChange<WorkerKey, ProgressMsg>;
 
 /// All progress stores have to implement this writer.
 ///
 /// Since trait aliases don't work in stable, don't actually `impl`
 /// this, but it's used for bounds.
-pub(crate) trait ProgressWriter: KWriter<WorkerKey, BorderEpoch> {}
+pub(crate) trait ProgressWriter: KWriter<WorkerKey, ProgressMsg> {}
 
 impl<P> ProgressWriter for Box<P> where P: ProgressWriter + ?Sized {}
 
@@ -48,6 +73,6 @@ impl<P> ProgressWriter for Box<P> where P: ProgressWriter + ?Sized {}
 ///
 /// Since trait aliases don't work in stable, don't actually `impl`
 /// this, but it's used for bounds.
-pub(crate) trait ProgressReader: KReader<WorkerKey, BorderEpoch> {}
+pub(crate) trait ProgressReader: KReader<WorkerKey, ProgressMsg> {}
 
 impl<P> ProgressReader for Box<P> where P: ProgressReader + ?Sized {}

--- a/src/recovery/model/state.rs
+++ b/src/recovery/model/state.rs
@@ -54,7 +54,7 @@ pub(crate) enum StateKey {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct FlowKey(pub(crate) StepId, pub(crate) StateKey);
 
-/// Epoch that should be interpreted as
+/// This state snapshot happened at the end of this epoch.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub(crate) struct SnapshotEpoch(pub(crate) u64);
 

--- a/src/recovery/model/state.rs
+++ b/src/recovery/model/state.rs
@@ -54,7 +54,7 @@ pub(crate) enum StateKey {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct FlowKey(pub(crate) StepId, pub(crate) StateKey);
 
-///
+/// Epoch that should be interpreted as
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub(crate) struct SnapshotEpoch(pub(crate) u64);
 

--- a/src/recovery/store/in_mem.rs
+++ b/src/recovery/store/in_mem.rs
@@ -350,10 +350,10 @@ impl InMemProgress {
     /// well-formed.
     pub(crate) fn new(count: WorkerCount) -> Self {
         let ex = Into::<i128>::into(<u64 as Timestamp>::minimum()) - 1;
-        let mut frontiers = HashMap::new();
-        for worker in count.iter() {
-            frontiers.insert(worker, WorkerFrontier(<u64 as Timestamp>::minimum()));
-        }
+        let frontiers = count
+            .iter()
+            .map(|worker| (worker, WorkerFrontier(<u64 as Timestamp>::minimum())))
+            .collect();
         Self { ex, frontiers }
     }
 
@@ -371,10 +371,10 @@ impl InMemProgress {
         assert!(!(in_ex < self.ex), "Execution regressed");
         if in_ex > self.ex {
             self.ex = in_ex;
-            self.frontiers.clear();
-            for worker in count.iter() {
-                self.frontiers.insert(worker, WorkerFrontier(epoch.0));
-            }
+            self.frontiers = count
+                .iter()
+                .map(|worker| (worker, WorkerFrontier(epoch.0)))
+                .collect();
         // It's ok if in_ex == self.ex since we might have multiple
         // workers from the previous execution multiplexed into the
         // same progress partition.

--- a/src/recovery/store/kafka.rs
+++ b/src/recovery/store/kafka.rs
@@ -212,5 +212,5 @@ where
 
 impl StateWriter for KafkaWriter<StoreKey, Change<StateBytes>> {}
 impl StateReader for KafkaReader<StoreKey, Change<StateBytes>> {}
-impl ProgressWriter for KafkaWriter<WorkerKey, BorderEpoch> {}
-impl ProgressReader for KafkaReader<WorkerKey, BorderEpoch> {}
+impl ProgressWriter for KafkaWriter<WorkerKey, ProgressMsg> {}
+impl ProgressReader for KafkaReader<WorkerKey, ProgressMsg> {}

--- a/src/recovery/store/sqlite.rs
+++ b/src/recovery/store/sqlite.rs
@@ -14,12 +14,11 @@ use sqlx::sqlite::SqliteRow;
 use sqlx::sqlite::SqliteTypeInfo;
 use sqlx::sqlite::SqliteValueRef;
 use sqlx::ConnectOptions;
-use sqlx::Connection;
 use sqlx::Decode;
 use sqlx::Encode;
 use sqlx::Row;
 use sqlx::Sqlite;
-use sqlx::SqliteConnection;
+use sqlx::SqlitePool;
 use sqlx::Type;
 use tokio::runtime::Runtime;
 
@@ -139,9 +138,33 @@ impl<'r> Decode<'r, Sqlite> for WorkerIndex {
     }
 }
 
+impl Type<Sqlite> for WorkerCount {
+    fn type_info() -> SqliteTypeInfo {
+        // For some reason this does not like using i64 /
+        // SqliteArgumentValue::Int64. We get a similar error to
+        // https://github.com/launchbadge/sqlx/issues/2093. Maybe
+        // SQLite bug?
+        <i32 as Type<Sqlite>>::type_info()
+    }
+}
+
+impl<'q> Encode<'q, Sqlite> for WorkerCount {
+    fn encode_by_ref(&self, args: &mut Vec<SqliteArgumentValue<'q>>) -> IsNull {
+        args.push(SqliteArgumentValue::Int(self.0 as i32));
+        IsNull::No
+    }
+}
+
+impl<'r> Decode<'r, Sqlite> for WorkerCount {
+    fn decode(value: SqliteValueRef<'r>) -> Result<Self, BoxDynError> {
+        let value = <i32 as Decode<Sqlite>>::decode(value)?;
+        Ok(Self(value as usize))
+    }
+}
+
 pub struct SqliteStateWriter {
     rt: Runtime,
-    conn: SqliteConnection,
+    conn: SqlitePool,
     table_name: String,
 }
 
@@ -157,9 +180,9 @@ impl SqliteStateWriter {
         let mut options = SqliteConnectOptions::new().filename(db_file);
         options = options.create_if_missing(true);
         options.disable_statement_logging();
-        let future = SqliteConnection::connect_with(&options);
+        let future = SqlitePool::connect_with(options);
         tracing::debug!("Opening Sqlite connection to {db_file:?}");
-        let mut conn = rt.block_on(future).unwrap();
+        let conn = rt.block_on(future).unwrap();
 
         // TODO: SQLite doesn't let you bind to table names. Can
         // we do this in a slightly safer way? I'm not as worried
@@ -167,7 +190,7 @@ impl SqliteStateWriter {
         // stream, but from the config which should be under
         // developer control.
         let sql = format!("CREATE TABLE IF NOT EXISTS {table_name} (step_id TEXT, state_key TEXT, epoch INTEGER, snapshot BLOB, PRIMARY KEY (step_id, state_key, epoch));");
-        let future = query(&sql).execute(&mut conn);
+        let future = query(&sql).execute(&conn);
         rt.block_on(future).unwrap();
 
         Self {
@@ -201,7 +224,7 @@ impl KWriter<StoreKey, Change<StateBytes>> for SqliteStateWriter {
                     // Remember, reset state is stored as an explicit NULL in the
                     // DB.
                     .bind(snapshot)
-                    .execute(&mut self.conn);
+                    .execute(&self.conn);
                 self.rt.block_on(future).unwrap();
             }
             Change::Discard => {
@@ -216,7 +239,7 @@ impl KWriter<StoreKey, Change<StateBytes>> for SqliteStateWriter {
                         <u64 as TryInto<i64>>::try_into(epoch.0)
                             .expect("epoch can't fit into SQLite int"),
                     )
-                    .execute(&mut self.conn);
+                    .execute(&self.conn);
                 self.rt.block_on(future).unwrap();
             }
         }
@@ -235,7 +258,7 @@ impl SqliteStateReader {
         // Bootstrap off writer to get table creation.
         let writer = SqliteStateWriter::new(db_file);
         let rt = writer.rt;
-        let mut conn = writer.conn;
+        let conn = writer.conn;
 
         let (tx, rx) = tokio::sync::mpsc::channel(1);
 
@@ -261,7 +284,7 @@ impl SqliteStateReader {
                     let recovery_change = Change::Upsert(step_change);
                     KChange(store_key, recovery_change)
                 })
-                .fetch(&mut conn)
+                .fetch(&conn)
                 .map(|result| result.expect("Error selecting from SQLite"));
 
             while let Some(kchange) = stream.next().await {
@@ -282,13 +305,15 @@ impl KReader<StoreKey, Change<StateBytes>> for SqliteStateReader {
 
 pub(crate) struct SqliteProgressWriter {
     rt: Runtime,
-    conn: SqliteConnection,
-    table_name: String,
+    conn: SqlitePool,
+    progress_table_name: String,
+    execution_table_name: String,
 }
 
 impl SqliteProgressWriter {
     pub(crate) fn new(db_file: &Path) -> Self {
-        let table_name = "progress".to_string();
+        let progress_table_name = "progress".to_string();
+        let execution_table_name = "execution".to_string();
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -298,46 +323,88 @@ impl SqliteProgressWriter {
         let mut options = SqliteConnectOptions::new().filename(db_file);
         options = options.create_if_missing(true);
         options.disable_statement_logging();
-        let future = SqliteConnection::connect_with(&options);
+        // Use [`SqlitePool`] and not a direct [`SqliteConnection`] to
+        // allow multiple async queries at once.
+        let future = SqlitePool::connect_with(options);
         tracing::debug!("Opening Sqlite connection to {db_file:?}");
-        let mut conn = rt.block_on(future).unwrap();
+        let conn = rt.block_on(future).unwrap();
 
         let sql = format!(
-            "CREATE TABLE IF NOT EXISTS {table_name} (worker_index INTEGER PRIMARY KEY, border INTEGER);"
+            "CREATE TABLE IF NOT EXISTS {progress_table_name} (execution INTEGER, worker_index INTEGER, frontier INTEGER, PRIMARY KEY (execution, worker_index));"
         );
-        let future = query(&sql).execute(&mut conn);
+        let future = query(&sql).execute(&conn);
+        rt.block_on(future).unwrap();
+
+        let sql = format!(
+            "CREATE TABLE IF NOT EXISTS {execution_table_name} (execution INTEGER, worker_index INTEGER, worker_count INTEGER, resume_epoch INTEGER, PRIMARY KEY (execution, worker_index));"
+        );
+        let future = query(&sql).execute(&conn);
         rt.block_on(future).unwrap();
 
         Self {
             rt,
             conn,
-            table_name,
+            progress_table_name,
+            execution_table_name,
         }
     }
 }
 
-impl KWriter<WorkerKey, BorderEpoch> for SqliteProgressWriter {
+impl KWriter<WorkerKey, ProgressMsg> for SqliteProgressWriter {
     fn write(&mut self, kchange: ProgressChange) {
         tracing::trace!("Writing progress change {kchange:?}");
-        let KChange(worker_key, change) = kchange;
-        let WorkerKey(worker_index) = worker_key;
+        let KChange(key, change) = kchange;
+        let WorkerKey(ex, index) = key;
 
         match change {
-            Change::Upsert(epoch) => {
-                let sql = format!("INSERT INTO {} (worker_index, border) VALUES (?1, ?2) ON CONFLICT (worker_index) DO UPDATE SET border = EXCLUDED.border", self.table_name);
-                let future = query(&sql)
-                    .bind(worker_index)
-                    .bind(
-                        <u64 as TryInto<i64>>::try_into(epoch.0)
-                            .expect("epoch can't fit into SQLite int"),
-                    )
-                    .execute(&mut self.conn);
-                self.rt.block_on(future).unwrap();
-            }
+            Change::Upsert(msg) => match msg {
+                ProgressMsg::Init(count, epoch) => {
+                    let sql = format!("INSERT INTO {} (execution, worker_index, worker_count, resume_epoch) VALUES (?1, ?2, ?3, ?4) ON CONFLICT (execution, worker_index) DO UPDATE SET worker_count = EXCLUDED.worker_count, resume_epoch = EXCLUDED.resume_epoch", self.execution_table_name);
+                    let future = query(&sql)
+                        .bind(
+                            <u64 as TryInto<i64>>::try_into(ex.0)
+                                .expect("execution can't fit into SQLite int"),
+                        )
+                        .bind(index)
+                        .bind(count)
+                        .bind(
+                            <u64 as TryInto<i64>>::try_into(epoch.0)
+                                .expect("epoch can't fit into SQLite int"),
+                        )
+                        .execute(&self.conn);
+                    self.rt.block_on(future).unwrap();
+                }
+                ProgressMsg::Advance(epoch) => {
+                    let sql = format!("INSERT INTO {} (execution, worker_index, frontier) VALUES (?1, ?2, ?3) ON CONFLICT (execution, worker_index) DO UPDATE SET frontier = EXCLUDED.frontier", self.progress_table_name);
+                    let future = query(&sql)
+                        .bind(
+                            <u64 as TryInto<i64>>::try_into(ex.0)
+                                .expect("execution can't fit into SQLite int"),
+                        )
+                        .bind(index)
+                        .bind(
+                            <u64 as TryInto<i64>>::try_into(epoch.0)
+                                .expect("epoch can't fit into SQLite int"),
+                        )
+                        .execute(&self.conn);
+                    self.rt.block_on(future).unwrap();
+                }
+            },
             Change::Discard => {
-                let sql = format!("DELETE FROM {} WHERE worker_index = ?1", self.table_name);
-                let future = query(&sql).bind(worker_index).execute(&mut self.conn);
+                let sql = format!(
+                    "DELETE FROM {} WHERE execution = ?1 AND worker_index = ?2",
+                    self.progress_table_name
+                );
+                let future = query(&sql)
+                    .bind(
+                        <u64 as TryInto<i64>>::try_into(ex.0)
+                            .expect("execution can't fit into SQLite int"),
+                    )
+                    .bind(index)
+                    .execute(&self.conn);
                 self.rt.block_on(future).unwrap();
+                // TODO: Can we delete execution information? We'd
+                // need to change the key concept.
             }
         }
     }
@@ -350,28 +417,62 @@ pub(crate) struct SqliteProgressReader {
 
 impl SqliteProgressReader {
     pub(crate) fn new(db_file: &Path) -> Self {
-        let table_name = "progress";
+        let progress_table_name = "progress";
+        let execution_table_name = "execution";
 
         let writer = SqliteProgressWriter::new(db_file);
         let rt = writer.rt;
-        let mut conn = writer.conn;
+        let conn = writer.conn;
 
         let (tx, rx) = tokio::sync::mpsc::channel(1);
 
         rt.spawn(async move {
-            let sql = format!("SELECT worker_index, border FROM {table_name}");
+            let sql = format!("SELECT execution, worker_index, worker_count, resume_epoch FROM {execution_table_name}");
             let mut stream = query(&sql)
                 .map(|row: SqliteRow| {
-                    let worker_index: WorkerIndex = row.get(0);
-                    let worker_key = WorkerKey(worker_index);
-                    let border = BorderEpoch(
-                        row.get::<i64, _>(1)
+                    let ex = Execution(
+                        row.get::<i64, _>(0)
+                            .try_into()
+                            .expect("SQLite int can't fit into execution; might be negative"),
+                    );
+                    let index: WorkerIndex = row.get(1);
+                    let key = WorkerKey(ex, index);
+                    let count: WorkerCount = row.get(2);
+                    let epoch = ResumeEpoch(
+                        row.get::<i64, _>(3)
                             .try_into()
                             .expect("SQLite int can't fit into epoch; might be negative"),
                     );
-                    KChange(worker_key, Change::Upsert(border))
+                    let msg = ProgressMsg::Init(count, epoch);
+                    KChange(key, Change::Upsert(msg))
                 })
-                .fetch(&mut conn)
+                .fetch(&conn)
+                .map(|result| result.expect("Error selecting from SQLite"));
+
+            while let Some(kchange) = stream.next().await {
+                tracing::trace!("Reading progress change {kchange:?}");
+                tx.send(kchange).await.unwrap();
+            }
+
+            let sql = format!("SELECT execution, worker_index, frontier FROM {progress_table_name}");
+            let mut stream = query(&sql)
+                .map(|row: SqliteRow| {
+                    let ex = Execution(
+                        row.get::<i64, _>(0)
+                            .try_into()
+                            .expect("SQLite int can't fit into execution; might be negative"),
+                    );
+                    let index: WorkerIndex = row.get(1);
+                    let key = WorkerKey(ex, index);
+                    let epoch = WorkerFrontier(
+                        row.get::<i64, _>(2)
+                            .try_into()
+                            .expect("SQLite int can't fit into epoch; might be negative"),
+                    );
+                    let msg = ProgressMsg::Advance(epoch);
+                    KChange(key, Change::Upsert(msg))
+                })
+                .fetch(&conn)
                 .map(|result| result.expect("Error selecting from SQLite"));
 
             while let Some(kchange) = stream.next().await {
@@ -384,7 +485,7 @@ impl SqliteProgressReader {
     }
 }
 
-impl KReader<WorkerKey, BorderEpoch> for SqliteProgressReader {
+impl KReader<WorkerKey, ProgressMsg> for SqliteProgressReader {
     fn read(&mut self) -> Option<ProgressChange> {
         self.rt.block_on(self.rx.recv())
     }


### PR DESCRIPTION
The progress recovery data model used to have an issue: we never knew
how many workers were part of a cluster. This caused us to "lose"
workers if we crashed before any progress data was written by a
worker; during resume, it just looked like the cluster was smaller and
nothing was missing. Adds a new kind of progress recovery message that
is written as each cluster starts up with the total worker count so we
can know if we're missing a later progress message.

Fixes https://github.com/bytewax/bytewax/issues/181

Related to this, we also need to disambiguate between workers across
clusters. During recovery we need to know which "worker 3" a progress
message "worker 3 moved to epoch 30" applies to. To do this we add an
`Execution` ID which is sort of like "epochs but for the whole
cluster". This is an `u64` that increments on each resume and all
progress recovery data is labeled with it so we ignore data from older
clusters that might come out of order. Adds tables to SQLite recovery
DB to do that.

This gets us one more step closer to rescaling.

Rewrites the `Progress` operator to work on frontiers again... Turns
out if a worker never generates input, it'll never generate state
data, which never generates progress info because it was based off of
the `Tick`s flowing through that part of the dataflow graph. This
means it's unnessecary gymnastics to store the `BorderEpoch` so
removes that from the progress data model.
