### PR TITLE
More deterministic windowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- *Breaking change* `{Sliding,Tumbling}Window.start_at` has been
+  renamed to `align_to` and both now require that argument. It's not
+  possible to recover windowing operators without it.
+
+- Fixes bugs with windows not closing properly.
+
 - Fixes an issue with SQLite-based recovery. Previously you'd always
   get an "interleaved executions" panic whenever you resumed a cluster
   after the first time.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "bincode",
  "chrono",
  "futures",
+ "num",
  "opentelemetry",
  "opentelemetry-jaeger",
  "opentelemetry-otlp",
@@ -970,12 +971,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ axum = { version = "0.5.17" }
 bincode = { version = "1.3.3" }
 chrono = { version = "0.4", features = [ "serde" ] }
 futures = { version = "0.3.21" }
+num = { version = "0.4.0" }
 pyo3 = { version = "0.17.2", features = ["macros", "chrono"] }
 scopeguard = { version = "1.1.0" }
 send_wrapper = { version = "0.6.0" }

--- a/docs/articles/getting-started/design-patterns.md
+++ b/docs/articles/getting-started/design-patterns.md
@@ -26,7 +26,7 @@ from bytewax.execution import run_main
 from bytewax.testing import TestingInput
 from bytewax.connectors.stdio import StdOutput
 from bytewax.window import SystemClockConfig, TumblingWindow
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 ```
 
 ### For flat map:
@@ -95,7 +95,9 @@ def add_to_list(l, items):
 
 
 clock = SystemClockConfig()
-window = TumblingWindow(length=timedelta(seconds=5))
+window = TumblingWindow(
+    length=timedelta(seconds=5), align_to=datetime(2023, 1, 1, tzinfo=timezone.utc)
+)
 
 inp = [("a", ["x"]), ("a", ["y"])]
 flow = Dataflow()
@@ -170,7 +172,9 @@ def collect_user_events(flow, clock, window):
 
 
 clock = SystemClockConfig()
-window = TumblingWindow(length=timedelta(seconds=5))
+window = TumblingWindow(
+    length=timedelta(seconds=5), align_to=datetime(2023, 1, 1, tzinfo=timezone.utc)
+)
 
 inp = [{"user_id": "1", "type": "login"}, {"user_id": "1", "type": "logout"}]
 flow = Dataflow()

--- a/docs/articles/getting-started/simple-example.md
+++ b/docs/articles/getting-started/simple-example.md
@@ -18,7 +18,7 @@ And a copy of the code in a file called `wordcount.py`.
 import operator
 import re
 
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 
 from bytewax.dataflow import Dataflow
 from bytewax.connectors.files import FileInput
@@ -44,7 +44,9 @@ def add(count1, count2):
 
 
 clock_config = SystemClockConfig()
-window_config = TumblingWindow(length=timedelta(seconds=5))
+window_config = TumblingWindow(
+    length=timedelta(seconds=5), align_to=datetime(2023, 1, 1, tzinfo=timezone.utc)
+)
 
 flow = Dataflow()
 flow.input("inp", FileInput("wordcount.txt"))
@@ -197,7 +199,9 @@ def add(count1, count2):
 
 # Configuration for time based windows.
 clock_config = SystemClockConfig()
-window_config = TumblingWindow(length=timedelta(seconds=5))
+window_config = TumblingWindow(
+    length=timedelta(seconds=5), align_to=datetime(2023, 1, 1, tzinfo=timezone.utc)
+)
 
 flow.map(initial_count)
 flow.reduce_window("sum", clock_config, window_config, add)

--- a/pytests/test_encoder.py
+++ b/pytests/test_encoder.py
@@ -123,8 +123,8 @@ def test_encoding_stateful_map():
 
 def test_encoding_fold_window():
     flow = Dataflow()
-    start_at = datetime(2005, 7, 14, 12, 30).replace(tzinfo=timezone.utc)
-    wc = TumblingWindow(start_at=start_at, length=timedelta(seconds=5))
+    align_to = datetime(2005, 7, 14, 12, 30).replace(tzinfo=timezone.utc)
+    wc = TumblingWindow(align_to=align_to, length=timedelta(seconds=5))
     cc = EventClockConfig(
         lambda x: datetime.fromisoformat(x["time"]),
         wait_for_system_duration=timedelta(seconds=10),
@@ -147,7 +147,7 @@ def test_encoding_fold_window():
                     "type": "FoldWindow",
                     "window_config": {
                         "length": "0:00:05",
-                        "start_at": "2005-07-14T12:30:00+00:00",
+                        "align_to": "2005-07-14T12:30:00+00:00",
                         "type": "TumblingWindow",
                     },
                 }

--- a/pytests/test_event_time.py
+++ b/pytests/test_event_time.py
@@ -7,23 +7,20 @@ from bytewax.window import EventClockConfig, TumblingWindow
 
 
 def test_event_time_processing():
-    start_at = datetime(2022, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    align_to = datetime(2022, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
     window_length = timedelta(seconds=5)
-
-    def s(val):
-        return timedelta(seconds=val)
 
     inp = [
         # This should be processed in the first window
-        {"type": "temp", "time": start_at, "value": 1},
+        {"type": "temp", "time": align_to, "value": 1},
         # This too should be processed in the first window
-        {"type": "temp", "time": start_at + s(2), "value": 2},
+        {"type": "temp", "time": align_to + timedelta(seconds=2), "value": 2},
         # This should be processed in the second window
-        {"type": "temp", "time": start_at + s(7), "value": 200},
+        {"type": "temp", "time": align_to + timedelta(seconds=7), "value": 200},
         # This should be processed in the third window
-        {"type": "temp", "time": start_at + s(12), "value": 17},
+        {"type": "temp", "time": align_to + timedelta(seconds=12), "value": 17},
         # This should be dropped, because the first window already closed.
-        {"type": "temp", "time": start_at + s(1), "value": 200},
+        {"type": "temp", "time": align_to + timedelta(seconds=1), "value": 200},
     ]
 
     def extract_sensor_type(event):
@@ -36,7 +33,7 @@ def test_event_time_processing():
     cc = EventClockConfig(
         lambda event: event["time"], wait_for_system_duration=timedelta(seconds=0)
     )
-    wc = TumblingWindow(start_at=start_at, length=window_length)
+    wc = TumblingWindow(align_to=align_to, length=window_length)
 
     flow = Dataflow()
     flow.input("inp", TestingInput(inp))
@@ -52,7 +49,4 @@ def test_event_time_processing():
         {"temp_avg": 200},
         {"temp_avg": 17},
     ]
-    assert len(out) == 3
-    assert expected[0] in out
-    assert expected[1] in out
-    assert expected[2] in out
+    assert out == expected

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -156,7 +156,7 @@ impl PartitionedInput {
         index: WorkerIndex,
         count: WorkerCount,
         probe: &ProbeHandle<u64>,
-        start_at: ResumeEpoch,
+        align_to: ResumeEpoch,
         resume_state: StepStateBytes,
     ) -> PyResult<(Stream<S, TdPyAny>, FlowChangeStream<S>)>
     where
@@ -176,8 +176,8 @@ impl PartitionedInput {
 
         let step_id_op = step_id.clone();
         op_builder.build(move |mut init_caps| {
-            let change_cap = init_caps.pop().map(|cap| cap.delayed(&start_at.0)).unwrap();
-            let output_cap = init_caps.pop().map(|cap| cap.delayed(&start_at.0)).unwrap();
+            let change_cap = init_caps.pop().map(|cap| cap.delayed(&align_to.0)).unwrap();
+            let output_cap = init_caps.pop().map(|cap| cap.delayed(&align_to.0)).unwrap();
 
             let mut caps = Some((output_cap, change_cap));
             let mut epoch_started = Instant::now();
@@ -384,7 +384,7 @@ impl DynamicInput {
         index: WorkerIndex,
         count: WorkerCount,
         probe: &ProbeHandle<u64>,
-        start_at: ResumeEpoch,
+        align_to: ResumeEpoch,
     ) -> PyResult<Stream<S, TdPyAny>>
     where
         S: Scope<Timestamp = u64>,
@@ -400,7 +400,7 @@ impl DynamicInput {
         let activator = scope.activator_for(&info.address[..]);
 
         op_builder.build(move |mut init_caps| {
-            let output_cap = init_caps.pop().map(|cap| cap.delayed(&start_at.0)).unwrap();
+            let output_cap = init_caps.pop().map(|cap| cap.delayed(&align_to.0)).unwrap();
 
             let mut cap_src = Some((output_cap, source));
             let mut epoch_started = Instant::now();

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -156,7 +156,7 @@ impl PartitionedInput {
         index: WorkerIndex,
         count: WorkerCount,
         probe: &ProbeHandle<u64>,
-        align_to: ResumeEpoch,
+        start_at: ResumeEpoch,
         resume_state: StepStateBytes,
     ) -> PyResult<(Stream<S, TdPyAny>, FlowChangeStream<S>)>
     where
@@ -176,8 +176,8 @@ impl PartitionedInput {
 
         let step_id_op = step_id.clone();
         op_builder.build(move |mut init_caps| {
-            let change_cap = init_caps.pop().map(|cap| cap.delayed(&align_to.0)).unwrap();
-            let output_cap = init_caps.pop().map(|cap| cap.delayed(&align_to.0)).unwrap();
+            let change_cap = init_caps.pop().map(|cap| cap.delayed(&start_at.0)).unwrap();
+            let output_cap = init_caps.pop().map(|cap| cap.delayed(&start_at.0)).unwrap();
 
             let mut caps = Some((output_cap, change_cap));
             let mut epoch_started = Instant::now();
@@ -384,7 +384,7 @@ impl DynamicInput {
         index: WorkerIndex,
         count: WorkerCount,
         probe: &ProbeHandle<u64>,
-        align_to: ResumeEpoch,
+        start_at: ResumeEpoch,
     ) -> PyResult<Stream<S, TdPyAny>>
     where
         S: Scope<Timestamp = u64>,
@@ -400,7 +400,7 @@ impl DynamicInput {
         let activator = scope.activator_for(&info.address[..]);
 
         op_builder.build(move |mut init_caps| {
-            let output_cap = init_caps.pop().map(|cap| cap.delayed(&align_to.0)).unwrap();
+            let output_cap = init_caps.pop().map(|cap| cap.delayed(&start_at.0)).unwrap();
 
             let mut cap_src = Some((output_cap, source));
             let mut epoch_started = Instant::now();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -153,15 +153,15 @@ macro_rules! add_pymethods {(
 
         /// Unpickle from a PyDict
         fn __setstate__(&mut self, state: &pyo3::PyAny) -> pyo3::PyResult<()> {
-            let dict: &pyo3::types::PyDict = state.downcast()?;
+            let _dict: &pyo3::types::PyDict = state.downcast()?;
             // This is like crate::common::pickle_extract
             // Duplicated here so that we can doctest this macro
             // without making `pickle_extract` public.
             $(
-            self.$arg = dict
+            self.$arg = _dict
                 .get_item(stringify!($arg))
                 .ok_or_else(|| pyo3::exceptions::PyValueError::new_err(
-                    format!("bad pickle contents for {}: {}", stringify!($arg), dict)
+                    format!("bad pickle contents for {}: {}", stringify!($arg), _dict)
                 ))?
                 .extract()?;
             )*

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -153,17 +153,16 @@ macro_rules! add_pymethods {(
 
         /// Unpickle from a PyDict
         fn __setstate__(&mut self, state: &pyo3::PyAny) -> pyo3::PyResult<()> {
-            // Prefixed with _ just in case there are no arguments,
-            // then would be unused.
-            let _dict: &pyo3::types::PyDict = state.downcast()?;
+            #[allow(unused_variables)]
+            let dict: &pyo3::types::PyDict = state.downcast()?;
             // This is like crate::common::pickle_extract
             // Duplicated here so that we can doctest this macro
             // without making `pickle_extract` public.
             $(
-            self.$arg = _dict
+            self.$arg = dict
                 .get_item(stringify!($arg))
                 .ok_or_else(|| pyo3::exceptions::PyValueError::new_err(
-                    format!("bad pickle contents for {}: {}", stringify!($arg), _dict)
+                    format!("bad pickle contents for {}: {}", stringify!($arg), dict)
                 ))?
                 .extract()?;
             )*

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -153,6 +153,8 @@ macro_rules! add_pymethods {(
 
         /// Unpickle from a PyDict
         fn __setstate__(&mut self, state: &pyo3::PyAny) -> pyo3::PyResult<()> {
+            // Prefixed with _ just in case there are no arguments,
+            // then would be unused.
             let _dict: &pyo3::types::PyDict = state.downcast()?;
             // This is like crate::common::pickle_extract
             // Duplicated here so that we can doctest this macro

--- a/src/window/clock/event_time_clock.rs
+++ b/src/window/clock/event_time_clock.rs
@@ -48,7 +48,7 @@ pub(crate) struct EventClockConfig {
 impl ClockBuilder<TdPyAny> for EventClockConfig {
     fn build(&self, py: Python) -> PyResult<Builder<TdPyAny>> {
         let dt_getter = self.dt_getter.clone_ref(py);
-        let wait_for_system_duration = self.wait_for_system_duration.clone();
+        let wait_for_system_duration = self.wait_for_system_duration;
 
         Ok(Box::new(move |resume_snapshot: Option<StateBytes>| {
             let max_event_time_system_time =
@@ -96,7 +96,7 @@ struct TestTimeSource {
 
 impl TimeSource for TestTimeSource {
     fn now(&self) -> DateTime<Utc> {
-        self.now.clone()
+        self.now
     }
 }
 

--- a/src/window/clock/event_time_clock.rs
+++ b/src/window/clock/event_time_clock.rs
@@ -123,7 +123,7 @@ where
             Poll::Pending => None,
         };
 
-        let (max_event_time_system_time, watermark) =
+        let res =
             // Re-calc the current watermark using the item that
             // previously produced the largest watermark, and also the
             // watermark from the current new item (if any).
@@ -148,8 +148,12 @@ where
             // Then find the max watermark. If the new item would
             // cause the watermark to go backwards, we'll filter it
             // out here.
-                .max_by_key(|(_, watermark)| *watermark)
-                .unzip();
+            .max_by_key(|(_, watermark)| *watermark);
+        // TODO: Could replace with [`Option::unzip`] when stable.
+        let (max_event_time_system_time, watermark) = match res {
+            Some((et_st, watermark)) => (Some(et_st), Some(watermark)),
+            None => (None, None),
+        };
 
         self.max_event_time_system_time = max_event_time_system_time;
         // If we've seen no items yet, the watermark is infinitely far

--- a/src/window/clock/event_time_clock.rs
+++ b/src/window/clock/event_time_clock.rs
@@ -1,6 +1,7 @@
 use std::task::Poll;
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::prelude::*;
+use chrono::Duration;
 use pyo3::prelude::*;
 
 use crate::{
@@ -11,63 +12,55 @@ use crate::{
 
 use super::*;
 
-/// Use datetimes from events as clock.
+/// Use a getter function to lookup the timestamp for each item.
+///
+/// The watermark is the largest item timestamp seen thus far, minus
+/// the waiting duration, plus the system time duration that has
+/// elapsed since that item was seen. This effectively means items
+/// will be correctly processed as long as they are not out of order
+/// more than the waiting duration in system time.
 ///
 /// If the dataflow has no more input, all windows are closed.
 ///
-/// The watermark is the system time since the last element
-/// plus the value of `late` plus the delay of the latest received element.
-/// It is updated every time an event with a newer datetime is processed.
-///
 /// Args:
 ///
-///   dt_getter: Python function to get a datetime from an event.
-///     The datetime returned must have tzinfo set to timezone.utc:
-///     > datetime(1970, 1, 1, tzinfo=timezone.utc)
+///   dt_getter: Python function to get a datetime from an event. The
+///     datetime returned must have tzinfo set to
+///     `timezone.utc`. E.g. `datetime(1970, 1, 1,
+///     tzinfo=timezone.utc)`
 ///
-///   wait_for_system_duration: How much (system) time to wait before considering an event late.
+///   wait_for_system_duration: How much system time to wait before
+///     considering an event late.
 ///
 /// Returns:
-///   Config object. Pass this as the `clock_config` parameter to your
-///   windowing operator.
+///
+///   Config object. Pass this as the `clock_config` parameter to
+///   your windowing operator.
 #[pyclass(module="bytewax.window", extends=ClockConfig)]
-#[pyo3(text_signature = "(dt_getter, wait_for_system_duration)")]
 #[derive(Clone)]
 pub(crate) struct EventClockConfig {
     #[pyo3(get)]
     pub(crate) dt_getter: TdPyCallable,
     #[pyo3(get)]
-    pub(crate) wait_for_system_duration: chrono::Duration,
+    pub(crate) wait_for_system_duration: Duration,
 }
 
 impl ClockBuilder<TdPyAny> for EventClockConfig {
-    fn build(&self, _py: Python) -> PyResult<Builder<TdPyAny>> {
-        let dt_getter = self.dt_getter.clone();
-        let wait_for_system_duration = self.wait_for_system_duration;
-        Ok(Box::new(move |resume_snapshot: Option<StateBytes>| {
-            // Deserialize data if a snapshot existed
-            let (latest_event_time, system_time_of_last_event, late_time, watermark) =
-                resume_snapshot.map(StateBytes::de).unwrap_or_else(|| {
-                    // Defaults values
-                    (
-                        None,
-                        // system_time_of_last_event
-                        Utc::now(),
-                        // late_time
-                        DateTime::<Utc>::MIN_UTC,
-                        // watermark
-                        DateTime::<Utc>::MIN_UTC,
-                    )
-                });
+    fn build(&self, py: Python) -> PyResult<Builder<TdPyAny>> {
+        let dt_getter = self.dt_getter.clone_ref(py);
+        let wait_for_system_duration = self.wait_for_system_duration.clone();
 
-            Box::new(EventClock::new(
-                dt_getter.clone(),
+        Ok(Box::new(move |resume_snapshot: Option<StateBytes>| {
+            let max_event_time_system_time =
+                resume_snapshot.map(StateBytes::de).unwrap_or_default();
+
+            let dt_getter = dt_getter.clone();
+            Box::new(EventClock {
+                source: SystemTimeSource {},
+                dt_getter,
                 wait_for_system_duration,
-                latest_event_time,
-                late_time,
-                system_time_of_last_event,
-                watermark,
-            ))
+                max_event_time_system_time,
+            })
         }))
     }
 }
@@ -82,59 +75,87 @@ add_pymethods!(
     }
 );
 
-pub(crate) struct EventClock {
-    dt_getter: TdPyCallable,
-    late: chrono::Duration,
-    // State
-    late_time: DateTime<Utc>,
-    latest_event_time: Option<DateTime<Utc>>,
-    system_time_of_last_event: DateTime<Utc>,
-    watermark: DateTime<Utc>,
+/// A little mock point for getting system time.
+trait TimeSource {
+    fn now(&self) -> DateTime<Utc>;
 }
 
-impl EventClock {
-    fn new(
-        dt_getter: TdPyCallable,
-        late: chrono::Duration,
-        latest_event_time: Option<DateTime<Utc>>,
-        late_time: DateTime<Utc>,
-        system_time_of_last_event: DateTime<Utc>,
-        watermark: DateTime<Utc>,
-    ) -> Self {
-        Self {
-            dt_getter,
-            late,
-            latest_event_time,
-            late_time,
-            system_time_of_last_event,
-            watermark,
-        }
+/// Get the actual system time.
+struct SystemTimeSource {}
+
+impl TimeSource for SystemTimeSource {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
     }
 }
 
-impl Clock<TdPyAny> for EventClock {
+/// Use a fixed system time.
+struct TestTimeSource {
+    now: DateTime<Utc>,
+}
+
+impl TimeSource for TestTimeSource {
+    fn now(&self) -> DateTime<Utc> {
+        self.now.clone()
+    }
+}
+
+pub(crate) struct EventClock<S> {
+    source: S,
+    dt_getter: TdPyCallable,
+    wait_for_system_duration: Duration,
+    /// The largest event time we've seen and the system time we saw
+    /// that event at.
+    max_event_time_system_time: Option<(DateTime<Utc>, DateTime<Utc>)>,
+}
+
+impl<S> Clock<TdPyAny> for EventClock<S>
+where
+    S: TimeSource,
+{
     fn watermark(&mut self, next_value: &Poll<Option<TdPyAny>>) -> DateTime<Utc> {
-        let now = Utc::now();
-        match next_value {
-            Poll::Ready(Some(event)) => {
-                let event_late_time = self.time_for(event) - self.late;
-                if event_late_time > self.late_time {
-                    self.late_time = event_late_time;
-                    self.system_time_of_last_event = now;
-                }
-            }
-            Poll::Ready(None) => {
-                self.late_time = DateTime::<Utc>::MAX_UTC;
-                self.system_time_of_last_event = now;
-            }
-            Poll::Pending => {}
-        }
-        let system_duration_since_last_event =
-            now.signed_duration_since(self.system_time_of_last_event);
-        // This is the watermark
-        self.late_time
-            .checked_add_signed(system_duration_since_last_event)
-            .unwrap_or(DateTime::<Utc>::MAX_UTC)
+        let now = self.source.now();
+
+        // Incoming event time and system time it was ingested.
+        let next_event_time_system_time = match next_value {
+            Poll::Ready(Some(event)) => Some((self.time_for(event), now)),
+            Poll::Ready(None) => Some((DateTime::<Utc>::MAX_UTC, now)),
+            Poll::Pending => None,
+        };
+
+        let (max_event_time_system_time, watermark) =
+            // Re-calc the current watermark using the item that
+            // previously produced the largest watermark, and also the
+            // watermark from the current new item (if any).
+            [self.max_event_time_system_time, next_event_time_system_time]
+                .into_iter()
+                .flatten()
+                .map(|(event_time, event_system_time)| {
+                    let system_duration_since_max_event =
+                        now.signed_duration_since(event_system_time);
+                    // If we're at the end of input, force watermark
+                    // to end also. Otherwise, subtract the late
+                    // "waiting duration" and progress it forward as
+                    // system time flows on.
+                    let watermark = if event_time == DateTime::<Utc>::MAX_UTC {
+                        DateTime::<Utc>::MAX_UTC
+                    } else {
+                        event_time - self.wait_for_system_duration + system_duration_since_max_event
+                    };
+
+                    ((event_time, event_system_time), watermark)
+                })
+            // Then find the max watermark. If the new item would
+            // cause the watermark to go backwards, we'll filter it
+            // out here.
+                .max_by_key(|(_, watermark)| *watermark)
+                .unzip();
+
+        self.max_event_time_system_time = max_event_time_system_time;
+        // If we've seen no items yet, the watermark is infinitely far
+        // in the past since we have no idea what time the data will
+        // start at.
+        watermark.unwrap_or(DateTime::<Utc>::MIN_UTC)
     }
 
     fn time_for(&mut self, event: &TdPyAny) -> DateTime<Utc> {
@@ -150,12 +171,7 @@ impl Clock<TdPyAny> for EventClock {
     }
 
     fn snapshot(&self) -> StateBytes {
-        StateBytes::ser(&(
-            self.latest_event_time,
-            self.system_time_of_last_event,
-            self.late_time,
-            self.watermark,
-        ))
+        StateBytes::ser(&self.max_event_time_system_time)
     }
 }
 
@@ -164,44 +180,113 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_watermark() {
+        pyo3::prepare_freethreaded_python();
+
+        // We're going to pass in datetimes as the items themselves.
+        let identity = Python::with_gil(|py| {
+            py.eval("lambda x: x", None, None)
+                .unwrap()
+                .extract()
+                .unwrap()
+        });
+
+        let mut clock = EventClock {
+            source: TestTimeSource {
+                now: Utc.ymd(2023, 5, 10).and_hms(9, 0, 0),
+            },
+            dt_getter: identity,
+            wait_for_system_duration: Duration::seconds(10),
+            max_event_time_system_time: None,
+        };
+
+        let found = clock.watermark(&Poll::Pending);
+        assert_eq!(
+            found,
+            DateTime::<Utc>::MIN_UTC,
+            "watermark should start at the beginning of time before any items"
+        );
+
+        let item1 = Python::with_gil(|py| Utc.ymd(2023, 3, 16).and_hms(9, 0, 0).into_py(py).into());
+        let found = clock.watermark(&Poll::Ready(Some(item1)));
+        assert_eq!(
+            found,
+            Utc.ymd(2023, 3, 16).and_hms(8, 59, 50),
+            "watermark should be item time minus late time"
+        );
+
+        clock.source.now = Utc.ymd(2023, 5, 10).and_hms(9, 0, 2);
+        let found = clock.watermark(&Poll::Pending);
+        assert_eq!(
+            found,
+            Utc.ymd(2023, 3, 16).and_hms(8, 59, 52),
+            "watermark should forward by system time between awakenings if no new items"
+        );
+
+        clock.source.now = Utc.ymd(2023, 5, 10).and_hms(9, 0, 4);
+        let item2 = Python::with_gil(|py| Utc.ymd(2023, 3, 16).and_hms(9, 1, 0).into_py(py).into());
+        let found = clock.watermark(&Poll::Ready(Some(item2)));
+        assert_eq!(
+            found,
+            Utc.ymd(2023, 3, 16).and_hms(9, 0, 50),
+            "watermark should advance to item time minus late time if new item"
+        );
+
+        clock.source.now = Utc.ymd(2023, 5, 10).and_hms(9, 0, 6);
+        let item3 = Python::with_gil(|py| Utc.ymd(2023, 3, 16).and_hms(9, 1, 1).into_py(py).into());
+        let found = clock.watermark(&Poll::Ready(Some(item3)));
+        assert_eq!(
+            found,
+            Utc.ymd(2023, 3, 16).and_hms(9, 0, 52),
+            "watermark should not go backwards due to slow item"
+        );
+
+        clock.source.now = Utc.ymd(2023, 5, 10).and_hms(9, 0, 8);
+        let found = clock.watermark(&Poll::Ready(None));
+        assert_eq!(
+            found,
+            DateTime::<Utc>::MAX_UTC,
+            "watermark should advance to the end of time when input ends"
+        );
+
+        clock.source.now = Utc.ymd(2023, 5, 10).and_hms(9, 0, 10);
+        let found = clock.watermark(&Poll::Ready(None));
+        assert_eq!(
+            found,
+            DateTime::<Utc>::MAX_UTC,
+            "watermark should saturate to the end of time after input ends"
+        );
+    }
+
+    #[test]
     fn test_event_time_clock_serialization() {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|py| {
-            let dt_getter: TdPyCallable = TdPyCallable::pickle_new(py);
-            let dt_getter_clone: TdPyCallable = dt_getter.clone_ref(py);
-            let late = chrono::Duration::zero();
-            let latest_event_time = Some(Utc::now());
-            let late_time = Utc::now();
-            let system_time_of_last_event = Utc::now();
-            let watermark = Utc::now();
-            let mut event_clock = EventClock::new(
-                dt_getter,
-                late,
-                latest_event_time,
-                late_time,
-                system_time_of_last_event,
-                watermark,
-            );
-            // Call the `watermark` function with None event, so that the watermark
-            // becomes MAX_UTC
-            event_clock.watermark(&Poll::Ready(None));
+            let config = EventClockConfig {
+                // This will never be called in this test so can be
+                // junk.
+                dt_getter: TdPyCallable::pickle_new(py),
+                wait_for_system_duration: Duration::zero(),
+            };
 
-            // Take a snapshot
+            let mut event_clock = config.build(py).unwrap()(None);
+
+            let found = event_clock.watermark(&Poll::Ready(None));
+            assert_eq!(
+                found,
+                DateTime::<Utc>::MAX_UTC,
+                "watermark did not advance to the end of time when input ends"
+            );
+
             let snapshot = event_clock.snapshot();
 
-            // Rebuild an EventClock from the snapshot
-            let config = EventClockConfig {
-                dt_getter: dt_getter_clone,
-                wait_for_system_duration: late,
-            };
-            let mut deserialized = config.build(py).unwrap()(Some(snapshot));
+            let mut event_clock = config.build(py).unwrap()(Some(snapshot));
 
-            // If everything is (de)serialized correctly, the watermark should be exactly
-            // MAX_UTC. If something didn't work with (de)serialization, it would be slightly
-            // after MIN_UTC.
+            let found = event_clock.watermark(&Poll::Pending);
             assert_eq!(
-                deserialized.watermark(&Poll::Pending),
-                DateTime::<Utc>::MAX_UTC
+                found,
+                DateTime::<Utc>::MAX_UTC,
+                "clock built from snapshot did not restore state"
             );
         });
     }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -30,7 +30,7 @@
 //! how to create a [`SystemClock`].
 use crate::operators::stateful_unary::*;
 use crate::pyo3_extensions::PyConfigClass;
-use chrono::{DateTime, Utc};
+use chrono::prelude::*;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -157,7 +157,7 @@ pub(crate) trait Clock<V> {
 pub(crate) struct WindowKey(i64);
 
 /// An error that can occur when windowing an item.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum InsertError {
     /// The inserted item was late for a window.
     Late(WindowKey),
@@ -314,7 +314,7 @@ where
 impl<V, R, I, L, LB> StatefulLogic<V, Result<R, WindowError<V>>, Vec<Result<R, WindowError<V>>>>
     for WindowStatefulLogic<V, R, I, L, LB>
 where
-    V: Data,
+    V: Data + Debug,
     I: IntoIterator<Item = R>,
     L: WindowLogic<V, R, I>,
     LB: Fn(Option<StateBytes>) -> L,
@@ -323,17 +323,21 @@ where
         let mut output = Vec::new();
 
         let watermark = self.clock.watermark(&next_value);
+        tracing::trace!("Watermark at {watermark:?}");
 
         if let Poll::Ready(Some(value)) = next_value {
             let item_time = self.clock.time_for(&value);
+            tracing::trace!("{value:?} has time {item_time:?}");
 
             for window_result in self.windower.insert(&watermark, &item_time) {
                 let value = value.clone();
                 match window_result {
-                    Err(InsertError::Late(_window_key)) => {
+                    Err(InsertError::Late(window_key)) => {
+                        tracing::trace!("{value:?} late for {window_key:?}");
                         output.push(Err(WindowError::Late(value)));
                     }
                     Ok(window_key) => {
+                        tracing::trace!("{value:?} in {window_key:?}");
                         let logic = self
                             .current_state
                             .entry(window_key)

--- a/src/window/sliding_window.rs
+++ b/src/window/sliding_window.rs
@@ -191,7 +191,7 @@ impl Windower for SlidingWindower {
 }
 
 #[test]
-fn test_intersect_overlap_offset_divisible_by_length_bulk() {
+fn test_intersect_overlap_offset_divisible_by_length_bulk_positive() {
     let windower = SlidingWindower {
         length: Duration::seconds(10),
         offset: Duration::seconds(5),
@@ -224,14 +224,38 @@ fn test_intersect_overlap_offset_divisible_by_length_bulk_negative() {
         close_times: HashMap::new(),
     };
 
-    //   9:00:01
-    //   I
-    // ----1)
-    // [0--------)
-    //      [1--------)
-    //           [2--------)
-    //                [3--------)
-    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 1);
+    //             8:59:57
+    //             I
+    // [--------3)
+    //      [--------2)
+    //           [--------1)
+    //                [0--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(8, 59, 57);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![
+            (WindowKey(-2), Utc.ymd(2023, 3, 16).and_hms(9, 0, 0)),
+            (WindowKey(-1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 5)),
+        ],
+    );
+}
+
+#[test]
+fn test_intersect_overlap_offset_divisible_by_length_bulk_zero_negative() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(5),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //              9:00:03
+    //              I
+    // [--------2)
+    //      [--------1)
+    //           [0--------)
+    //                [1--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 3);
     assert_eq!(
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![
@@ -242,7 +266,7 @@ fn test_intersect_overlap_offset_divisible_by_length_bulk_negative() {
 }
 
 #[test]
-fn test_intersect_overlap_offset_divisible_by_length_edge() {
+fn test_intersect_overlap_offset_divisible_by_length_bulk_zero_positive() {
     let windower = SlidingWindower {
         length: Duration::seconds(10),
         offset: Duration::seconds(5),
@@ -250,17 +274,44 @@ fn test_intersect_overlap_offset_divisible_by_length_edge() {
         close_times: HashMap::new(),
     };
 
-    //           9:00:10
-    //           I
-    // [0--------)
-    //      [1--------)
-    //           [2--------)
-    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 10);
+    //             9:00:07
+    //             I
+    // [--------1)
+    //      [0--------)
+    //           [1--------)
+    //                [2--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 7);
     assert_eq!(
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![
+            (WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10)),
             (WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 15)),
+        ],
+    );
+}
+
+#[test]
+fn test_intersect_overlap_offset_divisible_by_length_edge_positive() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(5),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                9:00:15
+    //                I
+    // [0--------)
+    //      [1--------)
+    //           [2--------)
+    //                [3--------)
+    //                     [4--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 15);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![
             (WindowKey(2), Utc.ymd(2023, 3, 16).and_hms(9, 0, 20)),
+            (WindowKey(3), Utc.ymd(2023, 3, 16).and_hms(9, 0, 25)),
         ]
     );
 }
@@ -291,7 +342,7 @@ fn test_intersect_overlap_offset_divisible_by_length_edge_negative() {
 }
 
 #[test]
-fn test_intersect_overlap_offset_divisible_by_length_edge_zero() {
+fn test_intersect_overlap_offset_divisible_by_length_edge_start_zero() {
     let windower = SlidingWindower {
         length: Duration::seconds(10),
         offset: Duration::seconds(5),
@@ -299,10 +350,12 @@ fn test_intersect_overlap_offset_divisible_by_length_edge_zero() {
         close_times: HashMap::new(),
     };
 
-    // 9:00:00
-    // I
-    // ----1)
-    // [0--------)
+    //           9:00:00
+    //           I
+    // [--------2)
+    //      [--------1)
+    //           [0--------)
+    //                [1--------)
     let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 0);
     assert_eq!(
         windower.intersects(&item_time).collect::<Vec<_>>(),
@@ -314,7 +367,32 @@ fn test_intersect_overlap_offset_divisible_by_length_edge_zero() {
 }
 
 #[test]
-fn test_intersect_overlap_offset_indivisible_by_length_bulk() {
+fn test_intersect_overlap_offset_divisible_by_length_edge_end_zero() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(5),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //           9:00:10
+    //           I
+    // [0--------)
+    //      [1--------)
+    //           [2--------)
+    //                [3--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 10);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![
+            (WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 15)),
+            (WindowKey(2), Utc.ymd(2023, 3, 16).and_hms(9, 0, 20)),
+        ]
+    );
+}
+
+#[test]
+fn test_intersect_overlap_offset_indivisible_by_length_bulk_positive() {
     let windower = SlidingWindower {
         length: Duration::seconds(10),
         offset: Duration::seconds(3),
@@ -349,29 +427,53 @@ fn test_intersect_overlap_offset_indivisible_by_length_bulk_negative() {
         close_times: HashMap::new(),
     };
 
-    //   9:00:02
-    //   I
-    // 3)
-    // ---2)
-    // ------1)
-    // [0--------)
-    //    [1--------)
-    //       [2--------)
-    //          [3--------)
-    //             [4--------)
-    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 2);
+    //            8:59:59
+    //            I
+    // [--------4)
+    //    [--------3)
+    //       [--------2)
+    //          [--------1)
+    //             [0--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(8, 59, 59);
     assert_eq!(
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![
+            (WindowKey(-3), Utc.ymd(2023, 3, 16).and_hms(9, 0, 1)),
             (WindowKey(-2), Utc.ymd(2023, 3, 16).and_hms(9, 0, 4)),
             (WindowKey(-1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 7)),
-            (WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10)),
         ],
     );
 }
 
 #[test]
-fn test_intersect_overlap_offset_indivisible_by_length_edge_start() {
+fn test_intersect_overlap_offset_indivisible_by_length_bulk_zero() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(3),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //            9:00:05
+    //            I
+    // [--------2)
+    //    [--------1)
+    //       [0--------)
+    //          [1--------)
+    //             [2--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 5);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![
+            (WindowKey(-1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 7)),
+            (WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10)),
+            (WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 13)),
+        ],
+    );
+}
+
+#[test]
+fn test_intersect_overlap_offset_indivisible_by_length_edge_start_positive() {
     let windower = SlidingWindower {
         length: Duration::seconds(10),
         offset: Duration::seconds(7),
@@ -427,10 +529,11 @@ fn test_intersect_overlap_offset_indivisible_by_length_edge_start_zero() {
         close_times: HashMap::new(),
     };
 
-    // 9:00:00
-    // I
-    // --1)
-    // [0--------)
+    //        9:00:00
+    //        I
+    // [--------1)
+    //        [0--------)
+    //               [1--------)
     let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 0);
     assert_eq!(
         windower.intersects(&item_time).collect::<Vec<_>>(),
@@ -442,7 +545,7 @@ fn test_intersect_overlap_offset_indivisible_by_length_edge_start_zero() {
 }
 
 #[test]
-fn test_intersect_overlap_offset_indivisible_by_length_edge_end() {
+fn test_intersect_overlap_offset_indivisible_by_length_edge_end_positive() {
     let windower = SlidingWindower {
         length: Duration::seconds(10),
         offset: Duration::seconds(7),
@@ -484,7 +587,7 @@ fn test_intersect_overlap_offset_indivisible_by_length_edge_end_negative() {
 }
 
 #[test]
-fn test_intersect_overlap_offset_indivisible_by_length_edge_zero() {
+fn test_intersect_overlap_offset_indivisible_by_length_edge_end_zero() {
     let windower = SlidingWindower {
         length: Duration::seconds(10),
         offset: Duration::seconds(7),
@@ -492,11 +595,11 @@ fn test_intersect_overlap_offset_indivisible_by_length_edge_zero() {
         close_times: HashMap::new(),
     };
 
-    //           9:00:10
-    //           I
-    // [0--------)
-    //        [1--------)
-    //               [2--------)
+    //                  9:00:10
+    //                  I
+    // [--------1)
+    //        [0--------)
+    //               [1--------)
     let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 10);
     assert_eq!(
         windower.intersects(&item_time).collect::<Vec<_>>(),
@@ -505,7 +608,7 @@ fn test_intersect_overlap_offset_indivisible_by_length_edge_zero() {
 }
 
 #[test]
-fn test_intersect_tumble_edge() {
+fn test_intersect_tumble_bulk_positive() {
     let windower = SlidingWindower {
         length: Duration::seconds(10),
         offset: Duration::seconds(10),
@@ -513,10 +616,140 @@ fn test_intersect_tumble_edge() {
         close_times: HashMap::new(),
     };
 
-    //           9:00:10
-    //           I
+    //                9:00:15
+    //                I
     // [0--------)
     //           [1--------)
+    //                     [2--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 15);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 20))],
+    );
+}
+
+#[test]
+fn test_intersect_tumble_bulk_negative() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(10),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                8:59:55
+    //                I
+    // [--------2)
+    //           [--------1)
+    //                     [0--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(8, 59, 55);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(-1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 0))],
+    );
+}
+
+#[test]
+fn test_intersect_tumble_bulk_zero() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(10),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                9:00:05
+    //                I
+    // [--------1)
+    //           [0--------)
+    //                     [1--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 5);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10))],
+    );
+}
+
+#[test]
+fn test_intersect_tumble_edge_positive() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(10),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                     9:00:20
+    //                     I
+    // [0--------)
+    //           [1--------)
+    //                     [2--------)
+    //                               [3--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 20);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(2), Utc.ymd(2023, 3, 16).and_hms(9, 0, 30))],
+    );
+}
+
+#[test]
+fn test_intersect_tumble_edge_negative() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(10),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                     8:59:50
+    //                     I
+    // [--------3)
+    //           [--------2)
+    //                     [--------1)
+    //                               [0--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(8, 59, 50);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(-1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 0))],
+    );
+}
+
+#[test]
+fn test_intersect_tumble_edge_zero_start() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(10),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //           9:00:00
+    //           I
+    // [--------1)
+    //           [0--------)
+    //                     [1--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 0);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10))],
+    );
+}
+
+#[test]
+fn test_intersect_tumble_edge_zero_end() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(10),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                     9:00:10
+    //                     I
+    // [--------1)
+    //           [0--------)
+    //                     [1--------)
+    //                               [2--------)
     let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 10);
     assert_eq!(
         windower.intersects(&item_time).collect::<Vec<_>>(),
@@ -525,19 +758,62 @@ fn test_intersect_tumble_edge() {
 }
 
 #[test]
-fn test_intersect_tumble_bulk() {
+fn test_intersect_gap_bulk_positive() {
     let windower = SlidingWindower {
         length: Duration::seconds(10),
-        offset: Duration::seconds(10),
+        offset: Duration::seconds(13),
         align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
         close_times: HashMap::new(),
     };
 
-    //         9:00:08
-    //         I
+    //                   9:00:18
+    //                   I
     // [0--------)
-    //           [1--------)
-    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 8);
+    //              [1--------)
+    //                           [2--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 18);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 23))],
+    );
+}
+
+#[test]
+fn test_intersect_gap_bulk_negative() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(13),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                   8:59:48
+    //                   I
+    // [--------2)
+    //              [--------1)
+    //                           [0--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(8, 59, 48);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(-1), Utc.ymd(2023, 3, 16).and_hms(8, 59, 57))],
+    );
+}
+
+#[test]
+fn test_intersect_gap_bulk_zero() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(13),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                   9:00:03
+    //                   I
+    // [--------1)
+    //              [0--------)
+    //                           [1--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 3);
     assert_eq!(
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10))],
@@ -545,76 +821,153 @@ fn test_intersect_tumble_bulk() {
 }
 
 #[test]
-fn test_intersect_gap_edge_start() {
+fn test_intersect_gap_gap_positive() {
     let windower = SlidingWindower {
         length: Duration::seconds(10),
-        offset: Duration::seconds(15),
+        offset: Duration::seconds(13),
         align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
         close_times: HashMap::new(),
     };
 
-    //                9:00:15
-    //                I
+    //             9:00:20
+    //             I
     // [0--------)
-    //                [1--------)
-    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 15);
-    assert_eq!(
-        windower.intersects(&item_time).collect::<Vec<_>>(),
-        vec![(WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 25))],
-    );
-}
-
-#[test]
-fn test_intersect_gap_bulk_inside() {
-    let windower = SlidingWindower {
-        length: Duration::seconds(10),
-        offset: Duration::seconds(15),
-        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
-        close_times: HashMap::new(),
-    };
-
-    //         9:00:08
-    //         I
-    // [0--------)
-    //                [1--------)
-    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 8);
-    assert_eq!(
-        windower.intersects(&item_time).collect::<Vec<_>>(),
-        vec![(WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10))],
-    );
-}
-
-#[test]
-fn test_intersect_gap_edge_end() {
-    let windower = SlidingWindower {
-        length: Duration::seconds(10),
-        offset: Duration::seconds(15),
-        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
-        close_times: HashMap::new(),
-    };
-
-    //           9:00:10
-    //           I
-    // [0--------)
-    //                [1--------)
-    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 10);
+    //              [1--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 12);
     assert_eq!(windower.intersects(&item_time).collect::<Vec<_>>(), vec![]);
 }
 
 #[test]
-fn test_intersect_gap_bulk_outside() {
+fn test_intersect_gap_gap_negative() {
     let windower = SlidingWindower {
         length: Duration::seconds(10),
-        offset: Duration::seconds(15),
+        offset: Duration::seconds(13),
         align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
         close_times: HashMap::new(),
     };
 
-    //             9:00:12
+    //             8:59:59
     //             I
+    // [--------1)
+    //              [0--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(8, 59, 59);
+    assert_eq!(windower.intersects(&item_time).collect::<Vec<_>>(), vec![]);
+}
+
+#[test]
+fn test_intersect_gap_edge_start_positive() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(13),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //              9:00:13
+    //              I
     // [0--------)
-    //                [1--------)
-    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 12);
+    //              [1--------)
+    //                           [2--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 13);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 23))],
+    );
+}
+
+#[test]
+fn test_intersect_gap_edge_start_negative() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(13),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //              8:59:47
+    //              I
+    // [--------2)
+    //              [--------1)
+    //                           [0--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(8, 59, 47);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(-1), Utc.ymd(2023, 3, 16).and_hms(8, 59, 57))],
+    );
+}
+
+#[test]
+fn test_intersect_gap_edge_start_zero() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(13),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //              9:00:00
+    //              I
+    // [--------1)
+    //              [0--------)
+    //                           [1--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 0);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10))],
+    );
+}
+
+#[test]
+fn test_intersect_gap_edge_end_positive() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(13),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                        9:00:23
+    //                        I
+    // [0--------)
+    //              [1--------)
+    //                           [2--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 23);
+    assert_eq!(windower.intersects(&item_time).collect::<Vec<_>>(), vec![]);
+}
+
+#[test]
+fn test_intersect_gap_edge_end_negative() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(13),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                        8:59:57
+    //                        I
+    // [--------2)
+    //              [--------1)
+    //                           [0--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(8, 59, 57);
+    assert_eq!(windower.intersects(&item_time).collect::<Vec<_>>(), vec![]);
+}
+
+#[test]
+fn test_intersect_gap_edge_end_zero() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(13),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                        9:00:10
+    //                        I
+    // [--------1)
+    //              [0--------)
+    //                           [1--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 10);
     assert_eq!(windower.intersects(&item_time).collect::<Vec<_>>(), vec![]);
 }
 

--- a/src/window/sliding_window.rs
+++ b/src/window/sliding_window.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::prelude::*;
+use chrono::Duration;
 use pyo3::prelude::*;
 
 use crate::{add_pymethods, window::WindowConfig};
@@ -8,19 +9,29 @@ use crate::{add_pymethods, window::WindowConfig};
 use super::{Builder, InsertError, StateBytes, WindowBuilder, WindowKey, Windower};
 
 /// Sliding windows of fixed duration.
-/// If offset == length, you get tumbling windows.
-/// If offset < length, windows overlap.
-/// If offset > length, there will be holes between windows.
+///
+/// If offset == length, windows cover all time but do not
+/// overlap. Each item will fall in exactly one window. The
+/// `TumblingWindow` config will do this for you.
+///
+/// If offset < length, windows overlap. Each item will fall in
+/// multiple windows.
+///
+/// If offset > length, there will be gaps between windows. Each item
+/// can fall in up to one window, but might fall into none.
+///
+/// Window start times are inclusive, but end times are exclusive.
 ///
 /// Args:
 ///
-///   length (datetime.timedelta): Length of window.
+///   length (datetime.timedelta): Length of windows.
 ///
-///   offset (datetime.timedelta): Offset between windows.
+///   offset (datetime.timedelta): Duration between start times of
+///     adjacent windows.
 ///
-///   start_at (datetime.datetime): Instant of the first window. You
-///       can use this to align all windows to an hour,
-///       e.g. Defaults to system time of dataflow start.
+///   align_to (datetime.datetime): Align windows so this instant
+///     starts a window. You can use this to align all windows to hour
+///     boundaries, e.g.
 ///
 /// Returns:
 ///
@@ -34,17 +45,17 @@ pub(crate) struct SlidingWindow {
     #[pyo3(get)]
     pub(crate) offset: Duration,
     #[pyo3(get)]
-    pub(crate) start_at: Option<DateTime<Utc>>,
+    pub(crate) align_to: DateTime<Utc>,
 }
 
 add_pymethods!(
     SlidingWindow,
     parent: WindowConfig,
-    py_args: (length, offset, start_at = "None"),
+    py_args: (length, offset, align_to),
     args {
         length: Duration => Duration::zero(),
         offset: Duration => Duration::zero(),
-        start_at: Option<DateTime<Utc>> => None
+        align_to: DateTime<Utc> => DateTime::<Utc>::MIN_UTC
     }
 );
 
@@ -53,7 +64,7 @@ impl WindowBuilder for SlidingWindow {
         Ok(Box::new(SlidingWindower::builder(
             self.length,
             self.offset,
-            self.start_at.unwrap_or_else(Utc::now),
+            self.align_to,
         )))
     }
 }
@@ -61,7 +72,7 @@ impl WindowBuilder for SlidingWindow {
 pub(crate) struct SlidingWindower {
     length: Duration,
     offset: Duration,
-    start_at: DateTime<Utc>,
+    align_to: DateTime<Utc>,
     close_times: HashMap<WindowKey, DateTime<Utc>>,
 }
 
@@ -69,7 +80,7 @@ impl SlidingWindower {
     pub(crate) fn builder(
         length: Duration,
         offset: Duration,
-        start_at: DateTime<Utc>,
+        align_to: DateTime<Utc>,
     ) -> impl Fn(Option<StateBytes>) -> Box<dyn Windower> {
         move |resume_snapshot| {
             let close_times = resume_snapshot
@@ -78,22 +89,57 @@ impl SlidingWindower {
             Box::new(Self {
                 length,
                 offset,
-                start_at,
+                align_to,
                 close_times,
             })
         }
     }
 
-    fn add_close_time(&mut self, key: WindowKey, window_end: DateTime<Utc>) {
+    /// Yields all windows and their close times that intersect a
+    /// given time. Close time is exclusive.
+    fn intersects(&self, time: &DateTime<Utc>) -> impl Iterator<Item = (WindowKey, DateTime<Utc>)> {
+        let since_close_of_first_window = *time - (self.align_to + self.length);
+        let first_window_idx = since_close_of_first_window
+            .num_milliseconds()
+            // We always want to round towards -inf. TODO:
+            // i64::div_floor will more obviously do this.
+            .div_euclid(self.offset.num_milliseconds())
+            + 1;
+
+        // Round up to 1 in case we have offset > length. Always try
+        // at least one window. We might filter it out, though.
+        let num_windows = std::cmp::max(
+            self.length.num_milliseconds() / self.offset.num_milliseconds(),
+            1,
+        );
+
+        // Clone to not retain ownership of self in the closure.
+        let time = time.clone();
+        let align_to = self.align_to.clone();
+        let offset = self.offset.clone();
+        let length = self.length.clone();
+        (0..num_windows).flat_map(move |i| {
+            let window_idx = first_window_idx + i;
+            let window_open = align_to + offset * window_idx as i32;
+            if time < window_open {
+                None
+            } else {
+                let window_close = window_open + length;
+                Some((WindowKey(window_idx), window_close))
+            }
+        })
+    }
+
+    fn insert_window(&mut self, key: WindowKey, close_time: DateTime<Utc>) {
         self.close_times
             .entry(key)
             .and_modify(|existing| {
                 assert!(
-                    existing == &window_end,
+                    existing == &close_time,
                     "SlidingWindower is not generating consistent boundaries"
                 )
             })
-            .or_insert(window_end);
+            .or_insert(close_time);
     }
 }
 
@@ -103,32 +149,14 @@ impl Windower for SlidingWindower {
         watermark: &DateTime<Utc>,
         item_time: &DateTime<Utc>,
     ) -> Vec<Result<WindowKey, InsertError>> {
-        let since_start_at = (*item_time - self.start_at).num_milliseconds();
-        let since_watermark = (*watermark - self.start_at).num_milliseconds();
-        let offset = self.offset.num_milliseconds();
-
-        let windows_count = since_start_at / offset + 1;
-        let first_window = (since_watermark / offset - 1).max(0);
-
-        (first_window..windows_count)
-            .map(|i| {
-                // First generate the WindowKey and calculate
-                // the window_end time
-                let key = WindowKey(i);
-                let window_start = self.start_at + Duration::milliseconds(i * offset);
-                let window_end = window_start + self.length;
-                // We only want to add items that happened between
-                // start and end of the window.
-                // If the watermark is past the end of the window,
-                // any item is late for this window.
-                if *item_time >= window_start && *item_time < window_end && *watermark <= window_end
-                {
-                    self.add_close_time(key, window_end);
-                    Ok(key)
-                } else {
-                    // We send `Late` even if the item came too early,
-                    // maybe we should differentate
+        self.intersects(item_time)
+            .map(|(key, close_time)| {
+                tracing::trace!("Intersects with {key:?} closing at {close_time:?}");
+                if close_time < *watermark {
                     Err(InsertError::Late(key))
+                } else {
+                    self.insert_window(key, close_time);
+                    Ok(key)
                 }
             })
             .collect()
@@ -157,10 +185,336 @@ impl Windower for SlidingWindower {
     }
 
     fn next_close(&self) -> Option<DateTime<Utc>> {
-        self.close_times.values().cloned().min()
+        self.close_times.values().min().cloned()
     }
 
     fn snapshot(&self) -> StateBytes {
         StateBytes::ser::<HashMap<WindowKey, DateTime<Utc>>>(&self.close_times)
     }
+}
+
+#[test]
+fn test_intersect_overlap_bulk_offset_divisible_by_length() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(5),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //              9:00:13
+    //              I
+    // [0--------)
+    //      [1--------)
+    //           [2--------)
+    //                [3--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 13);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![
+            (WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 15)),
+            (WindowKey(2), Utc.ymd(2023, 3, 16).and_hms(9, 0, 20)),
+        ],
+    );
+}
+
+#[test]
+fn test_intersect_overlap_negative_offset_divisible_by_length() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(5),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //   9:00:01
+    //   I
+    // ----1)
+    // [0--------)
+    //      [1--------)
+    //           [2--------)
+    //                [3--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 1);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![
+            (WindowKey(-1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 5)),
+            (WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10)),
+        ],
+    );
+}
+
+#[test]
+fn test_intersect_overlap_bulk_offset_indivisible_by_length() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(3),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //            9:00:11
+    //            I
+    // [0--------)
+    //    [1--------)
+    //       [2--------)
+    //          [3--------)
+    //             [4--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 11);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![
+            (WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 13)),
+            (WindowKey(2), Utc.ymd(2023, 3, 16).and_hms(9, 0, 16)),
+            (WindowKey(3), Utc.ymd(2023, 3, 16).and_hms(9, 0, 19)),
+        ],
+    );
+}
+
+#[test]
+fn test_intersect_overlap_negative_offset_indivisible_by_length() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(3),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //   9:00:02
+    //   I
+    // 3)
+    // ---2)
+    // ------1)
+    // [0--------)
+    //    [1--------)
+    //       [2--------)
+    //          [3--------)
+    //             [4--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 2);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![
+            (WindowKey(-2), Utc.ymd(2023, 3, 16).and_hms(9, 0, 4)),
+            (WindowKey(-1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 7)),
+            (WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10)),
+        ],
+    );
+}
+
+#[test]
+fn test_intersect_overlap_end_edge_offset_divisible_by_length() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(7),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //           9:00:10
+    //           I
+    // [0--------)
+    //        [1--------)
+    //               [2--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 10);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 17))],
+    );
+}
+
+#[test]
+fn test_intersect_overlap_start_edge_offset_divisible_by_length() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(7),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //        9:00:07
+    //        I
+    // [0--------)
+    //        [1--------)
+    //               [2--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 7);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10)),],
+    );
+}
+
+#[test]
+fn test_intersect_overlap_edge_offset_divisible_by_length() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(5),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //           9:00:10
+    //           I
+    // [0--------)
+    //      [1--------)
+    //           [2--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 10);
+    let found: Vec<_> = windower.intersects(&item_time).collect();
+    assert_eq!(found.len(), 2);
+    assert_eq!(
+        found[0],
+        (WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 15)),
+        "intersect did not consider window end exclusive"
+    );
+    assert_eq!(
+        found[1],
+        (WindowKey(2), Utc.ymd(2023, 3, 16).and_hms(9, 0, 20)),
+        "intersect did not consider window start inclusive"
+    );
+}
+
+#[test]
+fn test_intersect_tumble_bulk() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(10),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //         9:00:08
+    //         I
+    // [0--------)
+    //           [1--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 8);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10))],
+    );
+}
+
+#[test]
+fn test_intersect_tumble_edge() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(10),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //           9:00:10
+    //           I
+    // [0--------)
+    //           [1--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 10);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 20))],
+    );
+}
+
+#[test]
+fn test_intersect_gap_bulk() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(15),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //         9:00:08
+    //         I
+    // [0--------)
+    //                [1--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 8);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(0), Utc.ymd(2023, 3, 16).and_hms(9, 0, 10))],
+    );
+}
+
+#[test]
+fn test_intersect_gap_end_edge() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(15),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //           9:00:10
+    //           I
+    // [0--------)
+    //                [1--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 10);
+    assert_eq!(windower.intersects(&item_time).collect::<Vec<_>>(), vec![]);
+}
+
+#[test]
+fn test_intersect_gap_start_edge() {
+    let windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(15),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                9:00:15
+    //                I
+    // [0--------)
+    //                [1--------)
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 15);
+    assert_eq!(
+        windower.intersects(&item_time).collect::<Vec<_>>(),
+        vec![(WindowKey(1), Utc.ymd(2023, 3, 16).and_hms(9, 0, 25))],
+    );
+}
+
+#[test]
+fn test_insert() {
+    let mut windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(5),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //                  9:00:17
+    //                  W
+    //              9:00:13
+    //              I
+    // [0--------)
+    //      [1--------)
+    //           [2--------)
+    //                [3--------)
+    let watermark = Utc.ymd(2023, 3, 16).and_hms(9, 0, 17);
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 13);
+    assert_eq!(
+        windower.insert(&watermark, &item_time),
+        vec![Err(InsertError::Late(WindowKey(1))), Ok(WindowKey(2))]
+    );
+}
+
+#[test]
+fn test_drain_closed() {
+    let mut windower = SlidingWindower {
+        length: Duration::seconds(10),
+        offset: Duration::seconds(5),
+        align_to: Utc.ymd(2023, 3, 16).and_hms(9, 0, 0),
+        close_times: HashMap::new(),
+    };
+
+    //     9:00:04      9:00:17
+    //     W1           W2
+    //              9:00:13
+    //              I
+    // [0--------)
+    //      [1--------)
+    //           [2--------)
+    //                [3--------)
+    let watermark1 = Utc.ymd(2023, 3, 16).and_hms(9, 0, 04);
+    let item_time = Utc.ymd(2023, 3, 16).and_hms(9, 0, 13);
+    let _ = windower.insert(&watermark1, &item_time);
+
+    let watermark2 = Utc.ymd(2023, 3, 16).and_hms(9, 0, 17);
+    assert_eq!(windower.drain_closed(&watermark2), vec![WindowKey(1)]);
 }

--- a/src/window/sliding_window.rs
+++ b/src/window/sliding_window.rs
@@ -114,10 +114,10 @@ impl SlidingWindower {
         );
 
         // Clone to not retain ownership of self in the closure.
-        let time = time.clone();
-        let align_to = self.align_to.clone();
-        let offset = self.offset.clone();
-        let length = self.length.clone();
+        let time = *time;
+        let align_to = self.align_to;
+        let offset = self.offset;
+        let length = self.length;
         (0..num_windows).flat_map(move |i| {
             let window_idx = first_window_idx + i;
             let window_open = align_to + offset * window_idx as i32;

--- a/src/window/sliding_window.rs
+++ b/src/window/sliding_window.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 
 use crate::{add_pymethods, window::WindowConfig};
 
-use super::{Builder, InsertError, StateBytes, WindowBuilder, WindowKey, Windower};
+use super::*;
 
 /// Sliding windows of fixed duration.
 ///
@@ -30,8 +30,8 @@ use super::{Builder, InsertError, StateBytes, WindowBuilder, WindowKey, Windower
 ///     adjacent windows.
 ///
 ///   align_to (datetime.datetime): Align windows so this instant
-///     starts a window. You can use this to align all windows to hour
-///     boundaries, e.g.
+///     starts a window. This must be a constant. You can use this to
+///     align all windows to hour boundaries, e.g.
 ///
 /// Returns:
 ///

--- a/src/window/tumbling_window.rs
+++ b/src/window/tumbling_window.rs
@@ -5,9 +5,7 @@ use pyo3::prelude::*;
 use crate::add_pymethods;
 
 use super::sliding_window::SlidingWindower;
-use super::Builder;
-use super::WindowBuilder;
-use super::WindowConfig;
+use super::*;
 
 /// Tumbling windows of fixed duration.
 ///
@@ -20,8 +18,8 @@ use super::WindowConfig;
 ///   length (datetime.timedelta): Length of windows.
 ///
 ///   align_to (datetime.datetime): Align windows so this instant
-///     starts a window. You can use this to align all windows to hour
-///     boundaries, e.g.
+///     starts a window. This must be a constant. You can use this to
+///     align all windows to hour boundaries, e.g.
 ///
 /// Returns:
 ///


### PR DESCRIPTION
As part of debugging what was going on with windowing in the
possibly-buggy recovery example, I found some issues with how clocks
and windowers were implemented. This was basically a week of
continually finding more and more obscure off-by-one errors.

First `start_at` is renamed to `align_to`. That former name
incorrectly implied that there were no windows before that time, but
that is not true; windows extend (almost) infinitely in both
directions in time from that alignment point. What determines if an
item is late for a window is not the windowing definition, but the
watermark of the clock.

Next, both `{Sliding,Tumbling}Window` are required to take
`align_to`. Previously, this was filled with the timestamp of the
start of the dataflow, but we did not persist it as the recovery
state, nor can we actually properly persist it because recovery state
is per-state-key but at that point we don't have any key. I didn't
want to work on figuring out a way to store "dataflow global" recovery
state, so to make it easier we require you to pick a fixed alignment
time. If you don't ensure `align_to` is consistent across executions,
you have window boundaries jumping around even when you are using
event time.

Then fixes up and adds additional tests for event time watermarking. I
don't belive we were properly advancing the watermark, preventing it
from going backwards, and handling the extreme no data and EOF cases.

Also does a fix for system time watermarking. Once the data has
completed, we should forever return the watermark as "end of time",
not just when there is an item being processed. I don't believe this
causes any difference in behavior with the way our operators are
currently written, but if we didn't process all available data on each
awakening, this is needed.

Then writes a ton more tests for sliding windowing. I believe we were
improperly mixing in the watermark time into the window
definitions. The definition of the window boundaries is a function of
the arguments to the config, not the current item time or
watermark. The watermark is just used to determine if an item is late.
