### PR TITLE
Using `add_pymethods` macro everywhere

### DIFF
--- a/src/execution/epoch/mod.rs
+++ b/src/execution/epoch/mod.rs
@@ -106,7 +106,7 @@ where
 /// Default to 10 second periodic epochs.
 pub(crate) fn default_epoch_config() -> Py<EpochConfig> {
     Python::with_gil(|py| {
-        PyCell::new(py, PeriodicEpochConfig::new(chrono::Duration::seconds(10)))
+        PyCell::new(py, PeriodicEpochConfig::py_new(chrono::Duration::seconds(10)))
             .unwrap()
             .extract()
             .unwrap()

--- a/src/outputs/manual_epoch_output.rs
+++ b/src/outputs/manual_epoch_output.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
-
 use crate::{
-    common::pickle_extract,
+    add_pymethods,
     execution::{WorkerCount, WorkerIndex},
     pyo3_extensions::{TdPyAny, TdPyCallable},
     unwrap_any,
 };
-use pyo3::{prelude::*, types::PyDict};
+use pyo3::prelude::*;
 
 use super::{OutputBuilder, OutputConfig, OutputWriter};
 
@@ -51,36 +49,14 @@ impl OutputBuilder for ManualEpochOutputConfig {
     }
 }
 
-#[pymethods]
-impl ManualEpochOutputConfig {
-    #[new]
-    #[args(output_builder)]
-    fn new(output_builder: TdPyCallable) -> (Self, OutputConfig) {
-        (Self { output_builder }, OutputConfig {})
+add_pymethods!(
+    ManualEpochOutputConfig,
+    parent: OutputConfig,
+    py_args: (output_builder),
+    args {
+        output_builder: TdPyCallable => Python::with_gil(TdPyCallable::pickle_new)
     }
-
-    /// Return a representation of this class as a PyDict.
-    fn __getstate__(&self) -> HashMap<&str, Py<PyAny>> {
-        Python::with_gil(|py| {
-            HashMap::from([
-                ("type", "ManualEpochOutputConfig".into_py(py)),
-                ("output_builder", self.output_builder.clone().into_py(py)),
-            ])
-        })
-    }
-
-    /// Egregious hack see [`SqliteRecoveryConfig::__getnewargs__`].
-    fn __getnewargs__(&self, py: Python) -> (TdPyCallable,) {
-        (TdPyCallable::pickle_new(py),)
-    }
-
-    /// Unpickle from tuple of arguments.
-    fn __setstate__(&mut self, state: &PyAny) -> PyResult<()> {
-        let dict: &PyDict = state.downcast()?;
-        self.output_builder = pickle_extract(dict, "output_builder")?;
-        Ok(())
-    }
-}
+);
 
 /// Call a Python callback function on each item of output with its
 /// epoch.


### PR DESCRIPTION
This PR makes use of the new `add_pymethods` macro to replace a lot of the boilerplate.