### PR TITLE
Fix "interleaved executions"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Fixes an issue with SQLite-based recovery. Previously you'd always
+  get an "interleaved executions" panic whenever you resumed a cluster
+  after the first time.
+
 - Added `HoppingWindowConfig` for windowing operators.
 - Add `filter_map` operator.
 

--- a/src/recovery/store/in_mem.rs
+++ b/src/recovery/store/in_mem.rs
@@ -460,7 +460,7 @@ fn worker_count_works() {
 
 #[test]
 #[should_panic]
-fn init_panics_on_regress() {
+fn init_panics_on_execution_regress() {
     let mut progress = InMemProgress::new(WorkerCount(2));
 
     let ex1 = Execution(1);
@@ -483,16 +483,41 @@ fn init_panics_on_inconsistent_worker_count() {
 
 #[test]
 #[should_panic]
-fn advance_panics_on_regress() {
+fn advance_panics_on_frontier_regress() {
     let mut progress = InMemProgress::new(WorkerCount(2));
 
     let ex1 = Execution(1);
     progress.init(ex1, WorkerCount(3), ResumeEpoch(1));
 
     progress.advance(ex1, WorkerIndex(0), WorkerFrontier(2));
+    progress.advance(ex1, WorkerIndex(0), WorkerFrontier(1));
+}
+
+#[test]
+#[should_panic]
+fn advance_panics_on_execution_skip() {
+    let mut progress = InMemProgress::new(WorkerCount(2));
+
+    let ex1 = Execution(1);
+    progress.init(ex1, WorkerCount(3), ResumeEpoch(1));
+
+    let ex2 = Execution(2);
+    progress.advance(ex2, WorkerIndex(0), WorkerFrontier(2));
+}
+
+#[test]
+fn advance_ignores_late_executions() {
+    let mut progress = InMemProgress::new(WorkerCount(2));
+
+    let ex1 = Execution(1);
+    progress.init(ex1, WorkerCount(3), ResumeEpoch(4));
 
     let ex0 = Execution(0);
-    progress.advance(ex0, WorkerIndex(1), WorkerFrontier(3));
+    progress.advance(ex0, WorkerIndex(0), WorkerFrontier(2));
+
+    let found = progress.resume_from();
+    let expected = ResumeFrom(Execution(2), ResumeEpoch(4));
+    assert_eq!(found, expected);
 }
 
 #[test]

--- a/src/recovery/store/sqlite.rs
+++ b/src/recovery/store/sqlite.rs
@@ -415,44 +415,55 @@ impl SqliteProgressReader {
                             .expect("SQLite int can't fit into epoch; might be negative"),
                     );
                     let msg = ProgressMsg::Init(count, epoch);
-                    KChange(key, Change::Upsert(msg))
+                    (key, msg)
                 })
                 .fetch(&conn)
                 .map(|result| result.expect("Error selecting from SQLite"));
 
-            while let Some(kchange) = stream.next().await {
+            let mut last_ex = None;
+
+            while let Some((key, msg)) = stream.next().await {
+                let WorkerKey(ex, _index) = key;
+                last_ex = Some(ex);
+
+                let kchange = KChange(key, Change::Upsert(msg));
                 tracing::trace!("Reading progress change {kchange:?}");
                 tx.send(kchange).await.unwrap();
             }
 
-            // TODO: We really could only select progress from the
-            // latest execution.
-            let sql =
-                "SELECT execution, worker_index, frontier FROM progress ORDER BY execution ASC";
+            if let Some(ex) = last_ex {
+                let sql =
+                    "SELECT execution, worker_index, frontier FROM progress WHERE execution = ?1 ORDER BY frontier ASC";
 
-            let mut stream = query(&sql)
-                .map(|row: SqliteRow| {
-                    let ex = Execution(
-                        row.get::<i64, _>(0)
-                            .try_into()
-                            .expect("SQLite int can't fit into execution; might be negative"),
-                    );
-                    let index: WorkerIndex = row.get(1);
-                    let key = WorkerKey(ex, index);
-                    let epoch = WorkerFrontier(
-                        row.get::<i64, _>(2)
-                            .try_into()
-                            .expect("SQLite int can't fit into epoch; might be negative"),
-                    );
-                    let msg = ProgressMsg::Advance(epoch);
-                    KChange(key, Change::Upsert(msg))
-                })
-                .fetch(&conn)
-                .map(|result| result.expect("Error selecting from SQLite"));
+                let mut stream = query(&sql)
+                    .bind(
+                        <u64 as TryInto<i64>>::try_into(ex.0)
+                            .expect("execution can't fit into SQLite int"),
+                    )
+                    .map(|row: SqliteRow| {
+                        let ex = Execution(
+                            row.get::<i64, _>(0)
+                                .try_into()
+                                .expect("SQLite int can't fit into execution; might be negative"),
+                        );
+                        let index: WorkerIndex = row.get(1);
+                        let key = WorkerKey(ex, index);
+                        let epoch = WorkerFrontier(
+                            row.get::<i64, _>(2)
+                                .try_into()
+                                .expect("SQLite int can't fit into epoch; might be negative"),
+                        );
+                        let msg = ProgressMsg::Advance(epoch);
+                        (key, msg)
+                    })
+                    .fetch(&conn)
+                    .map(|result| result.expect("Error selecting from SQLite"));
 
-            while let Some(kchange) = stream.next().await {
-                tracing::trace!("Reading progress change {kchange:?}");
-                tx.send(kchange).await.unwrap();
+                while let Some((key, msg)) = stream.next().await {
+                    let kchange = KChange(key, Change::Upsert(msg));
+                    tracing::trace!("Reading progress change {kchange:?}");
+                    tx.send(kchange).await.unwrap();
+                }
             }
         });
 

--- a/src/recovery/store/sqlite.rs
+++ b/src/recovery/store/sqlite.rs
@@ -398,7 +398,7 @@ impl SqliteProgressReader {
 
         rt.spawn(async move {
             let sql = "SELECT execution, worker_index, worker_count, resume_epoch \
-                       FROM execution";
+                       FROM execution ORDER BY execution DESC LIMIT 1";
             let mut stream = query(&sql)
                 .map(|row: SqliteRow| {
                     let ex = Execution(
@@ -425,7 +425,10 @@ impl SqliteProgressReader {
                 tx.send(kchange).await.unwrap();
             }
 
-            let sql = "SELECT execution, worker_index, frontier FROM progress";
+            // TODO: We really could only select progress from the
+            // latest execution.
+            let sql =
+                "SELECT execution, worker_index, frontier FROM progress ORDER BY execution ASC";
 
             let mut stream = query(&sql)
                 .map(|row: SqliteRow| {


### PR DESCRIPTION
Turns out they're ok. During resume, each worker's progress events are
in order. But! Because we're reading all the progress logs in parallel
and broadcasting them, across workers they might be out-of-order. Thus
we might do something like read all of worker 1's progress, then all
of worker 2's. Execution init messages are stored on all workers, so
the resume cluster might already have advanced to the final exeuction,
and then go "back in time" to see a slow reader's log. That's fine
because we already know the next exeuction started and thus can ignore
those progress messages.

Re-works some of the recovery tests to crash and restart twice to
start to probe this.
