### PR TITLE
Adds --bytewax-log-level to pytest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/flake8

--- a/README.md
+++ b/README.md
@@ -215,3 +215,5 @@ Contributions are welcome! This community and project would not be what it is wi
 <p align="center"> With ❤️ Bytewax</p> 
 <p align="center"><img src="https://user-images.githubusercontent.com/6073079/157482621-331ad886-df3c-4c92-8948-9e50accd38c9.png" /> </p>
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=07749572-3e76-4ac0-952b-d5dcf3bff737" />
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = ["multiprocess>=0.70", "dill>=0.3.5"]
 extras = ["kafka", "dev", "docs", "test"]
 
 [project.optional-dependencies]
-kafka = ["confluent-kafka>=2.0.2"]
+kafka = ["confluent-kafka<=2.0.2"]
 test = ["pytest==7.1.0", "myst-docutils==0.17.0"]
 docs = ["pdoc3==0.10.0"]
 dev = [

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -3,6 +3,21 @@ from pytest import fixture
 
 from bytewax.execution import cluster_main, run_main, spawn_cluster
 from bytewax.recovery import SqliteRecoveryConfig
+from bytewax.tracing import setup_tracing
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--bytewax-log-level",
+        action="store",
+        choices=["ERROR", "WARN", "INFO", "DEBUG", "TRACE"],
+    )
+
+
+def pytest_configure(config):
+    log_level = config.getoption("--bytewax-log-level")
+    if log_level:
+        setup_tracing(log_level=log_level)
 
 
 @fixture


### PR DESCRIPTION
You can now run `pytest --bytewax-log-level=TRACE pytests/` to add the `setup_tracing` call for you, rather than having to shove that into a single test you want to investigate. If you want to show the captured output for a passed test (which is usually suppressed), also add `-rP`.