### PR TITLE
Use sqlx migrations to handle schema evolution.

### DIFF
--- a/migrations/20230206170933_initial.sql
+++ b/migrations/20230206170933_initial.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS state (
+       step_id TEXT,
+       state_key TEXT,
+       epoch INTEGER,
+       snapshot BLOB,
+       PRIMARY KEY (step_id, state_key, epoch)
+);
+
+CREATE TABLE IF NOT EXISTS progress (
+       execution INTEGER,
+       worker_index INTEGER,
+       frontier INTEGER,
+       PRIMARY KEY (execution, worker_index)
+);
+
+CREATE TABLE IF NOT EXISTS execution (
+       execution INTEGER,
+       worker_index INTEGER,
+       worker_count INTEGER,
+       resume_epoch INTEGER,
+       PRIMARY KEY (execution, worker_index)
+);

--- a/src/execution/epoch/mod.rs
+++ b/src/execution/epoch/mod.rs
@@ -106,9 +106,12 @@ where
 /// Default to 10 second periodic epochs.
 pub(crate) fn default_epoch_config() -> Py<EpochConfig> {
     Python::with_gil(|py| {
-        PyCell::new(py, PeriodicEpochConfig::py_new(chrono::Duration::seconds(10)))
-            .unwrap()
-            .extract()
-            .unwrap()
+        PyCell::new(
+            py,
+            PeriodicEpochConfig::py_new(chrono::Duration::seconds(10)),
+        )
+        .unwrap()
+        .extract()
+        .unwrap()
     })
 }

--- a/src/recovery/store/sqlite.rs
+++ b/src/recovery/store/sqlite.rs
@@ -165,13 +165,10 @@ impl<'r> Decode<'r, Sqlite> for WorkerCount {
 pub struct SqliteStateWriter {
     rt: Runtime,
     conn: SqlitePool,
-    table_name: String,
 }
 
 impl SqliteStateWriter {
     pub fn new(db_file: &Path) -> Self {
-        let table_name = "state".to_string();
-
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -184,28 +181,11 @@ impl SqliteStateWriter {
         tracing::debug!("Opening Sqlite connection to {db_file:?}");
         let conn = rt.block_on(future).unwrap();
 
-        // TODO: SQLite doesn't let you bind to table names. Can
-        // we do this in a slightly safer way? I'm not as worried
-        // because this value is not from items in the dataflow
-        // stream, but from the config which should be under
-        // developer control.
-        let sql = format!(
-            "CREATE TABLE IF NOT EXISTS {table_name} ( \
-             step_id TEXT, \
-             state_key TEXT, \
-             epoch INTEGER, \
-             snapshot BLOB, \
-             PRIMARY KEY (step_id, state_key, epoch) \
-             );"
-        );
-        let future = query(&sql).execute(&conn);
-        rt.block_on(future).unwrap();
+        tracing::debug!("Running any pending sqlite migrations");
+        rt.block_on(sqlx::migrate!().run(&conn))
+            .expect("Unable to run sqlite migrations");
 
-        Self {
-            rt,
-            conn,
-            table_name,
-        }
+        Self { rt, conn }
     }
 }
 
@@ -222,11 +202,10 @@ impl KWriter<StoreKey, Change<StateBytes>> for SqliteStateWriter {
                     Change::Discard => None,
                 };
                 let sql = format!(
-                    "INSERT INTO {} (step_id, state_key, epoch, snapshot) \
+                    "INSERT INTO state (step_id, state_key, epoch, snapshot) \
                      VALUES (?1, ?2, ?3, ?4) \
                      ON CONFLICT (step_id, state_key, epoch) DO UPDATE \
                      SET snapshot = EXCLUDED.snapshot",
-                    self.table_name,
                 );
                 let future = query(&sql)
                     .bind(step_id)
@@ -243,8 +222,7 @@ impl KWriter<StoreKey, Change<StateBytes>> for SqliteStateWriter {
             }
             Change::Discard => {
                 let sql = format!(
-                    "DELETE FROM {} WHERE step_id = ?1 AND state_key = ?2 AND epoch = ?3",
-                    self.table_name
+                    "DELETE FROM state WHERE step_id = ?1 AND state_key = ?2 AND epoch = ?3",
                 );
                 let future = query(&sql)
                     .bind(step_id)
@@ -267,8 +245,6 @@ pub(crate) struct SqliteStateReader {
 
 impl SqliteStateReader {
     pub(crate) fn new(db_file: &Path) -> Self {
-        let table_name = "state";
-
         // Bootstrap off writer to get table creation.
         let writer = SqliteStateWriter::new(db_file);
         let rt = writer.rt;
@@ -279,7 +255,7 @@ impl SqliteStateReader {
         rt.spawn(async move {
             let sql = format!(
                 "SELECT step_id, state_key, epoch, snapshot \
-                 FROM {table_name} \
+                 FROM state \
                  ORDER BY epoch ASC"
             );
             let mut stream = query(&sql)
@@ -322,15 +298,10 @@ impl KReader<StoreKey, Change<StateBytes>> for SqliteStateReader {
 pub(crate) struct SqliteProgressWriter {
     rt: Runtime,
     conn: SqlitePool,
-    progress_table_name: String,
-    execution_table_name: String,
 }
 
 impl SqliteProgressWriter {
     pub(crate) fn new(db_file: &Path) -> Self {
-        let progress_table_name = "progress".to_string();
-        let execution_table_name = "execution".to_string();
-
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -345,35 +316,7 @@ impl SqliteProgressWriter {
         tracing::debug!("Opening Sqlite connection to {db_file:?}");
         let conn = rt.block_on(future).unwrap();
 
-        let sql = format!(
-            "CREATE TABLE IF NOT EXISTS {progress_table_name} ( \
-             execution INTEGER, \
-             worker_index INTEGER, \
-             frontier INTEGER, \
-             PRIMARY KEY (execution, worker_index) \
-             );"
-        );
-        let future = query(&sql).execute(&conn);
-        rt.block_on(future).unwrap();
-
-        let sql = format!(
-            "CREATE TABLE IF NOT EXISTS {execution_table_name} ( \
-             execution INTEGER, \
-             worker_index INTEGER, \
-             worker_count INTEGER, \
-             resume_epoch INTEGER, \
-             PRIMARY KEY (execution, worker_index) \
-             );"
-        );
-        let future = query(&sql).execute(&conn);
-        rt.block_on(future).unwrap();
-
-        Self {
-            rt,
-            conn,
-            progress_table_name,
-            execution_table_name,
-        }
+        Self { rt, conn }
     }
 }
 
@@ -387,13 +330,12 @@ impl KWriter<WorkerKey, ProgressMsg> for SqliteProgressWriter {
             Change::Upsert(msg) => match msg {
                 ProgressMsg::Init(count, epoch) => {
                     let sql = format!(
-                        "INSERT INTO {} \
+                        "INSERT INTO execution \
                          (execution, worker_index, worker_count, resume_epoch) \
                          VALUES (?1, ?2, ?3, ?4) \
                          ON CONFLICT (execution, worker_index) DO UPDATE \
                          SET worker_count = EXCLUDED.worker_count, \
                          resume_epoch = EXCLUDED.resume_epoch",
-                        self.execution_table_name,
                     );
                     let future = query(&sql)
                         .bind(
@@ -411,12 +353,11 @@ impl KWriter<WorkerKey, ProgressMsg> for SqliteProgressWriter {
                 }
                 ProgressMsg::Advance(epoch) => {
                     let sql = format!(
-                        "INSERT INTO {} \
+                        "INSERT INTO progress \
                          (execution, worker_index, frontier) \
                          VALUES (?1, ?2, ?3) \
                          ON CONFLICT (execution, worker_index) DO UPDATE \
                          SET frontier = EXCLUDED.frontier",
-                        self.progress_table_name,
                     );
                     let future = query(&sql)
                         .bind(
@@ -433,10 +374,8 @@ impl KWriter<WorkerKey, ProgressMsg> for SqliteProgressWriter {
                 }
             },
             Change::Discard => {
-                let sql = format!(
-                    "DELETE FROM {} WHERE execution = ?1 AND worker_index = ?2",
-                    self.progress_table_name
-                );
+                let sql =
+                    format!("DELETE FROM progress WHERE execution = ?1 AND worker_index = ?2",);
                 let future = query(&sql)
                     .bind(
                         <u64 as TryInto<i64>>::try_into(ex.0)

--- a/src/window/clock/event_time_clock.rs
+++ b/src/window/clock/event_time_clock.rs
@@ -1,6 +1,6 @@
 use std::task::Poll;
 
-use chrono::{DateTime, Utc, Duration};
+use chrono::{DateTime, Duration, Utc};
 use pyo3::prelude::*;
 
 use crate::{


### PR DESCRIPTION
Uses https://docs.rs/sqlx/latest/sqlx/macro.migrate.html to handle table creation and migration.