### PR TITLE
Allows KafkaInput to take multiple topics

### DIFF
--- a/pytests/connectors/test_kafka.py
+++ b/pytests/connectors/test_kafka.py
@@ -1,23 +1,27 @@
+import os
 import uuid
 from concurrent.futures import wait
 
 from confluent_kafka import Producer
 from confluent_kafka.admin import AdminClient, NewTopic
-from pytest import fixture, mark
+from pytest import fixture, mark, raises
 
 from bytewax.connectors.kafka import KafkaInput
 from bytewax.dataflow import Dataflow
 from bytewax.execution import run_main
 from bytewax.outputs import TestingOutputConfig
 
+pytestmark = mark.skipif(
+    "TEST_KAFKA_BROKER" not in os.environ,
+    reason="No Kafka broker set via `TEST_KAFKA_BROKER` env var",
+)
+KAFKA_BROKER = os.environ.get("TEST_KAFKA_BROKER")
+
 
 @fixture
 def tmp_topic(request):
     config = {
-        # For some reason Redpanda does not bind to IPv6 and my
-        # definition of `localhost` returns an IPv6 address first, so
-        # force usage of IPv4.
-        "bootstrap.servers": "127.0.0.1",
+        "bootstrap.servers": KAFKA_BROKER,
     }
     client = AdminClient(config)
     topic_name = f"pytest_{request.node.name}_{uuid.uuid4()}"
@@ -32,10 +36,9 @@ tmp_topic1 = tmp_topic
 tmp_topic2 = tmp_topic
 
 
-@mark.skip("Don't run unless you have a Kafka cluster setup on 127.0.0.1")
 def test_kafka_input(tmp_topic1, tmp_topic2):
     config = {
-        "bootstrap.servers": "127.0.0.1",
+        "bootstrap.servers": "localhost",
     }
     topics = [tmp_topic1, tmp_topic2]
     prod = Producer(config)
@@ -48,7 +51,7 @@ def test_kafka_input(tmp_topic1, tmp_topic2):
 
     flow = Dataflow()
 
-    flow.input("inp", KafkaInput(["localhost"], topics, tail=False))
+    flow.input("inp", KafkaInput([KAFKA_BROKER], topics, tail=False))
 
     out = []
     flow.capture(TestingOutputConfig(out))
@@ -63,3 +66,34 @@ def test_kafka_input(tmp_topic1, tmp_topic2):
         (b"key-1-1", b"value-1-1"),
         (b"key-1-2", b"value-1-2"),
     ]
+
+
+def test_kafka_input_raises_on_topic_not_exist():
+    flow = Dataflow()
+
+    flow.input("inp", KafkaInput([KAFKA_BROKER], ["missing-topic"], tail=False))
+
+    out = []
+    flow.capture(TestingOutputConfig(out))
+
+    with raises(Exception) as exinfo:
+        run_main(flow)
+
+    assert str(exinfo.value) == (
+        "error listing partitions for Kafka topic `'missing-topic'`: "
+        "Broker: Unknown topic or partition"
+    )
+
+
+def test_kafka_input_raises_on_str_brokers(tmp_topic):
+    with raises(TypeError) as exinfo:
+        KafkaInput(KAFKA_BROKER, [tmp_topic], tail=False)
+
+    assert str(exinfo.value) == "brokers must be an iterable and not a string"
+
+
+def test_kafka_input_raises_on_str_topics(tmp_topic):
+    with raises(TypeError) as exinfo:
+        KafkaInput([KAFKA_BROKER], tmp_topic, tail=False)
+
+    assert str(exinfo.value) == "topics must be an iterable and not a string"

--- a/pytests/connectors/test_kafka.py
+++ b/pytests/connectors/test_kafka.py
@@ -1,0 +1,65 @@
+import uuid
+from concurrent.futures import wait
+
+from confluent_kafka import Producer
+from confluent_kafka.admin import AdminClient, NewTopic
+from pytest import fixture, mark
+
+from bytewax.connectors.kafka import KafkaInput
+from bytewax.dataflow import Dataflow
+from bytewax.execution import run_main
+from bytewax.outputs import TestingOutputConfig
+
+
+@fixture
+def tmp_topic(request):
+    config = {
+        # For some reason Redpanda does not bind to IPv6 and my
+        # definition of `localhost` returns an IPv6 address first, so
+        # force usage of IPv4.
+        "bootstrap.servers": "127.0.0.1",
+    }
+    client = AdminClient(config)
+    topic_name = f"pytest_{request.node.name}_{uuid.uuid4()}"
+    wait(
+        client.create_topics([NewTopic(topic_name, -1)], operation_timeout=5.0).values()
+    )
+    yield topic_name
+    wait(client.delete_topics([topic_name], operation_timeout=5.0).values())
+
+
+tmp_topic1 = tmp_topic
+tmp_topic2 = tmp_topic
+
+
+@mark.skip("Don't run unless you have a Kafka cluster setup on 127.0.0.1")
+def test_kafka_input(tmp_topic1, tmp_topic2):
+    config = {
+        "bootstrap.servers": "127.0.0.1",
+    }
+    topics = [tmp_topic1, tmp_topic2]
+    prod = Producer(config)
+    for i, topic in enumerate(topics):
+        for j in range(3):
+            key = f"key-{i}-{j}".encode()
+            value = f"value-{i}-{j}".encode()
+            prod.produce(topic, value, key)
+    prod.flush()
+
+    flow = Dataflow()
+
+    flow.input("inp", KafkaInput(["localhost"], topics, tail=False))
+
+    out = []
+    flow.capture(TestingOutputConfig(out))
+
+    run_main(flow)
+
+    assert sorted(out) == [
+        (b"key-0-0", b"value-0-0"),
+        (b"key-0-1", b"value-0-1"),
+        (b"key-0-2", b"value-0-2"),
+        (b"key-1-0", b"value-1-0"),
+        (b"key-1-1", b"value-1-1"),
+        (b"key-1-2", b"value-1-2"),
+    ]

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -107,8 +107,9 @@ impl PartInput {
                 Ok((key, part))
             }).collect::<PyResult<HashMap<StateKey, PartIter>>>()?;
 
-        let remaining_keys: Vec<StateKey> = resume_state.into_keys().into_iter().collect();
-        assert!(remaining_keys.is_empty(), "Partition keys in resume state that are not in partition list; changing partition counts? recovery state routing bug?");
+        if !resume_state.is_empty() {
+            tracing::warn!("Resume state exists for unknown partitions {:?}; changing partition counts? recovery state routing bug?", resume_state.keys());
+        }
 
         Ok((PartBundle::new(parts), part_count))
     }

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -71,8 +71,17 @@ impl PartInput {
         worker_count: WorkerCount,
         mut resume_state: StepStateBytes,
     ) -> PyResult<(PartBundle, TotalPartCount)> {
-        let mut keys: Vec<StateKey> = self.0.call_method0(py, "list_parts")?.extract(py)?;
-        keys.sort();
+        let keys = {
+            let mut keys = self
+                .0
+                .call_method0(py, "list_parts")?
+                .as_ref(py)
+                .iter()?
+                .map(|i| i.and_then(PyAny::extract::<StateKey>))
+                .collect::<PyResult<Vec<StateKey>>>()?;
+            keys.sort();
+            keys
+        };
 
         let part_count = TotalPartCount(keys.len());
 

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -16,7 +16,7 @@
 //! sources are generated and epochs assigned. The only goal of the
 //! input system is "what's the next item for this input?"
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::task::Poll;
 
 use crate::execution::{WorkerCount, WorkerIndex};
@@ -71,17 +71,13 @@ impl PartInput {
         worker_count: WorkerCount,
         mut resume_state: StepStateBytes,
     ) -> PyResult<(PartBundle, TotalPartCount)> {
-        let keys = {
-            let mut keys = self
-                .0
-                .call_method0(py, "list_parts")?
-                .as_ref(py)
-                .iter()?
-                .map(|i| i.and_then(PyAny::extract::<StateKey>))
-                .collect::<PyResult<Vec<StateKey>>>()?;
-            keys.sort();
-            keys
-        };
+        let keys = self
+            .0
+            .call_method0(py, "list_parts")?
+            .as_ref(py)
+            .iter()?
+            .map(|i| i.and_then(PyAny::extract::<StateKey>))
+            .collect::<PyResult<BTreeSet<StateKey>>>()?;
 
         let part_count = TotalPartCount(keys.len());
 

--- a/src/recovery/model/state.rs
+++ b/src/recovery/model/state.rs
@@ -115,8 +115,12 @@ impl StepStateBytes {
         self.0.remove(key)
     }
 
-    pub(crate) fn into_keys(self) -> impl IntoIterator<Item = StateKey> {
-        self.0.into_keys()
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn keys(&self) -> Keys<'_, StateKey, StateBytes> {
+        self.0.keys()
     }
 }
 


### PR DESCRIPTION
It will multiplex them all at that point in the dataflow.

Adds a unit test for this, although since we don't have a Kafka
cluster in CI, skips it for now.

Also allows `PartInput.list_parts` to return an iterable.
