### PR TITLE
Fixes bugs with system time windows closing late

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
         architecture: x64
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.61
+        toolchain: 1.68.2
     - name: Install dill
       shell: bash
       run: |
@@ -36,7 +36,7 @@ jobs:
         args: --no-default-features
     - uses: messense/maturin-action@v1
       with:
-        rust-toolchain: 1.61
+        rust-toolchain: 1.68.2
         manylinux: auto
         container: off
         command: build
@@ -64,7 +64,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Rust Toolchain
       run: |
-        rustup default 1.61
+        rustup default 1.68.2
     - name: Cargo Test
       run: |
         cargo test --no-default-features
@@ -100,7 +100,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.61
+        toolchain: 1.68.2
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:
@@ -116,7 +116,7 @@ jobs:
         args: --no-default-features
     - uses: messense/maturin-action@v1
       with:
-        rust-toolchain: 1.61
+        rust-toolchain: 1.68.2
         command: build
         args: --release --no-sdist -o dist --interpreter python${{ matrix.python-version }}
     - name: Run tests
@@ -141,7 +141,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.61
+        toolchain: 1.68.2
         target: aarch64-apple-darwin
     - name: Rust tests
       uses: actions-rs/cargo@v1

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -168,6 +168,7 @@ where
                         clock_builder,
                         windower_builder,
                         CollectWindowLogic::builder(),
+                        resume_epoch,
                         step_resume_state,
                     );
 
@@ -259,6 +260,7 @@ where
                         clock_builder,
                         windower_builder,
                         FoldWindowLogic::new(builder, folder),
+                        resume_epoch,
                         step_resume_state,
                     );
 
@@ -291,6 +293,7 @@ where
                     let (output, changes) = stream.map(extract_state_pair).stateful_unary(
                         step_id,
                         ReduceLogic::builder(reducer, is_complete),
+                        resume_epoch,
                         step_resume_state,
                     );
                     stream = output.map(wrap_state_pair);
@@ -316,6 +319,7 @@ where
                         clock_builder,
                         windower_builder,
                         ReduceWindowLogic::builder(reducer),
+                        resume_epoch,
                         step_resume_state,
                     );
 
@@ -341,6 +345,7 @@ where
                     let (output, changes) = stream.map(extract_state_pair).stateful_unary(
                         step_id,
                         StatefulMapLogic::builder(builder, mapper),
+                        resume_epoch,
                         step_resume_state,
                     );
                     stream = output.map(wrap_state_pair);
@@ -402,6 +407,7 @@ where
         attach_recovery_to_dataflow(
             &mut probe,
             worker_key,
+            resume_epoch,
             resume_progress,
             store_summary,
             progress_writer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub(crate) mod operators;
 pub(crate) mod outputs;
 pub(crate) mod pyo3_extensions;
 pub(crate) mod recovery;
+pub(crate) mod timely;
 pub(crate) mod tracing;
 pub(crate) mod webserver;
 pub(crate) mod window;

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -282,7 +282,7 @@ where
 
         op_builder.build(move |init_caps| {
             let mut inbuf = InBuffer::new();
-            let mut ncater = EagerNotificator::stateful_new(init_caps, bundle);
+            let mut ncater = EagerNotificator::new(init_caps, bundle);
 
             move |input_frontiers| {
                 input_handle.for_each(|cap, incoming| {
@@ -291,7 +291,7 @@ where
                     ncater.notify_at(*epoch);
                 });
 
-                ncater.stateful_for_each(
+                ncater.for_each(
                     input_frontiers,
                     |caps, bundle| {
                         unwrap_any!(Python::with_gil(|py| -> PyResult<_> {

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -8,13 +8,14 @@ use crate::execution::{WorkerCount, WorkerIndex};
 use crate::pyo3_extensions::{extract_state_pair, wrap_state_pair, TdPyAny, TdPyCallable};
 use crate::recovery::model::*;
 use crate::recovery::operators::{FlowChangeStream, Route};
+use crate::timely::{EagerNotificator, InBuffer};
 use crate::unwrap_any;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use std::collections::{BTreeSet, HashMap};
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use timely::dataflow::operators::{FrontierNotificator, Map, Operator};
+use timely::dataflow::operators::{Map, Operator};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 
@@ -258,8 +259,6 @@ where
             worker_count,
             resume_state,
         )?;
-        let mut bundle = Some(bundle);
-
         let kv_stream = self.map(extract_state_pair);
 
         let mut op_builder = OperatorBuilder::new(step_id.0.clone(), self.scope());
@@ -281,44 +280,33 @@ where
             vec![Antichain::from_elem(0), Antichain::from_elem(0)],
         );
 
-        op_builder.build(move |_init_caps| {
-            let mut incoming_buffer: HashMap<S::Timestamp, Vec<(StateKey, TdPyAny)>> =
-                HashMap::new();
-
-            let mut tmp_incoming: Vec<(StateKey, TdPyAny)> = Vec::new();
-
-            let mut output_ncater = FrontierNotificator::new();
-            let mut change_ncater = FrontierNotificator::new();
+        op_builder.build(move |init_caps| {
+            let mut inbuf = InBuffer::new();
+            let mut ncater = EagerNotificator::stateful_new(init_caps, bundle);
 
             move |input_frontiers| {
-                bundle = bundle.take().and_then(|mut bundle| {
-                    input_handle.for_each(|cap, incoming| {
-                        let epoch = cap.time();
+                input_handle.for_each(|cap, incoming| {
+                    let epoch = cap.time();
+                    inbuf.extend(*epoch, incoming);
+                    ncater.notify_at(*epoch);
+                });
 
-                        assert!(tmp_incoming.is_empty());
-                        incoming.swap(&mut tmp_incoming);
+                ncater.stateful_for_each(
+                    input_frontiers,
+                    |caps, bundle| {
+                        unwrap_any!(Python::with_gil(|py| -> PyResult<_> {
+                            let output_cap = &caps[0];
+                            let epoch = output_cap.time();
 
-                        incoming_buffer
-                            .entry(*epoch)
-                            .or_insert_with(Vec::new)
-                            .append(&mut tmp_incoming);
-
-                        output_ncater.notify_at(cap.delayed_for_output(epoch, 0));
-                        change_ncater.notify_at(cap.delayed_for_output(epoch, 1));
-                    });
-
-                    output_ncater.for_each(&[&input_frontiers[0]], |cap, _| {
-                        unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
-                            let epoch = cap.time();
-
-                            if let Some(items) = incoming_buffer.remove(epoch) {
+                            if let Some(items) = inbuf.remove(epoch) {
                                 let mut output_handle = output_wrapper.activate();
-                                let mut output_session = output_handle.session(&cap);
+                                let mut output_session = output_handle.session(output_cap);
                                 for (key, value) in items {
                                     let part_key = assigner.assign_part(py, key.clone())?;
                                     let sink = bundle.parts.get_mut(&part_key).expect(
                                         "Item routed to non-local partition; output routing bug?",
                                     );
+
                                     sink.write(py, value.clone_ref(py))
                                         .reraise("error writing to output")?;
                                     output_session.give(wrap_state_pair((key, value)));
@@ -326,9 +314,10 @@ where
                             }
                             Ok(())
                         }))
-                    });
+                    },
+                    |caps, bundle| {
+                        let change_cap = &caps[1];
 
-                    change_ncater.for_each(&[&input_frontiers[0]], |cap, _| {
                         let kchanges = unwrap_any!(Python::with_gil(|py| bundle.snapshot(py)))
                             .into_iter()
                             .map(|(key, snapshot)| {
@@ -336,17 +325,11 @@ where
                             });
                         change_wrapper
                             .activate()
-                            .session(&cap)
+                            .session(change_cap)
                             .give_iterator(kchanges);
-                    });
-
-                    if input_frontiers.iter().all(|f| f.is_empty()) {
-                        unwrap_any!(Python::with_gil(|py| bundle.close(py)));
-                        None
-                    } else {
-                        Some(bundle)
-                    }
-                });
+                    },
+                    |bundle| unwrap_any!(Python::with_gil(|py| bundle.close(py))),
+                );
             }
         });
 

--- a/src/recovery/operators.rs
+++ b/src/recovery/operators.rs
@@ -247,6 +247,7 @@ where
 pub(crate) trait Write<S, K, V, W>
 where
     S: Scope,
+    S::Timestamp: TotalOrder,
     K: ExchangeData + Route,
     V: ExchangeData,
     W: KWriter<K, V> + 'static,
@@ -260,7 +261,8 @@ where
 
 impl<S, K, V, W> Write<S, K, V, W> for KChangeStream<S, K, V>
 where
-    S: Scope<Timestamp = u64>,
+    S: Scope,
+    S::Timestamp: TotalOrder,
     K: ExchangeData + Route,
     V: ExchangeData,
     W: KWriter<K, V> + 'static,
@@ -274,20 +276,20 @@ where
             "write",
             move |init_cap, _info| {
                 let mut inbuf = InBuffer::new();
-                let mut ncater = EagerNotificator::new(vec![init_cap]);
+                let mut ncater = EagerNotificator::new(vec![init_cap], ());
 
                 move |input, output| {
                     input.for_each(|cap, incoming| {
                         let epoch = cap.time();
-                        inbuf.extend(*epoch, incoming);
-                        ncater.notify_at(*epoch);
+                        inbuf.extend(epoch.clone(), incoming);
+                        ncater.notify_at(epoch.clone());
                     });
 
                     // Use notificator so writes are in epoch order per
                     // key.
                     ncater.for_each(
-                        &[*input.frontier()],
-                        |caps| {
+                        &[input.frontier().clone()],
+                        |caps, ()| {
                             let cap = &caps[0];
                             let epoch = cap.time();
 
@@ -295,12 +297,13 @@ where
                                 writer.write_many(incoming);
                             }
                         },
-                        |caps| {
+                        |caps, ()| {
                             let cap = &caps[0];
 
                             let mut session = output.session(&cap);
                             session.give(());
                         },
+                        |()| {},
                     );
                 }
             },
@@ -311,6 +314,7 @@ where
 pub(crate) trait BroadcastWrite<S, K, V, W>
 where
     S: Scope,
+    S::Timestamp: TotalOrder,
     K: ExchangeData,
     V: ExchangeData,
     W: KWriter<K, V> + 'static,
@@ -322,7 +326,8 @@ where
 
 impl<S, K, V, W> BroadcastWrite<S, K, V, W> for KChangeStream<S, K, V>
 where
-    S: Scope<Timestamp = u64>,
+    S: Scope,
+    S::Timestamp: TotalOrder,
     K: ExchangeData,
     V: ExchangeData,
     W: KWriter<K, V> + 'static,
@@ -331,18 +336,18 @@ where
         self.broadcast()
             .unary_frontier(Pipeline, "write", move |init_cap, _info| {
                 let mut inbuf = InBuffer::new();
-                let mut ncater = EagerNotificator::new(vec![init_cap]);
+                let mut ncater = EagerNotificator::new(vec![init_cap], ());
 
                 move |input, output| {
                     input.for_each(|cap, incoming| {
                         let epoch = cap.time();
-                        inbuf.extend(*epoch, incoming);
-                        ncater.notify_at(*epoch);
+                        inbuf.extend(epoch.clone(), incoming);
+                        ncater.notify_at(epoch.clone());
                     });
 
                     ncater.for_each(
-                        &[*input.frontier()],
-                        |caps| {
+                        &[input.frontier().clone()],
+                        |caps, ()| {
                             let cap = &caps[0];
                             let epoch = cap.time();
 
@@ -350,12 +355,13 @@ where
                                 writer.write_many(incoming);
                             }
                         },
-                        |caps| {
+                        |caps, ()| {
                             let cap = &caps[0];
 
                             let mut session = output.session(cap);
                             session.give(());
                         },
+                        |()| {},
                     );
                 }
             })
@@ -415,14 +421,14 @@ where
     S: Scope<Timestamp = u64>,
 {
     fn recover(&self) -> FlowChangeStream<S> {
-        let mut state = InMemStore::new();
+        let state = InMemStore::new();
 
         self.unary_frontier(
             Exchange::new(|KChange(StoreKey(_epoch, flow_key), _change)| flow_key.route()),
             "recover",
             move |init_cap, _info| {
                 let mut inbuf = InBuffer::new();
-                let mut ncater = EagerNotificator::new(vec![init_cap]);
+                let mut ncater = EagerNotificator::new(vec![init_cap], state);
 
                 move |input, output| {
                     input.for_each(|cap, incoming| {
@@ -432,8 +438,8 @@ where
                     });
 
                     ncater.for_each(
-                        &[*input.frontier()],
-                        |caps| {
+                        &[input.frontier().clone()],
+                        |caps, state| {
                             let cap = &caps[0];
                             let epoch = cap.time();
 
@@ -444,12 +450,13 @@ where
                                 state.filter_last();
                             }
                         },
-                        |caps| {
+                        |caps, state| {
                             let cap = &caps[0];
 
                             let mut session = output.session(&cap);
                             session.give_iterator(state.drain_flatten().into_iter());
                         },
+                        |_state| {},
                     );
                 }
             },
@@ -508,8 +515,8 @@ where
     fn garbage_collect(
         &self,
         progress_stream: ProgressStream<S>,
-        mut cluster_progress: InMemProgress,
-        mut summary: StoreSummary,
+        cluster_progress: InMemProgress,
+        summary: StoreSummary,
     ) -> StoreChangeStream<S> {
         // This is effectively "binary aggregate with epoch" but Timely
         // doesn't give us that.
@@ -521,7 +528,7 @@ where
             move |init_cap, _info| {
                 let mut summary_inbuf = InBuffer::new();
                 let mut progress_inbuf = InBuffer::new();
-                let mut ncater = EagerNotificator::new(vec![init_cap]);
+                let mut ncater = EagerNotificator::new(vec![init_cap], (summary, cluster_progress));
 
                 move |summary_input, progress_input, output| {
                     summary_input.for_each(|cap, incoming| {
@@ -537,8 +544,11 @@ where
                     });
 
                     ncater.for_each(
-                        &[*summary_input.frontier(), *progress_input.frontier()],
-                        |caps| {
+                        &[
+                            summary_input.frontier().clone(),
+                            progress_input.frontier().clone(),
+                        ],
+                        |caps, (summary, cluster_progress)| {
                             let cap = &caps[0];
                             let epoch = cap.time();
 
@@ -549,7 +559,7 @@ where
                                 cluster_progress.write_many(progress_changes);
                             }
                         },
-                        |caps| {
+                        |caps, (summary, cluster_progress)| {
                             let cap = &caps[0];
 
                             let ResumeFrom(_ex, resume_epoch) = cluster_progress.resume_from();
@@ -561,6 +571,7 @@ where
                                     .map(|key| KChange(key, Change::Discard)),
                             );
                         },
+                        |(_summary, _cluster_progress)| {},
                     );
                 }
             },

--- a/src/recovery/operators.rs
+++ b/src/recovery/operators.rs
@@ -6,10 +6,9 @@
 //! [`crate::operators::stateful_unary`].
 
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
-
 use std::hash::Hash;
 use std::hash::Hasher;
+
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::flow_controlled::iterator_source;
@@ -23,6 +22,10 @@ use timely::order::TotalOrder;
 use timely::progress::Timestamp;
 use timely::Data;
 use timely::ExchangeData;
+
+use crate::timely::EagerNotificator;
+use crate::timely::FrontierEx;
+use crate::timely::InBuffer;
 
 use super::model::*;
 use super::store::in_mem::*;
@@ -196,7 +199,7 @@ where
                 });
 
                 cap = cap.take().and_then(|cap| {
-                    let frontier = input_frontiers[0].frontier().iter().min().copied();
+                    let frontier = input_frontiers.simplify();
                     // Do not delay cap before the write; we will
                     // delay downstream progress messages longer than
                     // necessary if so. This would manifest as
@@ -257,49 +260,49 @@ where
 
 impl<S, K, V, W> Write<S, K, V, W> for KChangeStream<S, K, V>
 where
-    S: Scope,
+    S: Scope<Timestamp = u64>,
     K: ExchangeData + Route,
     V: ExchangeData,
     W: KWriter<K, V> + 'static,
 {
     fn write(&self, mut writer: W) -> ClockStream<S> {
-        let mut tmp_incoming = Vec::new();
-        let mut incoming_buffer = HashMap::new();
-
         // This is effectively "aggregate" but with `KChange`s not `(K,
         // V)`. It's just slightly longer, but clearer to write it out
         // ourselves.
-        self.unary_notify(
+        self.unary_frontier(
             Exchange::new(|KChange(key, _change): &KChange<K, V>| key.route()),
             "write",
-            None,
-            move |input, output, ncater| {
-                input.for_each(|cap, incoming| {
-                    let epoch = cap.time();
+            move |init_cap, _info| {
+                let mut inbuf = InBuffer::new();
+                let mut ncater = EagerNotificator::new(vec![init_cap]);
 
-                    assert!(tmp_incoming.is_empty());
-                    incoming.swap(&mut tmp_incoming);
+                move |input, output| {
+                    input.for_each(|cap, incoming| {
+                        let epoch = cap.time();
+                        inbuf.extend(*epoch, incoming);
+                        ncater.notify_at(*epoch);
+                    });
 
-                    incoming_buffer
-                        .entry(epoch.clone())
-                        .or_insert_with(Vec::new)
-                        .append(&mut tmp_incoming);
+                    // Use notificator so writes are in epoch order per
+                    // key.
+                    ncater.for_each(
+                        &[*input.frontier()],
+                        |caps| {
+                            let cap = &caps[0];
+                            let epoch = cap.time();
 
-                    ncater.notify_at(cap.retain());
-                });
+                            if let Some(incoming) = inbuf.remove(epoch) {
+                                writer.write_many(incoming);
+                            }
+                        },
+                        |caps| {
+                            let cap = &caps[0];
 
-                // Use notificator so writes are in epoch order per
-                // key.
-                ncater.for_each(|cap, _count, _ncater| {
-                    let epoch = cap.time();
-
-                    if let Some(incoming) = incoming_buffer.remove(epoch) {
-                        writer.write_many(incoming);
-
-                        let mut session = output.session(&cap);
-                        session.give(());
-                    }
-                });
+                            let mut session = output.session(&cap);
+                            session.give(());
+                        },
+                    );
+                }
             },
         )
     }
@@ -319,41 +322,42 @@ where
 
 impl<S, K, V, W> BroadcastWrite<S, K, V, W> for KChangeStream<S, K, V>
 where
-    S: Scope,
+    S: Scope<Timestamp = u64>,
     K: ExchangeData,
     V: ExchangeData,
     W: KWriter<K, V> + 'static,
 {
     fn broadcast_write(&self, mut writer: W) -> ClockStream<S> {
-        let mut tmp_incoming = Vec::new();
-        let mut incoming_buffer = HashMap::new();
-
         self.broadcast()
-            .unary_notify(Pipeline, "write", None, move |input, output, ncater| {
-                input.for_each(|cap, incoming| {
-                    let epoch = cap.time();
+            .unary_frontier(Pipeline, "write", move |init_cap, _info| {
+                let mut inbuf = InBuffer::new();
+                let mut ncater = EagerNotificator::new(vec![init_cap]);
 
-                    assert!(tmp_incoming.is_empty());
-                    incoming.swap(&mut tmp_incoming);
+                move |input, output| {
+                    input.for_each(|cap, incoming| {
+                        let epoch = cap.time();
+                        inbuf.extend(*epoch, incoming);
+                        ncater.notify_at(*epoch);
+                    });
 
-                    incoming_buffer
-                        .entry(epoch.clone())
-                        .or_insert_with(Vec::new)
-                        .append(&mut tmp_incoming);
+                    ncater.for_each(
+                        &[*input.frontier()],
+                        |caps| {
+                            let cap = &caps[0];
+                            let epoch = cap.time();
 
-                    ncater.notify_at(cap.retain());
-                });
+                            if let Some(incoming) = inbuf.remove(epoch) {
+                                writer.write_many(incoming);
+                            }
+                        },
+                        |caps| {
+                            let cap = &caps[0];
 
-                ncater.for_each(|cap, _count, _ncater| {
-                    let epoch = cap.time();
-
-                    if let Some(incoming) = incoming_buffer.remove(epoch) {
-                        writer.write_many(incoming);
-
-                        let mut session = output.session(&cap);
-                        session.give(());
-                    }
-                });
+                            let mut session = output.session(cap);
+                            session.give(());
+                        },
+                    );
+                }
             })
     }
 }
@@ -408,33 +412,46 @@ where
 
 impl<S> Recover<S> for StoreChangeStream<S>
 where
-    S: Scope,
+    S: Scope<Timestamp = u64>,
 {
     fn recover(&self) -> FlowChangeStream<S> {
-        let mut tmp_incoming = Vec::new();
         let mut state = InMemStore::new();
 
-        self.unary_notify(
+        self.unary_frontier(
             Exchange::new(|KChange(StoreKey(_epoch, flow_key), _change)| flow_key.route()),
             "recover",
-            None,
-            move |input, output, ncater| {
-                input.for_each(|cap, incoming| {
-                    assert!(tmp_incoming.is_empty());
-                    incoming.swap(&mut tmp_incoming);
+            move |init_cap, _info| {
+                let mut inbuf = InBuffer::new();
+                let mut ncater = EagerNotificator::new(vec![init_cap]);
 
-                    state.write_many(tmp_incoming.drain(..).collect());
-                    // Remove all but the newest changes so we don't
-                    // have to have the whole recovery store in mem.
-                    state.filter_last();
+                move |input, output| {
+                    input.for_each(|cap, incoming| {
+                        let epoch = cap.time();
+                        inbuf.extend(*epoch, incoming);
+                        ncater.notify_at(*epoch);
+                    });
 
-                    ncater.notify_at(cap.retain());
-                });
+                    ncater.for_each(
+                        &[*input.frontier()],
+                        |caps| {
+                            let cap = &caps[0];
+                            let epoch = cap.time();
 
-                ncater.for_each(|cap, _count, _ncater| {
-                    let mut session = output.session(&cap);
-                    session.give_iterator(state.drain_flatten().into_iter());
-                });
+                            if let Some(changes) = inbuf.remove(epoch) {
+                                state.write_many(changes);
+                                // Remove all but the newest changes so we don't
+                                // have to have the whole recovery store in mem.
+                                state.filter_last();
+                            }
+                        },
+                        |caps| {
+                            let cap = &caps[0];
+
+                            let mut session = output.session(&cap);
+                            session.give_iterator(state.drain_flatten().into_iter());
+                        },
+                    );
+                }
             },
         )
     }
@@ -494,68 +511,58 @@ where
         mut cluster_progress: InMemProgress,
         mut summary: StoreSummary,
     ) -> StoreChangeStream<S> {
-        let mut tmp_summary = Vec::new();
-        let mut tmp_progress = Vec::new();
-
-        let mut store_buffer = HashMap::new();
-        let mut progress_buffer = HashMap::new();
-
         // This is effectively "binary aggregate with epoch" but Timely
         // doesn't give us that.
-        self.binary_notify(
+        self.binary_frontier(
             &progress_stream,
             Exchange::new(|KChange(StoreKey(_epoch, flow_key), _change)| flow_key.route()),
             Pipeline,
             "garbage_collect",
-            None,
-            move |summary_input, progress_input, output, ncater| {
-                summary_input.for_each(|cap, incoming| {
-                    let epoch = cap.time();
+            move |init_cap, _info| {
+                let mut summary_inbuf = InBuffer::new();
+                let mut progress_inbuf = InBuffer::new();
+                let mut ncater = EagerNotificator::new(vec![init_cap]);
 
-                    assert!(tmp_summary.is_empty());
-                    incoming.swap(&mut tmp_summary);
+                move |summary_input, progress_input, output| {
+                    summary_input.for_each(|cap, incoming| {
+                        let epoch = cap.time();
+                        summary_inbuf.extend(*epoch, incoming);
+                        ncater.notify_at(*epoch);
+                    });
 
-                    store_buffer
-                        .entry(*epoch)
-                        .or_insert_with(Vec::new)
-                        .append(&mut tmp_summary);
+                    progress_input.for_each(|cap, incoming| {
+                        let epoch = cap.time();
+                        progress_inbuf.extend(*epoch, incoming);
+                        ncater.notify_at(*epoch);
+                    });
 
-                    ncater.notify_at(cap.retain());
-                });
+                    ncater.for_each(
+                        &[*summary_input.frontier(), *progress_input.frontier()],
+                        |caps| {
+                            let cap = &caps[0];
+                            let epoch = cap.time();
 
-                progress_input.for_each(|cap, incoming| {
-                    let epoch = cap.time();
+                            if let Some(store_changes) = summary_inbuf.remove(epoch) {
+                                summary.write_many(store_changes);
+                            }
+                            if let Some(progress_changes) = progress_inbuf.remove(epoch) {
+                                cluster_progress.write_many(progress_changes);
+                            }
+                        },
+                        |caps| {
+                            let cap = &caps[0];
 
-                    assert!(tmp_progress.is_empty());
-                    incoming.swap(&mut tmp_progress);
-
-                    progress_buffer
-                        .entry(*epoch)
-                        .or_insert_with(Vec::new)
-                        .append(&mut tmp_progress);
-
-                    ncater.notify_at(cap.retain());
-                });
-
-                ncater.for_each(|cap, _count, _ncater| {
-                    let epoch = cap.time();
-
-                    if let Some(store_changes) = store_buffer.remove(epoch) {
-                        summary.write_many(store_changes);
-                    }
-                    if let Some(progress_changes) = progress_buffer.remove(epoch) {
-                        cluster_progress.write_many(progress_changes);
-                    }
-
-                    let ResumeFrom(_ex, resume_epoch) = cluster_progress.resume_from();
-                    let mut session = output.session(&cap);
-                    session.give_iterator(
-                        summary
-                            .drain_garbage(&resume_epoch)
-                            .into_iter()
-                            .map(|key| KChange(key, Change::Discard)),
+                            let ResumeFrom(_ex, resume_epoch) = cluster_progress.resume_from();
+                            let mut session = output.session(&cap);
+                            session.give_iterator(
+                                summary
+                                    .drain_garbage(&resume_epoch)
+                                    .into_iter()
+                                    .map(|key| KChange(key, Change::Discard)),
+                            );
+                        },
                     );
-                });
+                }
             },
         )
     }

--- a/src/timely.rs
+++ b/src/timely.rs
@@ -1,0 +1,229 @@
+//! Low-level, generic extensions for Timely.
+
+use std::collections::{BTreeSet, HashMap};
+
+use timely::communication::message::RefOrMut;
+use timely::dataflow::operators::Capability;
+use timely::progress::frontier::MutableAntichain;
+
+/// Helper class for buffering input in a Timely operator.
+pub(crate) struct InBuffer<D> {
+    tmp: Vec<D>,
+    buffer: HashMap<u64, Vec<D>>,
+}
+
+impl<D> InBuffer<D>
+where
+    D: Clone,
+{
+    pub(crate) fn new() -> Self {
+        Self {
+            tmp: Vec::new(),
+            buffer: HashMap::new(),
+        }
+    }
+
+    /// Buffer that this input was received on this epoch.
+    pub(crate) fn extend(&mut self, epoch: u64, incoming: RefOrMut<Vec<D>>) {
+        assert!(self.tmp.is_empty());
+        incoming.swap(&mut self.tmp);
+        self.buffer
+            .entry(epoch)
+            .or_insert_with(Vec::new)
+            .append(&mut self.tmp);
+    }
+
+    /// Get all input received on a given epoch.
+    ///
+    /// It's your job to decide if this epoch will see more data using
+    /// some sort of notificator or checking the frontier.
+    pub(crate) fn remove(&mut self, epoch: &u64) -> Option<Vec<D>> {
+        self.buffer.remove(epoch)
+    }
+
+    /// Return an iterator of all the epochs currently buffered.
+    pub(crate) fn epochs(&self) -> impl Iterator<Item = u64> + '_ {
+        self.buffer.keys().copied()
+    }
+}
+
+/// Extension trait for frontiers.
+pub(crate) trait FrontierEx {
+    /// Collapse a frontier into a single epoch value.
+    ///
+    /// We can do this because we're using a totally ordered epoch in
+    /// our dataflows.
+    fn simplify(&self) -> Option<u64>;
+
+    /// Is a given epoch closed based on this frontier?
+    fn is_closed(&self, epoch: &u64) -> bool {
+        self.simplify().iter().all(|frontier| *epoch < *frontier)
+    }
+
+    /// Is this input EOF and will see no more values?
+    fn is_eof(&self) -> bool {
+        self.simplify().is_none()
+    }
+}
+
+impl FrontierEx for MutableAntichain<u64> {
+    fn simplify(&self) -> Option<u64> {
+        self.frontier().iter().min().copied()
+    }
+}
+
+/// To allow collapsing frontiers of all inputs in an operator.
+impl FrontierEx for [MutableAntichain<u64>] {
+    fn simplify(&self) -> Option<u64> {
+        self.iter().flat_map(FrontierEx::simplify).min()
+    }
+}
+
+/// Extension trait for vectors of capabilities.
+pub(crate) trait CapabilityVecEx {
+    /// Run [`Capability::downgrade`] on all capabilities.
+    ///
+    /// Since capabilities retain their output port, you can do this
+    /// on the vec of initial caps.
+    fn downgrade_all(&mut self, epoch: &u64);
+}
+
+impl CapabilityVecEx for Vec<Capability<u64>> {
+    fn downgrade_all(&mut self, epoch: &u64) {
+        self.iter_mut().for_each(|cap| cap.downgrade(epoch));
+    }
+}
+
+/// Manages running logic functions and iteratively downgrading
+/// capabilities based on the current operator's input frontiers.
+///
+/// Any state that you need full ownership on EOF, you can put in the
+/// state variable and have full ownership of it in the EOF
+/// logic. Otherwise, you can close over it mutably in the epoch
+/// logics.
+///
+/// This is like [`timely::dataflow::operators::Notificator`] but does
+/// _not_ wait until the epoch is fully closed to run logic.
+pub(crate) struct EagerNotificator<D> {
+    /// We have to retain separate capabilities per-output. This seems
+    /// to be only documented in
+    /// https://github.com/TimelyDataflow/timely-dataflow/pull/187
+    caps_state: Option<(Vec<Capability<u64>>, D)>,
+    queue: BTreeSet<u64>,
+}
+
+impl<D> EagerNotificator<D> {
+    pub(crate) fn stateful_new(init_caps: Vec<Capability<u64>>, init_state: D) -> Self {
+        Self {
+            caps_state: Some((init_caps, init_state)),
+            queue: BTreeSet::new(),
+        }
+    }
+
+    /// Mark this epoch as having seen input items and logic should be
+    /// called when the time is right.
+    ///
+    /// We need to use the "notify at" pattern of Timely's built in
+    /// [`timely::dataflow::operators::Notificator`] because otherwise
+    /// we don't the largest epoch to process as closed on EOF.
+    pub(crate) fn notify_at(&mut self, epoch: u64) {
+        self.queue.insert(epoch);
+    }
+
+    /// Do some logic in epoch order eagerly.
+    ///
+    /// Call this on each operator activation with the current input
+    /// frontiers.
+    ///
+    /// Eager logic could be called multiple times for an epoch. Epoch
+    /// close logic will be called once when each epoch closes. EOF
+    /// logic will be called once when the input is finished and will
+    /// drop the state.
+    ///
+    /// Automatically downgrades capabilities for each output to the
+    /// relevant epochs.
+    pub(crate) fn stateful_for_each(
+        &mut self,
+        input_frontiers: &[MutableAntichain<u64>],
+        mut epoch_eager_logic: impl FnMut(&[Capability<u64>], &mut D),
+        mut epoch_close_logic: impl FnMut(&[Capability<u64>], &mut D),
+        eof_logic: impl FnOnce(D),
+    ) {
+        if let Some(frontier) = input_frontiers.simplify() {
+            assert!(self.caps_state.is_some(), "frontier re-opened");
+            self.caps_state = self.caps_state.take().map(|(mut caps, mut state)| {
+                // Drain off epochs from the queue that are less than
+                // the frontier and so we can run both logics on
+                // them. Ones in advance of the frontier remain in the
+                // queue for later.
+                let lt_frontier = {
+                    // Do a little swap-a-roo since
+                    // [`BTreeSet::split_off`] only calculates >=, but we
+                    // want <.
+                    let ge_frontier = self.queue.split_off(&frontier);
+                    std::mem::replace(&mut self.queue, ge_frontier)
+                };
+
+                // Will iterate in epoch order since [`BTreeSet`].
+                for epoch in lt_frontier {
+                    caps.downgrade_all(&epoch);
+
+                    epoch_eager_logic(&caps, &mut state);
+                    epoch_close_logic(&caps, &mut state);
+                }
+
+                // Now eagerly execute the frontier. No need to call
+                // logic if we haven't any data at the frontier yet.
+                caps.downgrade_all(&frontier);
+                if self.queue.contains(&frontier) {
+                    epoch_eager_logic(&caps, &mut state);
+                }
+
+                (caps, state)
+            });
+        // None means EOF on all inputs.
+        } else {
+            // This will only be called once, so we can take the state
+            // out with ownership.
+            if let Some((mut caps, mut state)) = self.caps_state.take() {
+                // Since there's no BTreeSet::drain. Will iterate in
+                // epoch order since [`BTreeSet`].
+                while let Some(epoch) = self.queue.pop_first() {
+                    caps.downgrade_all(&epoch);
+
+                    epoch_eager_logic(&caps, &mut state);
+                    epoch_close_logic(&caps, &mut state);
+                }
+
+                // This drops the state.
+                eof_logic(state);
+                // Drop caps because there will be no more input.
+            }
+            // Ignore if we re-activate multiple times after EOF.
+        }
+    }
+}
+
+/// A version where you don't need to close any state.
+impl EagerNotificator<()> {
+    pub(crate) fn new(init_caps: Vec<Capability<u64>>) -> Self {
+        Self::stateful_new(init_caps, ())
+    }
+
+    /// Just like [`stateful_for_each`] but hides the state if you're
+    /// not using it so there's less symbol line noise.
+    pub(crate) fn for_each(
+        &mut self,
+        input_frontiers: &[MutableAntichain<u64>],
+        mut epoch_eager_logic: impl FnMut(&[Capability<u64>]),
+        mut epoch_close_logic: impl FnMut(&[Capability<u64>]),
+    ) {
+        self.stateful_for_each(
+            input_frontiers,
+            |caps, ()| epoch_eager_logic(caps),
+            |caps, ()| epoch_close_logic(caps),
+            // Do nothing on frontier close.
+            |()| {},
+        );
+    }
+}

--- a/src/timely.rs
+++ b/src/timely.rs
@@ -90,7 +90,7 @@ where
     T: Timestamp + TotalOrder,
 {
     fn simplify(&self) -> Option<T> {
-        self.iter().flat_map(FrontierEx::simplify).min()
+        self.iter().flat_map(|ma| ma.simplify()).min()
     }
 }
 

--- a/src/window/clock/mod.rs
+++ b/src/window/clock/mod.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use pyo3::{exceptions::PyTypeError, prelude::*};
 
-use crate::{pyo3_extensions::{PyConfigClass, TdPyAny}, errors::tracked_err};
+use crate::{
+    errors::tracked_err,
+    pyo3_extensions::{PyConfigClass, TdPyAny},
+};
 
 use self::{event_time_clock::EventClockConfig, system_clock::SystemClockConfig};
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -372,7 +372,9 @@ where
     }
 
     fn next_awake(&self) -> Option<DateTime<Utc>> {
-        self.windower.next_close()
+        let next_awake = self.windower.next_close();
+        tracing::trace!("Next awake {next_awake:?}");
+        next_awake
     }
 
     fn snapshot(&self) -> StateBytes {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -31,6 +31,7 @@
 use crate::errors::tracked_err;
 use crate::operators::stateful_unary::*;
 use crate::pyo3_extensions::PyConfigClass;
+use crate::recovery::model::ResumeEpoch;
 use chrono::prelude::*;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -441,6 +442,7 @@ where
         clock_builder: CB,
         windower_builder: WB,
         logic_builder: LB,
+        resume_epoch: ResumeEpoch,
         resume_state: StepStateBytes,
     ) -> (
         StatefulStream<S, Result<R, WindowError<V>>>,
@@ -467,6 +469,7 @@ where
         clock_builder: CB,
         windower_builder: WB,
         logic_builder: LB,
+        resume_epoch: ResumeEpoch,
         resume_state: StepStateBytes,
     ) -> (
         StatefulStream<S, Result<R, WindowError<V>>>,
@@ -483,6 +486,7 @@ where
         self.stateful_unary(
             step_id,
             WindowStatefulLogic::builder(clock_builder, windower_builder, logic_builder),
+            resume_epoch,
             resume_state,
         )
     }

--- a/src/window/sliding_window.rs
+++ b/src/window/sliding_window.rs
@@ -163,18 +163,19 @@ impl Windower for SlidingWindower {
     /// closed, return them, and remove them from internal state.
     fn drain_closed(&mut self, watermark: &DateTime<Utc>) -> Vec<WindowKey> {
         let mut future_close_times = HashMap::new();
-        let mut closed_ids = Vec::new();
+        let mut closed_keys = Vec::new();
 
-        for (id, close_at) in self.close_times.iter() {
+        for (key, close_at) in self.close_times.iter() {
             if close_at < watermark {
-                closed_ids.push(*id);
+                tracing::trace!("{key:?} closed at {close_at:?}");
+                closed_keys.push(*key);
             } else {
-                future_close_times.insert(*id, *close_at);
+                future_close_times.insert(*key, *close_at);
             }
         }
 
         self.close_times = future_close_times;
-        closed_ids
+        closed_keys
     }
 
     fn is_empty(&self) -> bool {


### PR DESCRIPTION
Attempts to fix https://github.com/bytewax/bytewax/issues/221 which
was due to us using Timely's notificators, which only run logic code
at _the end of an epoch_. This means in our output operators we were
queuing up all data, then writing it out all at once at the end of an
epoch.

Adds a `bytewax::timely` module which contains some low-level
Timely-related stuff. See Rustdocs for details.

- `InBuffer` wraps up that pattern of building a temp vector and using
  `swap` and a `HashMap<u64, Vec<TdPyAny>>` for input buffering by
  epoch.

- `FrontierEx` which is an extension trait which does the proper
  calculations to reduce full antichains into our single "frontier"
  `u64`. This type of code is now centralized here.

- `EagerNotificator` which works similar to a notificator, but you can
  run code even before an epoch is closed.

In general, you always want to use an `EagerNotificator` over a
`Notificator` (unless you are working on the recovery system, and even
then usually you should be eager) because you always want data to be
processed ASAP.

Retrofits the above into all our existing Timely operators which could
use them:

- `PartitionedOutputOp`, uses the eager notificator that is what was
   causing the delayed output in the bug.

- `DynamicOutputOp` shouldn't use a notificator at all because it has
   no state we need to snapshot and so needs no ordering guarantees.

- The recovery operators; they were working correctly before, but by
  processing recovery information eagerly, we might get slightly lower
  memory usage because we don't buffer messages unnecessarily.

Note: we _don't_ use `EagerNotificator` in the "stateful unary"
operator because it needs to use awake times. Adding in awake time
logic into the eager notificator would complicate it a lot for only
being used in windowing. Eventually, I'd like to bake the stateful
awake time logic right into a "window base" operator and build a more
simple "stateful unary" operator that doesn't use awake times as the
core of `reduce` and `stateful_map` to help with debugging.

Then there is one other bug fix thrown in here ensuring windows are
closed promptly. Previously, in "stateful unary" we were only querying
for the next awake time after each snapshot. This is incorrect and was
causing system time windows to only close on epoch
boundaries. Instead, updates the next awake time after each logic
call.

Also adds slightly better trace logging surrounding windows.
