### PR TITLE
Hopping window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Added `SlidingWindowConfig` for windowing operators.
+
 ## 0.15.0
 
 - Fixes issue with multi-worker recovery. If the cluster crashed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
-- Added `SlidingWindowConfig` for windowing operators.
+- Added `HoppingWindowConfig` for windowing operators.
 
 ## 0.15.0
 

--- a/pysrc/bytewax/window.py
+++ b/pysrc/bytewax/window.py
@@ -72,6 +72,6 @@ from .bytewax import (  # noqa: F401
     EventClockConfig,
     SystemClockConfig,
     TumblingWindowConfig,
-    SlidingWindowConfig,
+    HoppingWindowConfig,
     WindowConfig,
 )

--- a/pysrc/bytewax/window.py
+++ b/pysrc/bytewax/window.py
@@ -72,5 +72,6 @@ from .bytewax import (  # noqa: F401
     EventClockConfig,
     SystemClockConfig,
     TumblingWindowConfig,
+    SlidingWindowConfig,
     WindowConfig,
 )

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -4,10 +4,10 @@ from bytewax.dataflow import Dataflow
 from bytewax.execution import run_main
 from bytewax.inputs import TestingBuilderInputConfig
 from bytewax.outputs import TestingOutputConfig
-from bytewax.window import EventClockConfig, SlidingWindowConfig, TumblingWindowConfig
+from bytewax.window import EventClockConfig, HoppingWindowConfig, TumblingWindowConfig
 
 
-def test_sliding_window():
+def test_hopping_window():
     start_at = datetime(2022, 1, 1, tzinfo=timezone.utc)
 
     flow = Dataflow()
@@ -28,7 +28,7 @@ def test_sliding_window():
     clock_config = EventClockConfig(
         lambda e: e["time"], wait_for_system_duration=timedelta(0)
     )
-    window_config = SlidingWindowConfig(
+    window_config = HoppingWindowConfig(
         length=timedelta(seconds=10), start_at=start_at, offset=timedelta(seconds=5)
     )
 

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -4,7 +4,43 @@ from bytewax.dataflow import Dataflow
 from bytewax.execution import run_main
 from bytewax.inputs import TestingBuilderInputConfig
 from bytewax.outputs import TestingOutputConfig
-from bytewax.window import EventClockConfig, TumblingWindowConfig
+from bytewax.window import EventClockConfig, SlidingWindowConfig, TumblingWindowConfig
+
+
+def test_sliding_window():
+    start_at = datetime(2022, 1, 1, tzinfo=timezone.utc)
+
+    flow = Dataflow()
+
+    def gen():
+        yield ("ALL", {"time": start_at + timedelta(seconds=1), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=4), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=8), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=12), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=13), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=14), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=16), "val": 1})
+
+    flow.input("inp", TestingBuilderInputConfig(gen))
+
+    clock_config = EventClockConfig(
+        lambda e: e["time"], wait_for_system_duration=timedelta(0)
+    )
+    window_config = SlidingWindowConfig(
+        length=timedelta(seconds=10), start_at=start_at, offset=timedelta(seconds=5)
+    )
+
+    def add(acc, x):
+        return acc + x["val"]
+
+    flow.fold_window("sum", clock_config, window_config, lambda: 0, add)
+
+    out = []
+    flow.capture(TestingOutputConfig(out))
+
+    run_main(flow)
+
+    assert sorted(out) == sorted([("ALL", 3), ("ALL", 4), ("ALL", 4), ("ALL", 1)])
 
 
 def test_tumbling_window():

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -20,6 +20,8 @@ def test_sliding_window():
         yield ("ALL", {"time": start_at + timedelta(seconds=13), "val": 1})
         yield ("ALL", {"time": start_at + timedelta(seconds=14), "val": 1})
         yield ("ALL", {"time": start_at + timedelta(seconds=16), "val": 1})
+        # This is late, and should be ignored
+        yield ("ALL", {"time": start_at + timedelta(seconds=1), "val": 10})
 
     flow.input("inp", TestingBuilderInputConfig(gen))
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -96,7 +96,7 @@ macro_rules! log_func {
 ///
 /// ```rust
 /// add_pymethods!(
-///     SlidingWindowConfig,
+///     HoppingWindowConfig,
 ///     parent: WindowConfig,
 ///     py_args: (length, offset, start_at = "None"),
 ///     args {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -43,10 +43,10 @@ use timely::dataflow::Scope;
 use timely::{Data, ExchangeData};
 
 pub(crate) mod clock;
-pub(crate) mod sliding_window;
+pub(crate) mod hopping_window;
 pub(crate) mod tumbling_window;
 
-use self::sliding_window::SlidingWindowConfig;
+use self::hopping_window::HoppingWindowConfig;
 use self::tumbling_window::TumblingWindowConfig;
 use clock::{event_time_clock::EventClockConfig, system_clock::SystemClockConfig, ClockConfig};
 
@@ -100,7 +100,7 @@ impl PyConfigClass<Box<dyn WindowBuilder>> for Py<WindowConfig> {
     fn downcast(&self, py: Python) -> StringResult<Box<dyn WindowBuilder>> {
         if let Ok(conf) = self.extract::<TumblingWindowConfig>(py) {
             Ok(Box::new(conf))
-        } else if let Ok(conf) = self.extract::<SlidingWindowConfig>(py) {
+        } else if let Ok(conf) = self.extract::<HoppingWindowConfig>(py) {
             Ok(Box::new(conf))
         } else {
             let pytype = self.as_ref(py).get_type();
@@ -523,6 +523,6 @@ pub(crate) fn register(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<SystemClockConfig>()?;
     m.add_class::<WindowConfig>()?;
     m.add_class::<TumblingWindowConfig>()?;
-    m.add_class::<SlidingWindowConfig>()?;
+    m.add_class::<HoppingWindowConfig>()?;
     Ok(())
 }

--- a/src/window/sliding_window.rs
+++ b/src/window/sliding_window.rs
@@ -1,0 +1,135 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Duration, Utc};
+use pyo3::{pyclass, Python};
+
+use crate::{add_pymethods, common::StringResult, window::WindowConfig};
+
+use super::{Builder, InsertError, StateBytes, WindowBuilder, WindowKey, Windower};
+
+/// Sliding windows of fixed duration.
+///
+/// Args:
+///
+///   length (datetime.timedelta): Length of window.
+///
+///   offset (datetime.timedelta): Offset between windows.
+///
+///   start_at (datetime.datetime): Instant of the first window. You
+///       can use this to align all windows to an hour,
+///       e.g. Defaults to system time of dataflow start.
+///
+/// Returns:
+///
+///   Config object. Pass this as the `window_config` parameter to
+///   your windowing operator.
+#[pyclass(module="bytewax.config", extends=WindowConfig)]
+#[derive(Clone)]
+pub(crate) struct SlidingWindowConfig {
+    #[pyo3(get)]
+    pub(crate) length: Duration,
+    #[pyo3(get)]
+    pub(crate) offset: Duration,
+    #[pyo3(get)]
+    pub(crate) start_at: Option<DateTime<Utc>>,
+}
+
+add_pymethods!(
+    SlidingWindowConfig,
+    parent: WindowConfig,
+    py_args: (length, offset, start_at = "None"),
+    args {
+        length: Duration => Duration::zero(),
+        offset: Duration => Duration::zero(),
+        start_at: Option<DateTime<Utc>> => None
+    }
+);
+
+impl WindowBuilder for SlidingWindowConfig {
+    fn build(&self, _py: Python) -> StringResult<Builder> {
+        Ok(Box::new(SlidingWindower::builder(
+            self.length,
+            self.offset,
+            self.start_at.unwrap_or_else(Utc::now),
+        )))
+    }
+}
+
+pub(crate) struct SlidingWindower {
+    length: Duration,
+    offset: Duration,
+    start_at: DateTime<Utc>,
+    close_times: HashMap<WindowKey, DateTime<Utc>>,
+}
+
+impl SlidingWindower {
+    pub(crate) fn builder(
+        length: Duration,
+        offset: Duration,
+        start_at: DateTime<Utc>,
+    ) -> impl Fn(Option<StateBytes>) -> Box<dyn Windower> {
+        move |resume_snapshot| {
+            let close_times = resume_snapshot
+                .map(StateBytes::de::<HashMap<WindowKey, DateTime<Utc>>>)
+                .unwrap_or_default();
+            Box::new(Self {
+                length,
+                offset,
+                start_at,
+                close_times,
+            })
+        }
+    }
+}
+
+impl Windower for SlidingWindower {
+    fn insert(
+        &mut self,
+        watermark: &DateTime<Utc>,
+        item_time: &DateTime<Utc>,
+    ) -> Vec<Result<WindowKey, InsertError>> {
+        let since_start_at = *item_time - self.start_at;
+        let windows_count = since_start_at.num_milliseconds() / self.offset.num_milliseconds() + 1;
+        let mut windows = vec![];
+        // TODO: Avoid starting from 0 here, we can skip windows closed before the watermark
+        for i in 0..windows_count {
+
+            let key = WindowKey(i);
+            let window_start =
+                self.start_at + Duration::milliseconds(i * self.offset.num_milliseconds());
+            let window_end = window_start + self.length;
+
+            if window_end < *watermark {
+                windows.push(Err(InsertError::Late(key)));
+                continue;
+            }
+
+            if *item_time < window_start {
+                continue;
+            }
+            if *item_time <= window_end {
+                self.close_times
+                    .entry(key)
+                    .and_modify(|existing| {
+                        assert!(
+                            existing == &window_end,
+                            "Sliding windower is not generating consistent boundaries"
+                        )
+                    })
+                    .or_insert(window_end);
+                windows.push(Ok(key));
+            } else {
+                windows.push(Err(InsertError::Late(key)));
+            }
+        }
+        windows
+    }
+
+    fn get_close_times(&self) -> &HashMap<WindowKey, DateTime<Utc>> {
+        &self.close_times
+    }
+
+    fn set_close_times(&mut self, close_times: HashMap<WindowKey, DateTime<Utc>>) {
+        self.close_times = close_times;
+    }
+}

--- a/src/window/tumbling_window.rs
+++ b/src/window/tumbling_window.rs
@@ -93,21 +93,17 @@ impl Windower for TumblingWindower {
         if &close_at < watermark {
             vec![Err(InsertError::Late(key))]
         } else {
-            self.close_times
-                .entry(key)
-                .and_modify(|existing_close_at| {
-                    assert!(
-                        existing_close_at == &close_at,
-                        "Tumbling windower is not generating consistent boundaries"
-                    )
-                })
-                .or_insert(close_at);
+            self.add_close_time(key, close_at);
             vec![Ok(key)]
         }
     }
 
     fn get_close_times(&self) -> &HashMap<WindowKey, DateTime<Utc>> {
         &self.close_times
+    }
+
+    fn get_close_times_mut(&mut self) -> &mut HashMap<WindowKey, DateTime<Utc>> {
+        &mut self.close_times
     }
 
     fn set_close_times(&mut self, close_times: HashMap<WindowKey, DateTime<Utc>>) {


### PR DESCRIPTION
Added a `HoppingWindowConfig` object.

I also refactored the `Windower` trait to autoimplement some methods since it was equal on both the `Window` configs. Trait methods can still be overridden if we need a different behavior in the future.

I also added a new macro, `add_pymethods`, which alleviates the problem of having to copy paste a lot of code for the infamuous `egregious hack`. I also have a separate branch where I use the macro everywhere else in the codebase, but I'd like to merge this first (or revert it if we don't like the macro).
