### PR TITLE
Hopping window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Added `SlidingWindowConfig` for windowing operators.
+
 ## 0.15.0
 
 - Fixes issue with multi-worker recovery. If the cluster crashed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
-- Added `SlidingWindowConfig` for windowing operators.
+- Added `HoppingWindowConfig` for windowing operators.
 
 ## 0.15.0
 

--- a/pysrc/bytewax/window.py
+++ b/pysrc/bytewax/window.py
@@ -72,6 +72,6 @@ from .bytewax import (  # noqa: F401
     EventClockConfig,
     SystemClockConfig,
     TumblingWindowConfig,
-    SlidingWindowConfig,
+    HoppingWindowConfig,
     WindowConfig,
 )

--- a/pysrc/bytewax/window.py
+++ b/pysrc/bytewax/window.py
@@ -72,5 +72,6 @@ from .bytewax import (  # noqa: F401
     EventClockConfig,
     SystemClockConfig,
     TumblingWindowConfig,
+    SlidingWindowConfig,
     WindowConfig,
 )

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -4,10 +4,10 @@ from bytewax.dataflow import Dataflow
 from bytewax.execution import run_main
 from bytewax.inputs import TestingBuilderInputConfig
 from bytewax.outputs import TestingOutputConfig
-from bytewax.window import EventClockConfig, SlidingWindowConfig, TumblingWindowConfig
+from bytewax.window import EventClockConfig, HoppingWindowConfig, TumblingWindowConfig
 
 
-def test_sliding_window():
+def test_hopping_window():
     start_at = datetime(2022, 1, 1, tzinfo=timezone.utc)
 
     flow = Dataflow()
@@ -28,7 +28,7 @@ def test_sliding_window():
     clock_config = EventClockConfig(
         lambda e: e["time"], wait_for_system_duration=timedelta(0)
     )
-    window_config = SlidingWindowConfig(
+    window_config = HoppingWindowConfig(
         length=timedelta(seconds=10), start_at=start_at, offset=timedelta(seconds=5)
     )
 

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -13,15 +13,15 @@ def test_hopping_window():
     flow = Dataflow()
 
     def gen():
-        yield ("ALL", {"time": start_at + timedelta(seconds=1), "val": 1})
-        yield ("ALL", {"time": start_at + timedelta(seconds=4), "val": 1})
-        yield ("ALL", {"time": start_at + timedelta(seconds=8), "val": 1})
-        yield ("ALL", {"time": start_at + timedelta(seconds=12), "val": 1})
-        yield ("ALL", {"time": start_at + timedelta(seconds=13), "val": 1})
-        yield ("ALL", {"time": start_at + timedelta(seconds=14), "val": 1})
-        yield ("ALL", {"time": start_at + timedelta(seconds=16), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=1), "val": "a"})
+        yield ("ALL", {"time": start_at + timedelta(seconds=4), "val": "b"})
+        yield ("ALL", {"time": start_at + timedelta(seconds=8), "val": "c"})
+        yield ("ALL", {"time": start_at + timedelta(seconds=12), "val": "d"})
+        yield ("ALL", {"time": start_at + timedelta(seconds=13), "val": "e"})
+        yield ("ALL", {"time": start_at + timedelta(seconds=14), "val": "f"})
+        yield ("ALL", {"time": start_at + timedelta(seconds=16), "val": "g"})
         # This is late, and should be ignored
-        yield ("ALL", {"time": start_at + timedelta(seconds=1), "val": 10})
+        yield ("ALL", {"time": start_at + timedelta(seconds=1), "val": "h"})
 
     flow.input("inp", TestingBuilderInputConfig(gen))
 
@@ -33,16 +33,23 @@ def test_hopping_window():
     )
 
     def add(acc, x):
-        return acc + x["val"]
+        acc.append(x["val"])
+        return acc
 
-    flow.fold_window("sum", clock_config, window_config, lambda: 0, add)
+    flow.fold_window("sum", clock_config, window_config, list, add)
 
     out = []
     flow.capture(TestingOutputConfig(out))
 
     run_main(flow)
-
-    assert sorted(out) == sorted([("ALL", 3), ("ALL", 4), ("ALL", 4), ("ALL", 1)])
+    assert sorted(out) == sorted(
+        [
+            ("ALL", ["a", "b", "c"]),
+            ("ALL", ["c", "d", "e", "f"]),
+            ("ALL", ["d", "e", "f", "g"]),
+            ("ALL", ["g"]),
+        ]
+    )
 
 
 def test_tumbling_window():
@@ -51,12 +58,12 @@ def test_tumbling_window():
     flow = Dataflow()
 
     def gen():
-        yield ("ALL", {"time": start_at, "val": 1})
-        yield ("ALL", {"time": start_at + timedelta(seconds=4), "val": 1})
-        yield ("ALL", {"time": start_at + timedelta(seconds=8), "val": 1})
+        yield ("ALL", {"time": start_at, "val": "a"})
+        yield ("ALL", {"time": start_at + timedelta(seconds=4), "val": "b"})
+        yield ("ALL", {"time": start_at + timedelta(seconds=8), "val": "c"})
         # First 10 second window should close just before processing this item.
-        yield ("ALL", {"time": start_at + timedelta(seconds=12), "val": 1})
-        yield ("ALL", {"time": start_at + timedelta(seconds=16), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=12), "val": "d"})
+        yield ("ALL", {"time": start_at + timedelta(seconds=16), "val": "e"})
 
     flow.input("inp", TestingBuilderInputConfig(gen))
 
@@ -68,16 +75,14 @@ def test_tumbling_window():
     )
 
     def add(acc, x):
-        if type(acc) == dict:
-            return acc["val"] + x["val"]
-        else:
-            return acc + x["val"]
+        acc.append(x["val"])
+        return acc
 
-    flow.reduce_window("sum", clock_config, window_config, add)
+    flow.fold_window("sum", clock_config, window_config, list, add)
 
     out = []
     flow.capture(TestingOutputConfig(out))
 
     run_main(flow)
 
-    assert sorted(out) == sorted([("ALL", 3), ("ALL", 2)])
+    assert sorted(out) == sorted([("ALL", ["a", "b", "c"]), ("ALL", ["d", "e"])])

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -4,7 +4,43 @@ from bytewax.dataflow import Dataflow
 from bytewax.execution import run_main
 from bytewax.inputs import TestingBuilderInputConfig
 from bytewax.outputs import TestingOutputConfig
-from bytewax.window import EventClockConfig, TumblingWindowConfig
+from bytewax.window import EventClockConfig, SlidingWindowConfig, TumblingWindowConfig
+
+
+def test_sliding_window():
+    start_at = datetime(2022, 1, 1, tzinfo=timezone.utc)
+
+    flow = Dataflow()
+
+    def gen():
+        yield ("ALL", {"time": start_at + timedelta(seconds=1), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=4), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=8), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=12), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=13), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=14), "val": 1})
+        yield ("ALL", {"time": start_at + timedelta(seconds=16), "val": 1})
+
+    flow.input("inp", TestingBuilderInputConfig(gen))
+
+    clock_config = EventClockConfig(
+        lambda e: e["time"], wait_for_system_duration=timedelta(0)
+    )
+    window_config = SlidingWindowConfig(
+        length=timedelta(seconds=10), start_at=start_at, offset=timedelta(seconds=5)
+    )
+
+    def add(acc, x):
+        return acc + x["val"]
+
+    flow.fold_window("sum", clock_config, window_config, lambda: 0, add)
+
+    out = []
+    flow.capture(TestingOutputConfig(out))
+
+    run_main(flow)
+
+    assert sorted(out) == sorted([("ALL", 3), ("ALL", 4), ("ALL", 4), ("ALL", 1)])
 
 
 def test_tumbling_window():

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -20,6 +20,8 @@ def test_sliding_window():
         yield ("ALL", {"time": start_at + timedelta(seconds=13), "val": 1})
         yield ("ALL", {"time": start_at + timedelta(seconds=14), "val": 1})
         yield ("ALL", {"time": start_at + timedelta(seconds=16), "val": 1})
+        # This is late, and should be ignored
+        yield ("ALL", {"time": start_at + timedelta(seconds=1), "val": 10})
 
     flow.input("inp", TestingBuilderInputConfig(gen))
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -96,7 +96,7 @@ macro_rules! log_func {
 ///
 /// ```rust
 /// add_pymethods!(
-///     SlidingWindowConfig,
+///     HoppingWindowConfig,
 ///     parent: WindowConfig,
 ///     py_args: (length, offset, start_at = "None"),
 ///     args {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -89,7 +89,7 @@ macro_rules! log_func {
 }
 
 #[macro_export]
-/// This macro adds some boilerplate to classes exposed tp Python.
+/// This macro generates some boilerplate for classes exposed to Python.
 /// This is needed mainly for pickling and unpickling of the objects.
 ///
 /// ```rust

--- a/src/window/hopping_window.rs
+++ b/src/window/hopping_window.rs
@@ -24,7 +24,7 @@ use super::{Builder, InsertError, StateBytes, WindowBuilder, WindowKey, Windower
 ///
 ///   Config object. Pass this as the `window_config` parameter to
 ///   your windowing operator.
-#[pyclass(module="bytewax.config", extends=WindowConfig)]
+#[pyclass(module="bytewax.window", extends=WindowConfig)]
 #[derive(Clone)]
 pub(crate) struct HoppingWindowConfig {
     #[pyo3(get)]
@@ -98,13 +98,15 @@ impl Windower for HoppingWindower {
 
         (first_window..windows_count)
             .map(|i| {
-                // First generate the WindowKey and calculate the window_end time
+                // First generate the WindowKey and calculate
+                // the window_end time
                 let key = WindowKey(i);
                 let window_start = self.start_at + Duration::milliseconds(i * offset);
                 let window_end = window_start + self.length;
-                // We only want to add items that happened between start and end of the window.
-                // If the watermark is past the end of the window, any item is late for this
-                // window.
+                // We only want to add items that happened between
+                // start and end of the window.
+                // If the watermark is past the end of the window,
+                // any item is late for this window.
                 if *item_time <= window_end
                     && *item_time >= window_start
                     && *watermark <= window_end
@@ -112,7 +114,8 @@ impl Windower for HoppingWindower {
                     self.add_close_time(key, window_end);
                     Ok(key)
                 } else {
-                    // We send `Late` even if the item came too early, maybe we should differentate
+                    // We send `Late` even if the item came too early,
+                    // maybe we should differentate
                     Err(InsertError::Late(key))
                 }
             })

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -43,10 +43,10 @@ use timely::dataflow::Scope;
 use timely::{Data, ExchangeData};
 
 pub(crate) mod clock;
-pub(crate) mod sliding_window;
+pub(crate) mod hopping_window;
 pub(crate) mod tumbling_window;
 
-use self::sliding_window::SlidingWindowConfig;
+use self::hopping_window::HoppingWindowConfig;
 use self::tumbling_window::TumblingWindowConfig;
 use clock::{event_time_clock::EventClockConfig, system_clock::SystemClockConfig, ClockConfig};
 
@@ -100,7 +100,7 @@ impl PyConfigClass<Box<dyn WindowBuilder>> for Py<WindowConfig> {
     fn downcast(&self, py: Python) -> StringResult<Box<dyn WindowBuilder>> {
         if let Ok(conf) = self.extract::<TumblingWindowConfig>(py) {
             Ok(Box::new(conf))
-        } else if let Ok(conf) = self.extract::<SlidingWindowConfig>(py) {
+        } else if let Ok(conf) = self.extract::<HoppingWindowConfig>(py) {
             Ok(Box::new(conf))
         } else {
             let pytype = self.as_ref(py).get_type();
@@ -523,6 +523,6 @@ pub(crate) fn register(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<SystemClockConfig>()?;
     m.add_class::<WindowConfig>()?;
     m.add_class::<TumblingWindowConfig>()?;
-    m.add_class::<SlidingWindowConfig>()?;
+    m.add_class::<HoppingWindowConfig>()?;
     Ok(())
 }

--- a/src/window/sliding_window.rs
+++ b/src/window/sliding_window.rs
@@ -1,0 +1,135 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Duration, Utc};
+use pyo3::{pyclass, Python};
+
+use crate::{add_pymethods, common::StringResult, window::WindowConfig};
+
+use super::{Builder, InsertError, StateBytes, WindowBuilder, WindowKey, Windower};
+
+/// Sliding windows of fixed duration.
+///
+/// Args:
+///
+///   length (datetime.timedelta): Length of window.
+///
+///   offset (datetime.timedelta): Offset between windows.
+///
+///   start_at (datetime.datetime): Instant of the first window. You
+///       can use this to align all windows to an hour,
+///       e.g. Defaults to system time of dataflow start.
+///
+/// Returns:
+///
+///   Config object. Pass this as the `window_config` parameter to
+///   your windowing operator.
+#[pyclass(module="bytewax.config", extends=WindowConfig)]
+#[derive(Clone)]
+pub(crate) struct SlidingWindowConfig {
+    #[pyo3(get)]
+    pub(crate) length: Duration,
+    #[pyo3(get)]
+    pub(crate) offset: Duration,
+    #[pyo3(get)]
+    pub(crate) start_at: Option<DateTime<Utc>>,
+}
+
+add_pymethods!(
+    SlidingWindowConfig,
+    parent: WindowConfig,
+    py_args: (length, offset, start_at = "None"),
+    args {
+        length: Duration => Duration::zero(),
+        offset: Duration => Duration::zero(),
+        start_at: Option<DateTime<Utc>> => None
+    }
+);
+
+impl WindowBuilder for SlidingWindowConfig {
+    fn build(&self, _py: Python) -> StringResult<Builder> {
+        Ok(Box::new(SlidingWindower::builder(
+            self.length,
+            self.offset,
+            self.start_at.unwrap_or_else(Utc::now),
+        )))
+    }
+}
+
+pub(crate) struct SlidingWindower {
+    length: Duration,
+    offset: Duration,
+    start_at: DateTime<Utc>,
+    close_times: HashMap<WindowKey, DateTime<Utc>>,
+}
+
+impl SlidingWindower {
+    pub(crate) fn builder(
+        length: Duration,
+        offset: Duration,
+        start_at: DateTime<Utc>,
+    ) -> impl Fn(Option<StateBytes>) -> Box<dyn Windower> {
+        move |resume_snapshot| {
+            let close_times = resume_snapshot
+                .map(StateBytes::de::<HashMap<WindowKey, DateTime<Utc>>>)
+                .unwrap_or_default();
+            Box::new(Self {
+                length,
+                offset,
+                start_at,
+                close_times,
+            })
+        }
+    }
+}
+
+impl Windower for SlidingWindower {
+    fn insert(
+        &mut self,
+        watermark: &DateTime<Utc>,
+        item_time: &DateTime<Utc>,
+    ) -> Vec<Result<WindowKey, InsertError>> {
+        let since_start_at = *item_time - self.start_at;
+        let windows_count = since_start_at.num_milliseconds() / self.offset.num_milliseconds() + 1;
+        let mut windows = vec![];
+        // TODO: Avoid starting from 0 here, we can skip windows closed before the watermark
+        for i in 0..windows_count {
+
+            let key = WindowKey(i);
+            let window_start =
+                self.start_at + Duration::milliseconds(i * self.offset.num_milliseconds());
+            let window_end = window_start + self.length;
+
+            if window_end < *watermark {
+                windows.push(Err(InsertError::Late(key)));
+                continue;
+            }
+
+            if *item_time < window_start {
+                continue;
+            }
+            if *item_time <= window_end {
+                self.close_times
+                    .entry(key)
+                    .and_modify(|existing| {
+                        assert!(
+                            existing == &window_end,
+                            "Sliding windower is not generating consistent boundaries"
+                        )
+                    })
+                    .or_insert(window_end);
+                windows.push(Ok(key));
+            } else {
+                windows.push(Err(InsertError::Late(key)));
+            }
+        }
+        windows
+    }
+
+    fn get_close_times(&self) -> &HashMap<WindowKey, DateTime<Utc>> {
+        &self.close_times
+    }
+
+    fn set_close_times(&mut self, close_times: HashMap<WindowKey, DateTime<Utc>>) {
+        self.close_times = close_times;
+    }
+}

--- a/src/window/tumbling_window.rs
+++ b/src/window/tumbling_window.rs
@@ -93,21 +93,17 @@ impl Windower for TumblingWindower {
         if &close_at < watermark {
             vec![Err(InsertError::Late(key))]
         } else {
-            self.close_times
-                .entry(key)
-                .and_modify(|existing_close_at| {
-                    assert!(
-                        existing_close_at == &close_at,
-                        "Tumbling windower is not generating consistent boundaries"
-                    )
-                })
-                .or_insert(close_at);
+            self.add_close_time(key, close_at);
             vec![Ok(key)]
         }
     }
 
     fn get_close_times(&self) -> &HashMap<WindowKey, DateTime<Utc>> {
         &self.close_times
+    }
+
+    fn get_close_times_mut(&mut self) -> &mut HashMap<WindowKey, DateTime<Utc>> {
+        &mut self.close_times
     }
 
     fn set_close_times(&mut self, close_times: HashMap<WindowKey, DateTime<Utc>>) {

--- a/src/window/tumbling_window.rs
+++ b/src/window/tumbling_window.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use chrono::{DateTime, Duration, Utc};
 use pyo3::prelude::*;
 
@@ -32,7 +30,8 @@ pub(crate) struct TumblingWindowConfig {
 
 impl WindowBuilder for TumblingWindowConfig {
     fn build(&self, _py: Python) -> StringResult<Builder> {
-        Ok(Box::new(TumblingWindower::builder(
+        Ok(Box::new(super::hopping_window::HoppingWindower::builder(
+            self.length,
             self.length,
             self.start_at.unwrap_or_else(Utc::now),
         )))
@@ -48,65 +47,3 @@ add_pymethods!(
         start_at: Option<DateTime<Utc>> => None
     }
 );
-
-/// Use fixed-length tumbling windows aligned to a start time.
-pub(crate) struct TumblingWindower {
-    length: Duration,
-    start_at: DateTime<Utc>,
-    close_times: HashMap<WindowKey, DateTime<Utc>>,
-}
-
-impl TumblingWindower {
-    pub(crate) fn builder(
-        length: Duration,
-        start_at: DateTime<Utc>,
-    ) -> impl Fn(Option<StateBytes>) -> Box<dyn Windower> {
-        move |resume_snapshot| {
-            let close_times = resume_snapshot
-                .map(StateBytes::de::<HashMap<WindowKey, DateTime<Utc>>>)
-                .unwrap_or_default();
-
-            Box::new(Self {
-                length,
-                start_at,
-                close_times,
-            })
-        }
-    }
-}
-
-impl Windower for TumblingWindower {
-    fn insert(
-        &mut self,
-        watermark: &DateTime<Utc>,
-        item_time: &DateTime<Utc>,
-    ) -> Vec<Result<WindowKey, InsertError>> {
-        let since_start_at = *item_time - self.start_at;
-        let window_count = since_start_at.num_milliseconds() / self.length.num_milliseconds();
-
-        let key = WindowKey(window_count);
-        let close_at = self
-            .start_at
-            .checked_add_signed(self.length * (window_count as i32 + 1))
-            .unwrap_or(DateTime::<Utc>::MAX_UTC);
-
-        if &close_at < watermark {
-            vec![Err(InsertError::Late(key))]
-        } else {
-            self.add_close_time(key, close_at);
-            vec![Ok(key)]
-        }
-    }
-
-    fn get_close_times(&self) -> &HashMap<WindowKey, DateTime<Utc>> {
-        &self.close_times
-    }
-
-    fn get_close_times_mut(&mut self) -> &mut HashMap<WindowKey, DateTime<Utc>> {
-        &mut self.close_times
-    }
-
-    fn set_close_times(&mut self, close_times: HashMap<WindowKey, DateTime<Utc>>) {
-        self.close_times = close_times;
-    }
-}


### PR DESCRIPTION
Added a `HoppingWindowConfig` object.

I also refactored the` Windower` trait to autoimplement some methods since it was equal on both the `WindowConfigs`. Trait methods can still be overridden if we need a different behavior in the future.

I also added a new macro, `add_pymethods`, which alleviates the problem of having to copy paste a lot of code for the infamuous egregious hack. I also have a separate branch where I use the macro everywhere else in the codebase, but I'd like to merge this first (or revert it if we don't like the macro).

Fixes #172 
