### PR TITLE
Update PyO3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,10 +25,6 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: 1.68.2
-    - name: Install dill
-      shell: bash
-      run: |
-        pip install dill
     - name: Rust tests
       uses: actions-rs/cargo@v1
       with:
@@ -88,6 +84,8 @@ jobs:
 
   macos_x86:
     runs-on: macos-latest
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.9
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
@@ -103,10 +101,6 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install system dependency
-      shell: bash
-      run: |
-        pip install dill
     - name: Rust tests
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -116,7 +116,7 @@ jobs:
       with:
         rust-toolchain: 1.68.2
         command: build
-        args: --release --no-sdist -o dist --interpreter python${{ matrix.python-version }}
+        args: --release -o dist --interpreter python${{ matrix.python-version }}
     - name: Run tests
       shell: bash
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,12 +230,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -581,7 +578,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -946,7 +943,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -2112,17 +2109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "timely"
 version = "0.12.0"
 source = "git+https://github.com/TimelyDataflow/timely-dataflow.git?rev=432ef57#432ef57fae761f1e4773833b0474b41f1efe7e7c"
@@ -2567,12 +2553,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,9 +919,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.17.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201b6887e5576bf2f945fe65172c1fcbf3fcf285b23e4d71eb171d9736e38d32"
+checksum = "e3b1ac5b3731ba34fdaa9785f8d74d17448cd18f30cf19e0c7e7b1fdb5272109"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -1475,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.17.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0708c9ed01692635cbf056e286008e5a2927ab1a5e48cdd3aeb1ba5a6fef47"
+checksum = "9cb946f5ac61bb61a5014924910d936ebd2b23b705f7a4a3c40b05c720b079a3"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1485,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.17.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90352dea4f486932b72ddf776264d293f85b79a1d214de1d023927b41461132d"
+checksum = "fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1495,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.17.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb24b804a2d9e88bfcc480a5a6dd76f006c1e3edaf064e8250423336e2cd79d"
+checksum = "a9d39c55dab3fc5a4b25bbd1ac10a2da452c4aca13bb450f22818a002e29648d"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1507,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.17.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22bb49f6a7348c253d7ac67a6875f2dc65f36c2ae64a82c381d528972bea6d6"
+checksum = "97daff08a4c48320587b5224cc98d609e3c27b6d437315bd40b605c98eeb5918"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bincode = { version = "1.3.3" }
 chrono = { version = "0.4", features = [ "serde" ] }
 futures = { version = "0.3.21" }
 num = { version = "0.4.0" }
-pyo3 = { version = "0.17.2", features = ["macros", "chrono"] }
+pyo3 = { version = "0.18.3", features = ["macros", "chrono"] }
 serde = { version = "1.0.134" }
 serde_test = { version = "1.0.134" }
 sqlx = { version = "0.6.1", features = [ "runtime-tokio-rustls", "postgres", "sqlite", "chrono" ] }
@@ -38,7 +38,7 @@ rdkafka = { version = "0.28.0", features = [ "cmake-build", "gssapi-vendored", "
 rdkafka = { version = "0.28.0", features = [ "cmake-build", "gssapi", "ssl" ] }
 
 [dev-dependencies]
-pyo3 = { version = "0.17.2", default-features = false, features = ["macros", "chrono"] }
+pyo3 = { version = "0.18.3", default-features = false, features = ["macros", "chrono"] }
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,10 @@ edition = "2021"
 name = "bytewax"
 crate-type = ["cdylib", "rlib"]
 
-[package.metadata.maturin]
-python-source = "pysrc"
-
 [dependencies]
 axum = { version = "0.5.17" }
 bincode = { version = "1.3.3" }
-chrono = { version = "0.4", features = [ "serde" ] }
+chrono = { version = "0.4", default_features = false, features = [ "serde" ] }
 futures = { version = "0.3.21" }
 num = { version = "0.4.0" }
 pyo3 = { version = "0.18.3", features = ["macros", "chrono"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.12,<0.13"]
+requires = ["maturin>=0.13,<=0.15.1"]
 build-backend = "maturin"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,5 @@ testpaths = [
     "docs",
 ]
 
+[tool.maturin]
+python-source = "pysrc"

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -73,7 +73,7 @@ impl Dataflow {
     ///   step_id (str): Uniquely identifies this step for recovery.
     ///
     ///   input (bytewax.inputs.Input): Input definition.
-    #[pyo3(text_signature = "(self, step_id, input)")]
+    #[pyo3(signature = (step_id, input))]
     fn input(&mut self, step_id: StepId, input: Input) {
         self.steps.push(Step::Input { step_id, input });
     }
@@ -93,7 +93,7 @@ impl Dataflow {
     ///   step_id (str): Uniquely identifies this step for recovery.
     ///
     ///   output (bytewax.outputs.Output): Output definition.
-    #[pyo3(text_signature = "(self, step_id, output)")]
+    #[pyo3(signature = (step_id, output))]
     fn output(&mut self, step_id: StepId, output: Output) {
         self.steps.push(Step::Output { step_id, output });
     }
@@ -130,7 +130,7 @@ impl Dataflow {
     /// Args:
     ///
     ///   predicate: `predicate(item: Any) => should_emit: bool`
-    #[pyo3(text_signature = "(self, predicate)")]
+    #[pyo3(signature = (predicate))]
     fn filter(&mut self, predicate: TdPyCallable) {
         self.steps.push(Step::Filter { predicate });
     }
@@ -148,7 +148,7 @@ impl Dataflow {
     /// ...
     /// >>> flow.filter_map(validate)
     ///
-    #[pyo3(text_signature = "(self, mapper)")]
+    #[pyo3(signature = (mapper))]
     fn filter_map(&mut self, mapper: TdPyCallable) {
         self.steps.push(Step::FilterMap { mapper });
     }
@@ -184,7 +184,7 @@ impl Dataflow {
     /// Args:
     ///
     ///   mapper: `mapper(item: Any) => emit: Iterable[Any]`
-    #[pyo3(text_signature = "(self, mapper)")]
+    #[pyo3(signature = (mapper))]
     fn flat_map(&mut self, mapper: TdPyCallable) {
         self.steps.push(Step::FlatMap { mapper });
     }
@@ -215,7 +215,7 @@ impl Dataflow {
     /// Args:
     ///
     ///   inspector: `inspector(item: Any) => None`
-    #[pyo3(text_signature = "(self, inspector)")]
+    #[pyo3(signature = (inspector))]
     fn inspect(&mut self, inspector: TdPyCallable) {
         self.steps.push(Step::Inspect { inspector });
     }
@@ -248,7 +248,7 @@ impl Dataflow {
     /// Args:
     ///
     ///   inspector: `inspector(epoch: int, item: Any) => None`
-    #[pyo3(text_signature = "(self, inspector)")]
+    #[pyo3(signature = (inspector))]
     fn inspect_epoch(&mut self, inspector: TdPyCallable) {
         self.steps.push(Step::InspectEpoch { inspector });
     }
@@ -282,7 +282,7 @@ impl Dataflow {
     /// Args:
     ///
     ///   mapper: `mapper(item: Any) => updated_item: Any`
-    #[pyo3(text_signature = "(self, mapper)")]
+    #[pyo3(signature = (mapper))]
     fn map(&mut self, mapper: TdPyCallable) {
         self.steps.push(Step::Map { mapper });
     }
@@ -357,7 +357,7 @@ impl Dataflow {
     ///
     ///   is_complete: `is_complete(updated_accumulator: Any) =>
     ///       should_emit: bool`
-    #[pyo3(text_signature = "(self, step_id, reducer, is_complete)")]
+    #[pyo3(signature = (step_id, reducer, is_complete))]
     fn reduce(&mut self, step_id: StepId, reducer: TdPyCallable, is_complete: TdPyCallable) {
         self.steps.push(Step::Reduce {
             step_id,
@@ -438,7 +438,7 @@ impl Dataflow {
     ///   builder: `builder(key: Any) => initial_accumulator: Any`
     ///
     ///   folder: `folder(accumulator: Any, value: Any) => updated_accumulator: Any`
-    #[pyo3(text_signature = "(self, step_id, clock_config, window_config, builder, folder)")]
+    #[pyo3(signature = (step_id, clock_config, window_config, builder, folder))]
     fn fold_window(
         &mut self,
         step_id: StepId,
@@ -530,7 +530,7 @@ impl Dataflow {
     ///
     ///   reducer: `reducer(accumulator: Any, value: Any) =>
     ///       updated_accumulator: Any`
-    #[pyo3(text_signature = "(self, step_id, clock_config, window_config, reducer)")]
+    #[pyo3(signature = (step_id, clock_config, window_config, reducer))]
     fn reduce_window(
         &mut self,
         step_id: StepId,
@@ -570,7 +570,7 @@ impl Dataflow {
     ///
     ///   window_config (bytewax.window.WindowConfig): Windower
     ///       config to use. See `bytewax.window`.
-    #[pyo3(text_signature = "(self, step_id, clock_config, window_config)")]
+    #[pyo3(signature = (step_id, clock_config, window_config))]
     fn collect_window(
         &mut self,
         step_id: StepId,
@@ -657,7 +657,7 @@ impl Dataflow {
     ///
     ///   mapper: `mapper(state: Any, value: Any) => (updated_state:
     ///       Any, updated_value: Any)`
-    #[pyo3(text_signature = "(self, step_id, builder, mapper)")]
+    #[pyo3(signature = (step_id, builder, mapper))]
     fn stateful_map(&mut self, step_id: StepId, builder: TdPyCallable, mapper: TdPyCallable) {
         self.steps.push(Step::StatefulMap {
             step_id,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -83,7 +83,7 @@ macro_rules! log_func {
 /// add_pymethods!(
 ///     SlidingWindow,
 ///     parent: WindowConfig,
-///     py_args: (length,),
+///     signature: (length),
 ///     args {
 ///         length: Duration => Duration::zero()
 ///     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -92,13 +92,13 @@ macro_rules! log_func {
 macro_rules! add_pymethods {(
     $struct:ident,
     parent: $parent:ident,
-    py_args: $py_args:tt,
+    signature: $signature:tt,
     args { $($arg:ident: $arg_type:ty => $default:expr),* }
 ) => {
     #[pyo3::pymethods]
     impl $struct {
         #[new]
-        #[args $py_args ]
+        #[pyo3(signature=$signature)]
         pub(crate) fn py_new($($arg: $arg_type),*) -> (Self, $parent) {
             (Self { $($arg),* }, $parent {})
         }

--- a/src/recovery/python.rs
+++ b/src/recovery/python.rs
@@ -118,7 +118,7 @@ pub(crate) struct NoopRecoveryConfig;
 add_pymethods!(
     NoopRecoveryConfig,
     parent: RecoveryConfig,
-    py_args: (),
+    signature: (),
     args {}
 );
 
@@ -187,7 +187,6 @@ impl RecoveryBuilder for NoopRecoveryConfig {
 ///   Config object. Pass this as the `recovery_config` argument to
 ///   your execution entry point.
 #[pyclass(module="bytewax.recovery", extends=RecoveryConfig)]
-#[pyo3(text_signature = "(db_dir)")]
 #[derive(Clone)]
 pub(crate) struct SqliteRecoveryConfig {
     #[pyo3(get)]
@@ -197,7 +196,7 @@ pub(crate) struct SqliteRecoveryConfig {
 add_pymethods!(
     SqliteRecoveryConfig,
     parent: RecoveryConfig,
-    py_args: (db_dir),
+    signature: (db_dir),
     args {
         db_dir: PathBuf => String::new().into()
     }
@@ -306,7 +305,7 @@ pub(crate) struct KafkaRecoveryConfig {
 add_pymethods!(
     KafkaRecoveryConfig,
     parent: RecoveryConfig,
-    py_args: (brokers, topic_prefix),
+    signature: (brokers, topic_prefix),
     args {
         brokers: Vec<String> => Vec::new(),
         topic_prefix: String => String::new()

--- a/src/run.rs
+++ b/src/run.rs
@@ -100,7 +100,7 @@ fn start_server_runtime(df: &Py<Dataflow>) -> PyResult<Runtime> {
 ///       `bytewax.recovery`. If `None`, state will not be
 ///       persisted.
 ///
-#[pyfunction(flow, "*", epoch_interval = "None", recovery_config = "None")]
+#[pyfunction]
 #[pyo3(text_signature = "(flow, *, epoch_interval, recovery_config)")]
 pub(crate) fn run_main(
     py: Python,
@@ -200,16 +200,9 @@ pub(crate) fn run_main(
 ///
 ///   worker_count_per_proc: Number of worker threads to start on
 ///       each process.
-#[pyfunction(
-    flow,
-    addresses,
-    proc_id,
-    "*",
-    epoch_interval = "None",
-    recovery_config = "None",
-    worker_count_per_proc = "1"
-)]
+#[pyfunction]
 #[pyo3(
+    signature = (flow, addresses, proc_id, *, epoch_interval = None, recovery_config = None, worker_count_per_proc = 1),
     text_signature = "(flow, addresses, proc_id, *, epoch_interval, recovery_config, worker_count_per_proc)"
 )]
 pub(crate) fn cluster_main(
@@ -322,15 +315,18 @@ pub(crate) fn cluster_main(
 
 /// This is only supposed to be used through `python -m
 /// bytewax.run`. See the module docstring for use.
-#[pyfunction(
-    flow,
-    "*",
-    processes = 1,
-    workers_per_process = 1,
-    process_id = "None",
-    addresses = "None",
-    epoch_interval = "None",
-    recovery_config = "None"
+#[pyfunction]
+#[pyo3(
+    signature = (
+        flow,
+        *,
+        processes = 1,
+        workers_per_process = 1,
+        process_id = None,
+        addresses = None,
+        epoch_interval = None,
+        recovery_config = None
+    )
 )]
 pub(crate) fn cli_main(
     py: Python,

--- a/src/run.rs
+++ b/src/run.rs
@@ -101,7 +101,10 @@ fn start_server_runtime(df: &Py<Dataflow>) -> PyResult<Runtime> {
 ///       persisted.
 ///
 #[pyfunction]
-#[pyo3(text_signature = "(flow, *, epoch_interval, recovery_config)")]
+#[pyo3(
+    signature = (flow, *, epoch_interval = None, recovery_config = None),
+    text_signature = "(flow, *, epoch_interval = None, recovery_config = None)",
+)]
 pub(crate) fn run_main(
     py: Python,
     flow: Py<Dataflow>,
@@ -203,7 +206,7 @@ pub(crate) fn run_main(
 #[pyfunction]
 #[pyo3(
     signature = (flow, addresses, proc_id, *, epoch_interval = None, recovery_config = None, worker_count_per_proc = 1),
-    text_signature = "(flow, addresses, proc_id, *, epoch_interval, recovery_config, worker_count_per_proc)"
+    text_signature = "(flow, addresses, proc_id, *, epoch_interval = None, recovery_config = None, worker_count_per_proc = 1)"
 )]
 pub(crate) fn cluster_main(
     py: Python,
@@ -317,16 +320,8 @@ pub(crate) fn cluster_main(
 /// bytewax.run`. See the module docstring for use.
 #[pyfunction]
 #[pyo3(
-    signature = (
-        flow,
-        *,
-        processes = 1,
-        workers_per_process = 1,
-        process_id = None,
-        addresses = None,
-        epoch_interval = None,
-        recovery_config = None
-    )
+    signature=(flow, *, processes=1, workers_per_process=1, process_id=None, addresses=None, epoch_interval=None, recovery_config=None),
+    text_signature="(flow, *, processes=1, workers_per_process=1, process_id=None, addresses=None, epoch_interval=None, recovery_config=None)"
 )]
 pub(crate) fn cli_main(
     py: Python,

--- a/src/tracing/jaeger_tracing.rs
+++ b/src/tracing/jaeger_tracing.rs
@@ -58,7 +58,7 @@ impl TracerBuilder for JaegerConfig {
 add_pymethods!(
     JaegerConfig,
     parent: TracingConfig,
-    py_args: (service_name, endpoint, sampling_ratio = "None"),
+    signature: (service_name, endpoint=None, sampling_ratio=None),
     args {
         service_name: String => String::new(),
         endpoint: Option<String> => None,

--- a/src/tracing/jaeger_tracing.rs
+++ b/src/tracing/jaeger_tracing.rs
@@ -23,7 +23,7 @@ use super::{TracerBuilder, TracingConfig};
 /// If a config option is passed to JaegerConfig,
 /// it takes precedence over env vars.
 #[pyclass(module="bytewax.tracing", extends=TracingConfig)]
-#[pyo3(text_signature = "(service_name, endpoint, sampling_ratio=1.0)")]
+#[pyo3(text_signature = "(service_name, endpoint = None, sampling_ratio = 1.0)")]
 #[derive(Clone)]
 pub(crate) struct JaegerConfig {
     /// Service name, identifies this dataflow.
@@ -34,16 +34,16 @@ pub(crate) struct JaegerConfig {
     ///   samplig_ratio >= 1 - all traces are sampled
     ///   samplig_ratio <= 0 - most traces are not sampled
     #[pyo3(get)]
-    pub(crate) sampling_ratio: Option<f64>,
+    pub(crate) sampling_ratio: f64,
 }
 
 impl TracerBuilder for JaegerConfig {
     fn build(&self) -> PyResult<Tracer> {
         opentelemetry::global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
         let mut tracer = opentelemetry_jaeger::new_agent_pipeline()
-            .with_trace_config(config().with_sampler(Sampler::TraceIdRatioBased(
-                self.sampling_ratio.unwrap_or(1.0),
-            )))
+            .with_trace_config(
+                config().with_sampler(Sampler::TraceIdRatioBased(self.sampling_ratio)),
+            )
             .with_service_name(self.service_name.clone());
 
         // Overwrite the endpoint if needed
@@ -58,10 +58,10 @@ impl TracerBuilder for JaegerConfig {
 add_pymethods!(
     JaegerConfig,
     parent: TracingConfig,
-    signature: (service_name, endpoint=None, sampling_ratio=None),
+    signature: (service_name, endpoint=None, sampling_ratio=1.0),
     args {
         service_name: String => String::new(),
         endpoint: Option<String> => None,
-        sampling_ratio: Option<f64> => None
+        sampling_ratio: f64 => 1.0
     }
 );

--- a/src/tracing/otlp_tracing.rs
+++ b/src/tracing/otlp_tracing.rs
@@ -36,7 +36,7 @@ pub(crate) struct OtlpTracingConfig {
     ///   samplig_ratio >= 1 - all traces are sampled
     ///   samplig_ratio <= 0 - most traces are not sampled
     #[pyo3(get)]
-    pub(crate) sampling_ratio: Option<f64>,
+    pub(crate) sampling_ratio: f64,
 }
 
 impl TracerBuilder for OtlpTracingConfig {
@@ -55,9 +55,7 @@ impl TracerBuilder for OtlpTracingConfig {
             .with_exporter(exporter)
             .with_trace_config(
                 config()
-                    .with_sampler(Sampler::TraceIdRatioBased(
-                        self.sampling_ratio.unwrap_or(1.0),
-                    ))
+                    .with_sampler(Sampler::TraceIdRatioBased(self.sampling_ratio))
                     .with_resource(Resource::new(vec![KeyValue::new(
                         "service.name",
                         self.service_name.clone(),
@@ -71,10 +69,10 @@ impl TracerBuilder for OtlpTracingConfig {
 add_pymethods!(
     OtlpTracingConfig,
     parent: TracingConfig,
-    signature: (service_name, url=None, sampling_ratio=None),
+    signature: (service_name, url=None, sampling_ratio=1.0),
     args {
         service_name: String => String::new(),
         url: Option<String> => None,
-        sampling_ratio: Option<f64> => None
+        sampling_ratio: f64 => 1.0
     }
 );

--- a/src/tracing/otlp_tracing.rs
+++ b/src/tracing/otlp_tracing.rs
@@ -71,7 +71,7 @@ impl TracerBuilder for OtlpTracingConfig {
 add_pymethods!(
     OtlpTracingConfig,
     parent: TracingConfig,
-    py_args: (service_name, url, sampling_ratio = "None"),
+    signature: (service_name, url=None, sampling_ratio=None),
     args {
         service_name: String => String::new(),
         url: Option<String> => None,

--- a/src/window/clock/event_time_clock.rs
+++ b/src/window/clock/event_time_clock.rs
@@ -68,7 +68,7 @@ impl ClockBuilder<TdPyAny> for EventClockConfig {
 add_pymethods!(
     EventClockConfig,
     parent: ClockConfig,
-    signature: (dt_getter, wait_for_system_duration=Duration::zero()),
+    signature: (dt_getter, wait_for_system_duration),
     args {
         dt_getter: TdPyCallable => Python::with_gil(TdPyCallable::pickle_new),
         wait_for_system_duration: Duration => Duration::zero()

--- a/src/window/clock/event_time_clock.rs
+++ b/src/window/clock/event_time_clock.rs
@@ -68,7 +68,7 @@ impl ClockBuilder<TdPyAny> for EventClockConfig {
 add_pymethods!(
     EventClockConfig,
     parent: ClockConfig,
-    py_args: (dt_getter, wait_for_system_duration),
+    signature: (dt_getter, wait_for_system_duration=Duration::zero()),
     args {
         dt_getter: TdPyCallable => Python::with_gil(TdPyCallable::pickle_new),
         wait_for_system_duration: Duration => Duration::zero()

--- a/src/window/clock/system_clock.rs
+++ b/src/window/clock/system_clock.rs
@@ -30,7 +30,12 @@ impl<V> ClockBuilder<V> for SystemClockConfig {
     }
 }
 
-add_pymethods!(SystemClockConfig, parent: ClockConfig, py_args: (), args {});
+add_pymethods!(
+    SystemClockConfig,
+    parent: ClockConfig,
+    signature: (),
+    args {}
+);
 
 /// Use the current system time.
 pub(crate) struct SystemClock {

--- a/src/window/session_window.rs
+++ b/src/window/session_window.rs
@@ -35,7 +35,7 @@ impl WindowBuilder for SessionWindow {
 add_pymethods!(
     SessionWindow,
     parent: WindowConfig,
-    signature: (gap=Duration::zero()),
+    signature: (gap),
     args {
         gap: Duration => Duration::zero()
     }

--- a/src/window/session_window.rs
+++ b/src/window/session_window.rs
@@ -35,7 +35,7 @@ impl WindowBuilder for SessionWindow {
 add_pymethods!(
     SessionWindow,
     parent: WindowConfig,
-    py_args: (gap),
+    signature: (gap=Duration::zero()),
     args {
         gap: Duration => Duration::zero()
     }

--- a/src/window/sliding_window.rs
+++ b/src/window/sliding_window.rs
@@ -52,7 +52,7 @@ pub(crate) struct SlidingWindow {
 add_pymethods!(
     SlidingWindow,
     parent: WindowConfig,
-    signature: (length=Duration::zero(), offset=Duration::zero(), align_to=DateTime::<Utc>::MIN_UTC),
+    signature: (length, offset, align_to),
     args {
         length: Duration => Duration::zero(),
         offset: Duration => Duration::zero(),

--- a/src/window/sliding_window.rs
+++ b/src/window/sliding_window.rs
@@ -52,7 +52,7 @@ pub(crate) struct SlidingWindow {
 add_pymethods!(
     SlidingWindow,
     parent: WindowConfig,
-    py_args: (length, offset, align_to),
+    signature: (length=Duration::zero(), offset=Duration::zero(), align_to=DateTime::<Utc>::MIN_UTC),
     args {
         length: Duration => Duration::zero(),
         offset: Duration => Duration::zero(),

--- a/src/window/tumbling_window.rs
+++ b/src/window/tumbling_window.rs
@@ -47,7 +47,7 @@ impl WindowBuilder for TumblingWindow {
 add_pymethods!(
     TumblingWindow,
     parent: WindowConfig,
-    py_args: (length, align_to),
+    signature: (length, align_to),
     args {
         length: Duration => Duration::zero(),
         align_to: DateTime<Utc> => DateTime::<Utc>::MIN_UTC


### PR DESCRIPTION
Updates PyO3 to 0.18.3

There may be a better way to unpack `args` within `add_pymethods!` that removes the need to write out both `args` and `signature`, but my macro skills are sadly not up to the task.