### PR TITLE
Spread operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "axum 0.5.17",
  "bincode",
  "chrono",
+ "fastrand",
  "futures",
  "num",
  "openssl-src",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ opentelemetry-jaeger = { version = "0.17", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.11", features = ["trace", "reqwest-client", "grpc-tonic"] }
 tracing-opentelemetry = "0.18"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+fastrand = "1.9.0"
 
 # For macos, use vendored gssapi
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -78,6 +78,47 @@ impl Dataflow {
         self.steps.push(Step::Input { step_id, input });
     }
 
+    /// Spread the work across workers, in a randomic way.
+    ///
+    /// This operators takes each item and sends it to
+    /// one of the available workers.
+    /// This operation has a overhead, since it will need
+    /// to serialize, send, and deserialize the items,
+    /// so while it can significantly speed up the
+    /// execution in some cases, it can also make it slower.
+    ///
+    /// A good use of this operator is to parallelize an IO
+    /// bound step, like a network request, or a heavy,
+    /// single-cpu workload, on a machine with multiple
+    /// workers and multiple cpu cores that would remain
+    /// unused otherwise.
+    ///
+    /// A bad use of this operator is if the operation you want
+    /// to parallelize is already really fast as it is, as the
+    /// overhead can overshadow the advantages of distributing
+    /// the work.
+    /// Another case where we see a regression in performance is
+    /// if the heavy CPU workload already spawns enough threads
+    /// to use all the available cores. In this case multiple
+    /// processes trying to compete for the cpu will end up being
+    /// slower than doing the work serially.
+    /// If the workers run on different machines though, it might
+    /// again be a valuable use of the operator.
+    ///
+    /// So, use this operator with caution, and measure whether you
+    /// get an improvement out of it.
+    ///
+    /// Once the work has been spread to another worker, it will
+    /// stay on that worker unless other operators explicitely
+    /// move the item again (usually this happens on the output).
+    fn spread_to_random_workers(&mut self) {
+        self.steps.push(Step::SpreadToRandomWorkers);
+    }
+
+    fn send_to_worker(&mut self, worker_id: u64) {
+        self.steps.push(Step::SendToWorker { worker_id });
+    }
+
     /// Write data to an output.
     ///
     /// At least one output is required on every dataflow.
@@ -251,6 +292,11 @@ impl Dataflow {
     #[pyo3(signature = (inspector))]
     fn inspect_epoch(&mut self, inspector: TdPyCallable) {
         self.steps.push(Step::InspectEpoch { inspector });
+    }
+
+    #[pyo3(text_signature = "(self, inspector)")]
+    fn inspect_worker(&mut self, inspector: TdPyCallable) {
+        self.steps.push(Step::InspectWorker { inspector });
     }
 
     /// Map is a one-to-one transformation of items.
@@ -676,6 +722,10 @@ impl Dataflow {
 /// for Timely's operators. We try to keep the same semantics here.
 #[derive(Clone)]
 pub(crate) enum Step {
+    SpreadToRandomWorkers,
+    SendToWorker {
+        worker_id: u64,
+    },
     Input {
         step_id: StepId,
         input: Input,
@@ -700,6 +750,9 @@ pub(crate) enum Step {
         folder: TdPyCallable,
     },
     Inspect {
+        inspector: TdPyCallable,
+    },
+    InspectWorker {
         inspector: TdPyCallable,
     },
     InspectEpoch {
@@ -769,6 +822,9 @@ impl<'source> FromPyObject<'source> for Step {
             "Inspect" => Ok(Self::Inspect {
                 inspector: pickle_extract(dict, "inspector")?,
             }),
+            "InspectWorker" => Ok(Self::InspectWorker {
+                inspector: pickle_extract(dict, "inspector")?,
+            }),
             "InspectEpoch" => Ok(Self::InspectEpoch {
                 inspector: pickle_extract(dict, "inspector")?,
             }),
@@ -811,6 +867,14 @@ impl<'source> FromPyObject<'source> for Step {
 impl IntoPy<PyObject> for Step {
     fn into_py(self, py: Python) -> Py<PyAny> {
         match self {
+            Self::SpreadToRandomWorkers => {
+                HashMap::from([("type", IntoPy::<PyObject>::into_py("Broadcast", py))]).into_py(py)
+            }
+            Self::SendToWorker { worker_id } => HashMap::from([
+                ("type", "Broadcast".into_py(py)),
+                ("worker_id", worker_id.into_py(py)),
+            ])
+            .into_py(py),
             Self::Input { step_id, input } => HashMap::from([
                 ("type", "Input".into_py(py)),
                 ("step_id", step_id.into_py(py)),
@@ -852,6 +916,11 @@ impl IntoPy<PyObject> for Step {
             ])
             .into_py(py),
             Self::Inspect { inspector } => HashMap::from([
+                ("type", "Inspect".into_py(py)),
+                ("inspector", inspector.into_py(py)),
+            ])
+            .into_py(py),
+            Self::InspectWorker { inspector } => HashMap::from([
                 ("type", "Inspect".into_py(py)),
                 ("inspector", inspector.into_py(py)),
             ])

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -313,26 +313,6 @@ impl PartitionedInput {
             }
         });
 
-        // Re-balance input if we have a small number of
-        // partitions. This will be a slight performance
-        // penalty if there are no CPU-heavy tasks, but it
-        // seems more intuitive to have all workers
-        // contribute.
-        let output_stream = if bundle_size < count.0 {
-            tracing::info!("Worker count < partition count; activating random load-balancing for input {step_id:?}");
-            // TODO: Could do this via `let mut counter =
-            // 0` when PR to make this FnMut lands in
-            // Timely stable.
-            let counter = Cell::new(0 as u64);
-            output_stream.exchange(move |_item| {
-                let next = counter.get().wrapping_add(1);
-                counter.set(next);
-                next
-            })
-        } else {
-            output_stream
-        };
-
         Ok((output_stream, change_stream))
     }
 }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -13,6 +13,7 @@ use crate::errors::PythonException;
 use crate::pyo3_extensions::{TdPyAny, TdPyCallable, TdPyIterator};
 use crate::try_unwrap;
 use crate::unwrap_any;
+use crate::worker::WorkerIndex;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 
@@ -63,6 +64,15 @@ pub(crate) fn inspect(inspector: &TdPyCallable, item: &TdPyAny) {
     Python::with_gil(|py| {
         unwrap_any!(inspector
             .call1(py, (item,))
+            .reraise("error calling `inspect` inspector"))
+    });
+}
+
+#[tracing::instrument(level = "trace")]
+pub(crate) fn inspect_worker(inspector: &TdPyCallable, item: &TdPyAny, worker_index: &WorkerIndex) {
+    Python::with_gil(|py| {
+        unwrap_any!(inspector
+            .call1(py, (worker_index.into_py(py), item,))
             .reraise("error calling `inspect` inspector"))
     });
 }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -69,11 +69,11 @@ pub(crate) fn inspect(inspector: &TdPyCallable, item: &TdPyAny) {
 }
 
 #[tracing::instrument(level = "trace")]
-pub(crate) fn inspect_worker(inspector: &TdPyCallable, item: &TdPyAny, worker_index: &WorkerIndex) {
+pub(crate) fn inspect_worker(inspector: &TdPyCallable, worker_index: &WorkerIndex, item: &TdPyAny) {
     Python::with_gil(|py| {
         unwrap_any!(inspector
             .call1(py, (worker_index.into_py(py), item,))
-            .reraise("error calling `inspect` inspector"))
+            .reraise("error calling `inspect_worker` inspector"))
     });
 }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -344,7 +344,7 @@ where
             match step {
                 Step::Redistribute => {
                     let count = worker_count.0 as u64;
-                    stream = stream.exchange(move |_| fastrand::u64(0..=count))
+                    stream = stream.exchange(move |_| fastrand::u64(0..count))
                 }
                 Step::CollectWindow {
                     step_id,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -482,7 +482,7 @@ where
                 }
                 Step::InspectWorker { inspector } => {
                     stream =
-                        stream.inspect(move |item| inspect_worker(&inspector, item, &worker_index));
+                        stream.inspect(move |item| inspect_worker(&inspector, &worker_index, item));
                 }
                 Step::InspectEpoch { inspector } => {
                     stream = stream

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -342,10 +342,9 @@ where
             // for a while when it's moved into the closure.
             let step = step.clone();
             match step {
-                Step::Redistribute => {
-                    let count = worker_count.0 as u64;
-                    stream = stream.exchange(move |_| fastrand::u64(0..count))
-                }
+                // The exchange operator wraps the number to a modulo of workers_count,
+                // so we can pass any valid u64 without specifying the range.
+                Step::Redistribute => stream = stream.exchange(move |_| fastrand::u64(..)),
                 Step::CollectWindow {
                     step_id,
                     clock_config,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -342,13 +342,9 @@ where
             // for a while when it's moved into the closure.
             let step = step.clone();
             match step {
-                Step::SpreadToRandomWorkers => {
+                Step::Redistribute => {
                     let count = worker_count.0 as u64;
                     stream = stream.exchange(move |_| fastrand::u64(0..=count))
-                }
-                Step::SendToWorker { worker_id } => {
-                    let count = worker_count.0 as u64;
-                    stream = stream.exchange(move |_| worker_id % count)
                 }
                 Step::CollectWindow {
                     step_id,


### PR DESCRIPTION
## Items flow
This PR is a proposal for 3 new operators:
- `flow.spread_to_random_workers()`
- `flow.send_to_worker(<worker_id>)`
- `flow.inspect_worker(...)`

The 2 operators allow users to have some control over where the work is done (outside of the input partitioning system).

### spread_to_random_workers
This operator sends each item to one of the available workers, chosen at random.

The need for this operator arised when writing a dataflow that uses an input source that creates a single partition for each url in a list. The dataflow would then extract a number of urls from each page, and make a request for each of the urls extracted.
There is currently now way to spread to IO bound work on multiple workers in the middle of a dataflow, so even if the dataflow was running on 16 different processes, the maximum parallelization achievable was still determined by the number of input partitions, and I ended up having a lot of workers unused.
Using this operator before the `map` step that makes the request allowed the dataflow to get results faster by just adding more workers (or processes) to the execution, and parallelizing the network requests.

### send_to_worker
This operator sends items to a specific worker.

It can be useful if a dataflow is running on multiple machines with different characteristcs, so that you can send a specific `map` operation to the only machine with access to a GPU.
Another use of the operator is to "serialize" a subset of the dataflow's execution, which can be useful when running a cluster on a single machine, and the operator internally spawn many threads to do CPU heavy computation (for example with numpy), in which case having multiple workers could cause contention on CPU cycles and slow down the execution.

### inspect_worker
This is an operator useful for debugging, just like `inspect_epoch` adds the `epoch` value to the function used to inspect the item, this one adds the `worker_index` so we can log where the operator is being ran.


### Ideas
The 2 operators could be merged into a single one: 
- `flow.send_to_workers(ids: Optional[list[int]])`

 If used without parameters, it behaves like `spread_to_random_workers`, if passed a list of ids it behaves similarly to `send_to_worker`, but with the possibility to send the work to a subset of the workers instead of always the same.
This might make the api a bit less intuitive though.

Also the naming of the operators is up for a debate, let me know if you have better ideas.
