### PR TITLE
Do not use built-in `hash` for routing

### DIFF
--- a/pysrc/bytewax/connectors/files.py
+++ b/pysrc/bytewax/connectors/files.py
@@ -4,6 +4,7 @@
 import os
 from pathlib import Path
 from typing import Callable
+from zlib import adler32
 
 from bytewax.inputs import PartitionedInput, StatefulSource
 from bytewax.outputs import PartitionedOutput, StatefulSink
@@ -145,7 +146,9 @@ class DirOutput(PartitionedOutput):
 
         assign_file: Will be called with the key of each consumed item
             and must return the file index the value will be written
-            to. Defaults to calling `hash`.
+            to. Will wrap to the file count if you return a larger
+            value. Defaults to calling `zlib.adler32` as a simple
+            globally-consistent hash.
 
         end: String to write after each item. Defaults to `"\n"`.
 
@@ -156,7 +159,7 @@ class DirOutput(PartitionedOutput):
         dir: Path,
         file_count: int,
         file_namer: Callable[[int, int], str] = lambda i, _n: f"part_{i}",
-        assign_file: Callable[[str], int] = hash,
+        assign_file: Callable[[str], int] = adler32,
         end: str = "\n",
     ):
         self._dir = dir

--- a/pysrc/bytewax/outputs.py
+++ b/pysrc/bytewax/outputs.py
@@ -114,6 +114,18 @@ class PartitionedOutput(Output):
         """Define how incoming `(key, value)` pairs should be routed
         to partitions.
 
+        This must be globally consistent and return the same partition
+        assignment on every call.
+
+        .. caution:: Do not use Python's built in `hash` function
+            here! It is [_not consistent between processes by
+            default_](https://docs.python.org/3/using/cmdline.html#cmdoption-R)
+            and using it will cause incorrect partitioning in cluster
+            executions.
+
+            You can start by using `zlib.adler32` as a quick drop-in
+            replacement.
+
         Args:
 
             item_key: Key that is about to be written.


### PR DESCRIPTION
We totally forgot that `hash` is _not_ consistent across Python
process invocations. Thus if we use it for output routing, we won't be
consistently routing data into partitions which breaks the promise of
partitioned output.

Currently our only partitioned output with more than one partition is
`DirOutput`, so makes that default to using `zlib.adler32`, which is a
simple consistent hash function. This will not prevent hash-based DoS,
but if you're concerned about that, you need to take a wholistic
approach to prevention anyway.

Adds a comment to `PartitionedOutput.assign_part` to describe the
dangers of `hash`. This uses `pdoc`'s support for RST admonitions.

Also adds a slightly more descriptive panic message when routing is
inconsistent.

Also changes to calculate the partition key once in a `map` operator
and re-use that, rather than calculate it twice.
