### PR TITLE
Batch input take 2

### DIFF
--- a/pysrc/bytewax/connectors/kafka.py
+++ b/pysrc/bytewax/connectors/kafka.py
@@ -122,6 +122,11 @@ class KafkaInput(PartitionedInput):
             documentation](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md)
             for options.
 
+        batch_size: How many messages to consume at most at each poll.
+            This is 1 by default, which means messages will be consumed
+            one at a time. The default setting is suited for lower latency,
+            but negatively affects throughput. If you need higher
+            throughput, set this to a higher value (eg: 1000)
     """
 
     def __init__(

--- a/pysrc/bytewax/connectors/kafka.py
+++ b/pysrc/bytewax/connectors/kafka.py
@@ -43,7 +43,14 @@ def _list_parts(client, topics):
 
 class _KafkaSource(StatefulSource):
     def __init__(
-        self, consumer, topic, part_idx, starting_offset, resume_state, batch_size
+        self,
+        consumer,
+        topic,
+        part_idx,
+        starting_offset,
+        resume_state,
+        batch_size,
+        timeout,
     ):
         self._offset = resume_state or starting_offset
         # Assign does not activate consumer grouping.
@@ -51,9 +58,10 @@ class _KafkaSource(StatefulSource):
         self._consumer = consumer
         self._topic = topic
         self._batch_size = batch_size
+        self._timeout = timeout
 
     def next(self):
-        msgs = self._consumer.consume(self._batch_size, 0.001)
+        msgs = self._consumer.consume(self._batch_size, self._timeout)
         if msgs is None:
             return
         result = []
@@ -117,6 +125,7 @@ class KafkaInput(PartitionedInput):
         starting_offset: int = OFFSET_BEGINNING,
         add_config: Dict[str, str] = None,
         batch_size: int = 1,
+        timeout: float = 0.001,
     ):
         add_config = add_config or {}
 
@@ -130,6 +139,7 @@ class KafkaInput(PartitionedInput):
         self._starting_offset = starting_offset
         self._add_config = add_config
         self._batch_size = batch_size
+        self._timeout = timeout
 
     def list_parts(self):
         config = {
@@ -165,6 +175,7 @@ class KafkaInput(PartitionedInput):
             self._starting_offset,
             resume_state,
             self._batch_size,
+            self._timeout,
         )
 
 

--- a/pysrc/bytewax/connectors/kafka.py
+++ b/pysrc/bytewax/connectors/kafka.py
@@ -50,7 +50,6 @@ class _KafkaSource(StatefulSource):
         starting_offset,
         resume_state,
         batch_size,
-        timeout,
     ):
         self._offset = resume_state or starting_offset
         # Assign does not activate consumer grouping.
@@ -58,16 +57,13 @@ class _KafkaSource(StatefulSource):
         self._consumer = consumer
         self._topic = topic
         self._batch_size = batch_size
-        self._timeout = timeout
         self._eof = False
 
     def next(self):
         if self._eof:
             raise StopIteration()
 
-        msgs = self._consumer.consume(self._batch_size, self._timeout)
-        if msgs is None:
-            return
+        msgs = self._consumer.consume(self._batch_size, 0.001)
 
         result = []
         for msg in msgs:
@@ -136,7 +132,6 @@ class KafkaInput(PartitionedInput):
         starting_offset: int = OFFSET_BEGINNING,
         add_config: Dict[str, str] = None,
         batch_size: int = 1,
-        timeout: float = 0.001,
     ):
         add_config = add_config or {}
 
@@ -150,7 +145,6 @@ class KafkaInput(PartitionedInput):
         self._starting_offset = starting_offset
         self._add_config = add_config
         self._batch_size = batch_size
-        self._timeout = timeout
 
     def list_parts(self):
         config = {
@@ -186,7 +180,6 @@ class KafkaInput(PartitionedInput):
             self._starting_offset,
             resume_state,
             self._batch_size,
-            self._timeout,
         )
 
 

--- a/pysrc/bytewax/connectors/kafka.py
+++ b/pysrc/bytewax/connectors/kafka.py
@@ -64,7 +64,7 @@ class _KafkaSource(StatefulSource):
             item = (msg.key(), msg.value())
             # Resume reading from the next message, not this one.
             self._offset = msg.offset() + 1
-            return item
+            return [item]
 
     def snapshot(self):
         return self._offset

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -8,7 +8,7 @@ Subclass the types here to implement input for your own custom source.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Set
+from typing import Any, Optional, Set, List
 
 __all__ = [
     "DynamicInput",
@@ -41,7 +41,7 @@ class StatefulSource(ABC):
     """Input source that maintains state of its position."""
 
     @abstractmethod
-    def next(self) -> list[Any]:
+    def next(self) -> List[Any]:
         """Attempt to get the next input items.
 
         This must participate in a kind of cooperative multi-tasking,
@@ -164,7 +164,7 @@ class StatelessSource(ABC):
     """Input source that is stateless."""
 
     @abstractmethod
-    def next(self) -> list[Any]:
+    def next(self) -> List[Any]:
         """Attempt to get the next input items.
 
         This must participate in a kind of cooperative multi-tasking,

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -41,16 +41,16 @@ class StatefulSource(ABC):
     """Input source that maintains state of its position."""
 
     @abstractmethod
-    def next(self) -> Optional[Any]:
-        """Attempt to get the next input item.
+    def next(self) -> list[Any]:
+        """Attempt to get the next input items.
 
         This must participate in a kind of cooperative multi-tasking,
-        never blocking but returning a bare `None` if there is no item
+        never blocking but returning an empty list if there are no items
         to emit currently.
 
         Returns:
 
-            An item or `None`.
+            A list of items.
 
         Raises:
 
@@ -164,16 +164,16 @@ class StatelessSource(ABC):
     """Input source that is stateless."""
 
     @abstractmethod
-    def next(self) -> Optional[Any]:
-        """Attempt to get the next input item.
+    def next(self) -> list[Any]:
+        """Attempt to get the next input items.
 
         This must participate in a kind of cooperative multi-tasking,
-        never blocking but yielding a bare `None` if there is no new
+        never blocking but returning an empty list if there is no new
         input.
 
         Returns:
 
-            An item or `None`.
+            A list of items.
 
         Raises:
 

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -28,7 +28,7 @@ class _IterSource(StatefulSource):
     def next(self):
         # next will raise StopIteration on its own.
         self._idx, item = next(self._it)
-        return item
+        return [item]
 
     def snapshot(self):
         return self._idx

--- a/pytests/connectors/test_files.py
+++ b/pytests/connectors/test_files.py
@@ -98,20 +98,20 @@ def test_file_input_resume_state():
     file_path = Path("examples/sample_data/cluster/partition-1.txt")
     inp = FileInput(file_path)
     part = inp.build_part(str(file_path), None)
-    assert part.next() == "one1"
-    assert part.next() == "one2"
+    assert part.next() == ["one1"]
+    assert part.next() == ["one2"]
     resume_state = part.snapshot()
-    assert part.next() == "one3"
-    assert part.next() == "one4"
+    assert part.next() == ["one3"]
+    assert part.next() == ["one4"]
     part.close()
 
     inp = FileInput(file_path)
     part = inp.build_part(str(file_path), resume_state)
     assert part.snapshot() == resume_state
-    assert part.next() == "one3"
-    assert part.next() == "one4"
-    assert part.next() == "one5"
-    assert part.next() == "one6"
+    assert part.next() == ["one3"]
+    assert part.next() == ["one4"]
+    assert part.next() == ["one5"]
+    assert part.next() == ["one6"]
     with raises(StopIteration):
         part.next()
     part.close()

--- a/pytests/test_testing.py
+++ b/pytests/test_testing.py
@@ -6,16 +6,16 @@ from bytewax.testing import TestingInput
 def test_input_resume_state():
     inp = TestingInput(range(3))
     part = inp.build_part("iter", None)
-    assert part.next() == 0
-    assert part.next() == 1
+    assert part.next() == [0]
+    assert part.next() == [1]
     resume_state = part.snapshot()
-    assert part.next() == 2
+    assert part.next() == [2]
     part.close()
 
     inp = TestingInput(range(3))
     part = inp.build_part("iter", resume_state)
     assert part.snapshot() == resume_state
-    assert part.next() == 2
+    assert part.next() == [2]
     with raises(StopIteration):
         part.next()
     part.close()

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,6 @@
 use std::panic::Location;
 
+use pyo3::PyDowncastError;
 use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::PyErr;
@@ -167,6 +168,12 @@ impl<T> PythonException<T> for Result<T, String> {
 }
 
 impl<T> PythonException<T> for Result<T, Box<dyn std::error::Error>> {
+    fn into_pyresult(self) -> PyResult<T> {
+        self.map_err(|err| PyErr::new::<PyException, _>(format!("{err}")))
+    }
+}
+
+impl<T> PythonException<T> for Result<T, PyDowncastError<'_>> {
     fn into_pyresult(self) -> PyResult<T> {
         self.map_err(|err| PyErr::new::<PyException, _>(format!("{err}")))
     }


### PR DESCRIPTION
## Batch input

This PR build on insights taken from @whoahbot branch, and makes all input sources return a list of elements rather than a single one.
This enables the ability for input sources to batch items.
The batching of input elements is added to our own KafkaInput, making it possible to avoid IO with kafka at every single message.
Two parameters are used to control the behaviour: `batch_size` and `timeout`. 

The difference with the previous approach on the api is that the `batch_size` is not a `Dataflow.input` parameter, but something specific to the input source. This allows us to do eager batching, which in case of our own `KafkaInput` makes a lot of difference, since we avoid a roundtrip between python and ffi, but it means each input will have to handle this on its own rather than having a single parameter in the `.input` operator.

I created a tool to benchmark the impact of the changes, and created a specific benchmark to test only kafka input throughput. To try this I used a custom `NullOutput` that does nothing on write.

As we can see from the benchmark, the current bytewax version can ingest ~100k messages per second without lagging if the dataflow doesn't do anything else, but struggles at 500k messages per second.

This is the repository of the benchmarking tool: https://github.com/Psykopear/bytewax-kafka-throughput

This is the plot of the results of processing 100k (first) and 500k (second) messages per second with:
- bytewax v0.16.2 with default kafka connectors
- bytewax at this branch, batching messages with `batch_size=500000` and `timeout=0.1`

The code for the 2 dataflows is really similar, the one at this branch just adds the 2 parameters to the `KafkaInput` initialization:

```python
class NullSource(StatelessSink):
    def write(self, item):
        pass

    def close():
        pass


class NullOutput(DynamicOutput):
    def build(self, worker_index, worker_count) -> StatelessSink:
        return NullSource()


flow = Dataflow()
flow.input(
    "kafka_in",
    KafkaInput(
        BROKERS,
        [CONSUME_TOPIC],
        add_config={
            "enable.auto.commit": True,
            "group.id": GROUP_ID,
        },
        # This is specific to this branch
        batch_size=500000,
        timeout=0.1,
    ),
)
flow.output(
    "null_output",
    NullOutput(),
)

```
### 100k messages per second
![100k-null-out](https://github.com/bytewax/bytewax/assets/5968682/8ec551cb-fa22-4c25-97a4-a8e8a9abb1b3)

### 500k messages per second
![500k](https://github.com/bytewax/bytewax/assets/5968682/24716904-7c9a-49a4-a956-53b6f1dc7355)

So we do get a noticeable improvement, but my impression is that the bottleneck on the output is probably more relevant than the one at the input, since using the `KafkaOutput` instead of the `NullOutput`, current bytewax struggles with ~10k messages per second. I still think this change in the api is a good one to have, since it only expands the capabilities of the input source.

### Notes

- When checking each message, I emit the batch if the partition reaches `eof`, but discard all the messages in the batch when we raise a `RuntimeError`, is that ok or should I still emit the rest of the batch in case of an error?
- We could make use of batching in other sources, but right now I just made the existing ones return a single item list