### PR TITLE
Fix encoder if a class is passed

### DIFF
--- a/pysrc/bytewax/_encoder.py
+++ b/pysrc/bytewax/_encoder.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import types
+import inspect
 
 from .bytewax import Dataflow
 
@@ -18,6 +19,13 @@ class DataflowEncoder(json.JSONEncoder):
     def default(self, obj):
         if hasattr(obj, "__json__"):
             return obj.__json__()
+
+        # Check if the object is a class, and return its name.
+        # If the object is a class the call to __getstate__ below
+        # WILL fail since we are not passing a `self` parameter.
+        if inspect.isclass(obj):
+            return obj.__qualname__
+
         # Python 3.11 added __getstate__ to the 'object' type,
         # but for some objects the result is `None`.
         # In those cases, it's probably better to try other options,

--- a/pytests/test_encoder.py
+++ b/pytests/test_encoder.py
@@ -22,6 +22,25 @@ class OrderBook:
         self.data.append(data)
 
 
+def test_encoding_custom_object():
+    flow = Dataflow()
+    flow.stateful_map("avg", OrderBook, OrderBook.update)
+    assert encode_dataflow(flow) == json.dumps(
+        {
+            "type": "Dataflow",
+            "steps": [
+                {
+                    "type": "StatefulMap",
+                    "builder": "OrderBook",
+                    "mapper": "update",
+                    "step_id": "avg",
+                }
+            ],
+        },
+        sort_keys=True,
+    )
+
+
 def test_encoding_custom_input():
     flow = Dataflow()
 


### PR DESCRIPTION
Our encoder fails if a class is passed as an argument to one of the operators, because we try to call `obj.__getstate__()`, and the class doesn't pass the `self` parameter in this case.

That can happen if we want to use a class `__init__` method in an operator:
```python
class Device:
    def __init__(self):
        ...
    def update_avg(self, data):
        ...

flow.stateful_map("average", Device, Device.update_avg)
```

Here we implicitely want to use `Device.__init__`, but we are passing the class `Device` itself to the operator.  When we try to encode it, we try to call `obj.__getstate__()`, but that fails since we are not passing an instance.

This fix prevents that by returning the name of the class if the passed object is, in fact, a class