### PR TITLE
Renames Part{Input,Output} to Partitioned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,16 @@ notes on GitHub when we make a new release.__
 
 - Add `filter_map` operator.
 
-- *Breaking change* New partition-based input API. This replaces
-  `ManualInputConfig` with a new `bytewax.inputs.PartInput`. See
-  `bytewax.inputs` for more info.
+- *Breaking change* New partition-based input and output API. This
+  removes `ManualInputConfig` and `ManualOutputConfig`. See
+  `bytewax.inputs` and `bytewax.outputs` for more info.
 
-- *Breaking change* `KafkaInputConfig` has been moved to
-  `bytewax.connectors.kafka.KafkaInput`.
+- *Breaking change* `Dataflow.capture` operator is renamed to
+  `Dataflow.output`.
+
+- *Breaking change* `KafkaInputConfig` and `KafkaOutputConfig` have
+  been moved to `bytewax.connectors.kafka.KafkaInput` and
+  `bytewax.connectors.kafka.KafkaOutput`.
 
 ## 0.15.0
 

--- a/examples/anomaly_detector.py
+++ b/examples/anomaly_detector.py
@@ -2,11 +2,11 @@ import random
 
 from bytewax.dataflow import Dataflow
 from bytewax.execution import spawn_cluster
-from bytewax.inputs import PartInput
+from bytewax.inputs import PartitionedInput
 from bytewax.outputs import ManualOutputConfig
 
 
-class RandomMetricInput(PartInput):
+class RandomMetricInput(PartitionedInput):
     def list_parts(self):
         return ["singleton"]
 

--- a/examples/events_to_parquet.py
+++ b/examples/events_to_parquet.py
@@ -9,12 +9,12 @@ from pyarrow import parquet, Table
 
 from bytewax.dataflow import Dataflow
 from bytewax.execution import spawn_cluster
-from bytewax.inputs import PartInput
+from bytewax.inputs import PartitionedInput
 from bytewax.outputs import ManualOutputConfig
 from bytewax.window import SystemClockConfig, TumblingWindow
 
 
-class FakeWebEventsInput(PartInput):
+class FakeWebEventsInput(PartitionedInput):
     def list_parts(self):
         return ["singleton"]
 

--- a/examples/orderbook.py
+++ b/examples/orderbook.py
@@ -6,11 +6,11 @@ from websocket import create_connection
 from bytewax import parse
 from bytewax.dataflow import Dataflow
 from bytewax.execution import spawn_cluster
-from bytewax.inputs import PartInput
+from bytewax.inputs import PartitionedInput
 from bytewax.outputs import StdOutputConfig
 
 
-class CoinbaseFeedInput(PartInput):
+class CoinbaseFeedInput(PartitionedInput):
     def __init__(self, product_ids):
         self.product_ids = product_ids
 

--- a/examples/wikistream.py
+++ b/examples/wikistream.py
@@ -8,12 +8,12 @@ import urllib3
 
 from bytewax.dataflow import Dataflow
 from bytewax.execution import run_main
-from bytewax.inputs import PartInput
+from bytewax.inputs import PartitionedInput
 from bytewax.outputs import StdOutputConfig
 from bytewax.window import SystemClockConfig, TumblingWindow
 
 
-class WikiStreamInput(PartInput):
+class WikiStreamInput(PartitionedInput):
     def list_parts(self):
         # Wikimedia's SSE stream has no way to request disjoint data,
         # so we have only one partition.

--- a/pysrc/bytewax/connectors/files.py
+++ b/pysrc/bytewax/connectors/files.py
@@ -5,8 +5,8 @@ import os
 from pathlib import Path
 from typing import Callable
 
-from bytewax.inputs import PartInput
-from bytewax.outputs import PartOutput
+from bytewax.inputs import PartitionedInput
+from bytewax.outputs import PartitionedOutput
 
 
 def _stateful_read(path, resume_state):
@@ -20,7 +20,7 @@ def _stateful_read(path, resume_state):
             yield i, line.strip()
 
 
-class DirInput(PartInput):
+class DirInput(PartitionedInput):
     """Read all files in a filesystem directory line-by-line.
 
     The directory must exist and contain identical data on all
@@ -60,7 +60,7 @@ class DirInput(PartInput):
         return _stateful_read(path, resume_state)
 
 
-class FileInput(PartInput):
+class FileInput(PartitionedInput):
     """Read a single file line-by-line from the filesystem.
 
     This file must exist and be identical on all workers.
@@ -104,7 +104,7 @@ def _stateful_write_builder(path, resume_state, end):
     return write
 
 
-class DirOutput(PartOutput):
+class DirOutput(PartitionedOutput):
     """Write to a set of files in a filesystem directory line-by-line.
 
     Items consumed from the dataflow must look like two-tuples of
@@ -167,7 +167,7 @@ class DirOutput(PartOutput):
         return _stateful_write_builder(path, resume_state, self.end)
 
 
-class FileOutput(PartOutput):
+class FileOutput(PartitionedOutput):
     """Write to a single file line-by-line on the filesystem.
 
     Items consumed from the dataflow must look like a string. Use a

--- a/pysrc/bytewax/connectors/kafka.py
+++ b/pysrc/bytewax/connectors/kafka.py
@@ -16,7 +16,7 @@ from confluent_kafka import (
 )
 from confluent_kafka.admin import AdminClient
 
-from bytewax.inputs import PartInput
+from bytewax.inputs import PartitionedInput
 from bytewax.outputs import DynamicOutput
 
 
@@ -36,7 +36,7 @@ def _list_parts(client, topics):
             yield f"{i}-{topic}"
 
 
-class KafkaInput(PartInput):
+class KafkaInput(PartitionedInput):
     """Use [Kafka](https://kafka.apache.org) topics as an input
     source.
 

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -19,7 +19,7 @@ items.
 
 It must yield a two-tuple of `(state, item)` where the state will be
 returned to you via the `resume_state` parameter of
-`PartInput.build_part`.
+`PartitionedInput.build_part`.
 
 If this is a generator, it must do a kind of cooperative
 multi-tasking, never blocking but yielding a bare `None` if there is
@@ -34,7 +34,7 @@ Yields:
 
 # TODO: Add ABC superclass. It messes up pickling. We should get rid
 # of pickling...
-class PartInput:
+class PartitionedInput:
     """An input source with a fixed number of independent partitions."""
 
     @abstractmethod

--- a/pysrc/bytewax/outputs.py
+++ b/pysrc/bytewax/outputs.py
@@ -36,7 +36,8 @@ StatefulSink = Callable[[Any], Any]
 
 Called once for each `(key, value)` at this point in the dataflow.
 
-See `PartOutput.assign_part` for how the key is mapped to partition.
+See `PartitionedOutput.assign_part` for how the key is mapped to
+partition.
 
 Args:
 
@@ -50,7 +51,7 @@ Returns:
 """
 
 
-class PartOutput(Output):
+class PartitionedOutput(Output):
     """An output with a fixed number of independent partitions.
 
     Will maintain the state of each sink and re-build using it during

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -5,11 +5,11 @@ from contextlib import contextmanager
 from threading import Lock
 from typing import Any, Iterable
 
-from bytewax.inputs import PartInput
+from bytewax.inputs import PartitionedInput
 from bytewax.outputs import DynamicOutput
 
 
-class TestingInput(PartInput):
+class TestingInput(PartitionedInput):
     """Produce input from a Python iterable. You only want to use this
     for unit testing.
 

--- a/pytests/test_encoder.py
+++ b/pytests/test_encoder.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 from bytewax._encoder import encode_dataflow
 from bytewax.dataflow import Dataflow
-from bytewax.inputs import PartInput
+from bytewax.inputs import PartitionedInput
 from bytewax.window import EventClockConfig, TumblingWindow
 
 
@@ -25,7 +25,7 @@ class OrderBook:
 def test_encoding_custom_input():
     flow = Dataflow()
 
-    class MyCustomInput(PartInput):
+    class MyCustomInput(PartitionedInput):
         def list_parts(self):
             return ["one"]
 

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -12,7 +12,7 @@
 use std::collections::HashMap;
 
 use crate::common::pickle_extract;
-use crate::inputs::PartInput;
+use crate::inputs::PartitionedInput;
 use crate::outputs::Output;
 use crate::pyo3_extensions::TdPyCallable;
 use crate::recovery::model::StepId;
@@ -87,7 +87,7 @@ impl Dataflow {
     ///   input: Source. See `bytewax.connectors` and
     ///       `bytewax.inputs`.
     #[pyo3(text_signature = "(self, step_id, input)")]
-    fn input(&mut self, step_id: StepId, input: PartInput) {
+    fn input(&mut self, step_id: StepId, input: PartitionedInput) {
         self.steps.push(Step::Input { step_id, input });
     }
 
@@ -689,7 +689,7 @@ impl Dataflow {
 pub(crate) enum Step {
     Input {
         step_id: StepId,
-        input: PartInput,
+        input: PartitionedInput,
     },
     Map {
         mapper: TdPyCallable,

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -35,7 +35,7 @@ use crate::operators::reduce_window::ReduceWindowLogic;
 use crate::operators::stateful_map::StatefulMapLogic;
 use crate::operators::stateful_unary::StatefulUnary;
 use crate::operators::*;
-use crate::outputs::{DynamicOutputOp, PartOutputOp};
+use crate::outputs::{DynamicOutputOp, PartitionedOutputOp};
 use crate::pyo3_extensions::{extract_state_pair, wrap_state_pair};
 use crate::recovery::dataflows::*;
 use crate::recovery::model::*;
@@ -350,7 +350,7 @@ where
                         let step_resume_state = resume_state.remove(&step_id);
 
                         let (output, changes) =
-                            stream.part_output(
+                            stream.partitioned_output(
                                 py,
                                 step_id,
                                 output,

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -3,13 +3,14 @@
 //! For a user-centric version of input, read the `bytewax.inputs`
 //! Python module docstring. Read that first.
 //!
-//! [`PartInput`] defines an input source. [`PartBundle`] is what is
-//! passed to the source operators defined in
+//! [`PartitionedInput`] defines an input source. [`PartBundle`] is
+//! what is passed to the source operators defined in
 //! [`crate::execution::epoch`].
 //!
 //! Each [`PartIter`] is keyed by a [`StateKey`] so that the recovery
 //! system can round trip the state data back to
-//! [`PartInput::build_parts`] and be provided to the correct builder.
+//! [`PartitionedInput::build_parts`] and be provided to the correct
+//! builder.
 //!
 //! The one extra quirk here is that input is completely decoupled
 //! from epoch generation. See [`crate::execution`] for how Timely
@@ -28,21 +29,21 @@ use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::PyIterator;
 
-/// Represents a `bytewax.inputs.PartInput` from Python.
+/// Represents a `bytewax.inputs.PartitionedInput` from Python.
 #[derive(Clone)]
-pub(crate) struct PartInput(Py<PyAny>);
+pub(crate) struct PartitionedInput(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'source> FromPyObject<'source> for PartInput {
+impl<'source> FromPyObject<'source> for PartitionedInput {
     fn extract(ob: &'source PyAny) -> PyResult<Self> {
         let abc = ob
             .py()
             .import("bytewax.inputs")?
-            .getattr("PartInput")?
+            .getattr("PartitionedInput")?
             .extract()?;
         if !ob.is_instance(abc)? {
             Err(PyTypeError::new_err(
-                "input must derive from `bytewax.inputs.PartInput`",
+                "input must derive from `bytewax.inputs.PartitionedInput`",
             ))
         } else {
             Ok(Self(ob.into()))
@@ -50,7 +51,7 @@ impl<'source> FromPyObject<'source> for PartInput {
     }
 }
 
-impl IntoPy<Py<PyAny>> for PartInput {
+impl IntoPy<Py<PyAny>> for PartitionedInput {
     fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
         self.0
     }
@@ -61,7 +62,7 @@ impl IntoPy<Py<PyAny>> for PartInput {
 /// Not just on this worker.
 pub(crate) struct TotalPartCount(pub(crate) usize);
 
-impl PartInput {
+impl PartitionedInput {
     /// Build all partitions for this input for this worker.
     pub(crate) fn build_parts(
         &self,

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -54,21 +54,21 @@ impl Output {
     }
 }
 
-/// Represents a `bytewax.outputs.PartOutput` from Python.
+/// Represents a `bytewax.outputs.PartitionedOutput` from Python.
 #[derive(Clone)]
-pub(crate) struct PartOutput(Py<PyAny>);
+pub(crate) struct PartitionedOutput(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'source> FromPyObject<'source> for PartOutput {
+impl<'source> FromPyObject<'source> for PartitionedOutput {
     fn extract(ob: &'source PyAny) -> PyResult<Self> {
         let abc = ob
             .py()
             .import("bytewax.outputs")?
-            .getattr("PartOutput")?
+            .getattr("PartitionedOutput")?
             .extract()?;
         if !ob.is_instance(abc)? {
             Err(PyTypeError::new_err(
-                "partitioned output must derive from `bytewax.outputs.PartOutput`",
+                "partitioned output must derive from `bytewax.outputs.PartitionedOutput`",
             ))
         } else {
             Ok(Self(ob.into()))
@@ -76,13 +76,13 @@ impl<'source> FromPyObject<'source> for PartOutput {
     }
 }
 
-impl IntoPy<Py<PyAny>> for PartOutput {
+impl IntoPy<Py<PyAny>> for PartitionedOutput {
     fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
         self.0
     }
 }
 
-impl PartOutput {
+impl PartitionedOutput {
     /// Turn a partitioned output definition into the components the
     /// Timely operator needs to work.
     fn build(
@@ -179,7 +179,7 @@ impl PartAssigner {
     }
 }
 
-pub(crate) trait PartOutputOp<S>
+pub(crate) trait PartitionedOutputOp<S>
 where
     S: Scope,
 {
@@ -191,26 +191,26 @@ where
     ///
     /// Will manage automatically distributing partition sinks. All
     /// you have to do is pass in the definition.
-    fn part_output(
+    fn partitioned_output(
         &self,
         py: Python,
         step_id: StepId,
-        output: PartOutput,
+        output: PartitionedOutput,
         worker_index: WorkerIndex,
         worker_count: WorkerCount,
         resume_state: StepStateBytes,
     ) -> PyResult<(Stream<S, TdPyAny>, FlowChangeStream<S>)>;
 }
 
-impl<S> PartOutputOp<S> for Stream<S, TdPyAny>
+impl<S> PartitionedOutputOp<S> for Stream<S, TdPyAny>
 where
     S: Scope<Timestamp = u64>,
 {
-    fn part_output(
+    fn partitioned_output(
         &self,
         py: Python,
         step_id: StepId,
-        output: PartOutput,
+        output: PartitionedOutput,
         worker_index: WorkerIndex,
         worker_count: WorkerCount,
         resume_state: StepStateBytes,


### PR DESCRIPTION
Minor thing, but we tend to not abbreviate our other "config" types
and will match `DynamicOutput` (and the soon to be `DynamicInput`).

Also adds to changelog that we updated the output API.
