### PR TITLE
Add _SQLSource and SQLInput to bytewax.connectors.sql

### DIFF
--- a/pysrc/bytewax/connectors/sql.py
+++ b/pysrc/bytewax/connectors/sql.py
@@ -1,0 +1,108 @@
+"""Connectors for [SQL](https://en.wikipedia.org/wiki/SQL).
+
+Importing this module requires the
+[`SQLAlchemy`](https://github.com/sqlalchemy/sqlalchemy)
+package to be installed.
+
+It also requires any database-specific packages to be installed, such as
+[`psycopg2`](https://github.com/psycopg/psycopg2) for PostgreSQL.
+
+"""
+from time import sleep
+
+from bytewax.inputs import PartitionedInput, StatefulSource
+from sqlalchemy import create_engine, text
+
+__all__ = [
+    "SQLInput",
+]
+
+
+class _SQLSource(StatefulSource):
+    def __init__(
+        self,
+        connection,
+        query,
+        starting_cursors,
+        resume_state,
+        backoff_start_delay,
+        backoff_factor,
+        backoff_max_delay,
+    ):
+        self._cursor_dict = resume_state or starting_cursors
+        self._connection = connection
+        self._query = query
+        self._result = None
+        self._backoff_start_delay = backoff_start_delay
+        self._backoff_factor = backoff_factor
+        self._backoff_max_delay = backoff_max_delay
+
+    def next(self):
+        delay = self._backoff_start_delay
+
+        while True:
+            if self._result is None or not self._result.returns_rows:
+                self._result = self._connection.execution_options(
+                    stream_results=True
+                ).execute(text(self._query), self._cursor_dict)
+
+            row = self._result.fetchone()
+
+            if row is not None:
+                item = row._asdict()
+                # update all cursor columns
+                for key in self._cursor_dict.keys():
+                    self._cursor_dict[key] = item[key]
+                return item
+            else:
+                # If there are no more rows to fetch, sleep for the specified interval
+                # and then try again
+                self._result.close()
+                self._result = None
+
+                sleep(delay)
+                delay = min(delay * self._backoff_factor, self._backoff_max_delay)
+
+    def snapshot(self):
+        return self._cursor_dict
+
+    def close(self):
+        self._connection.close()
+
+
+class SQLInput(PartitionedInput):
+    def __init__(
+        self,
+        connection_string: str,
+        query: str,
+        starting_cursors: dict,
+        backoff_start_delay: float = 1.0,
+        backoff_factor: float = 2.0,
+        backoff_max_delay: float = 60.0,
+    ):
+        self._connection_string = connection_string
+        self._query = query
+        self._starting_cursors = starting_cursors
+        self._backoff_start_delay = backoff_start_delay
+        self._backoff_factor = backoff_factor
+        self._backoff_max_delay = backoff_max_delay
+
+    def list_parts(self):
+        return {"single"}  # A single partition in this case
+
+    def build_part(self, for_part, resume_state):
+        engine = create_engine(
+            self._connection_string, connect_args={"options": "-c timezone=utc"}
+        )
+        connection = engine.connect()
+        # Setting the transaction to READ ONLY mode
+        connection.execution_options(isolation_level="READ COMMITTED", readonly=True)
+        return _SQLSource(
+            connection,
+            self._query,
+            self._starting_cursors,
+            resume_state,
+            self._backoff_start_delay,
+            self._backoff_factor,
+            self._backoff_max_delay,
+        )


### PR DESCRIPTION
Hi everyone 👋 

In the context of this [Slack thread](https://bytewaxcommunity.slack.com/archives/C035LJ7URAQ/p1687863336846369) I opened this MR to share a new kind of connector I wrote for bytewax.

The jist of it is that it uses SQLAlchemy core operations to abstract access to the SQL compatible DB (you will also depend on the underlying engine, our case is Postgres).

It presents this interface:
```
class SQLInput(PartitionedInput):
    def __init__(
        self,
        connection_string: str,
        query: str,
        starting_cursors: dict,
        backoff_start_delay: float = 1.0,
        backoff_factor: float = 2.0,
        backoff_max_delay: float = 60.0,
    ):
```

1. connection_string: connection URI of DB
2. query: query to run that returns the results you want
3. starting_cursors: let's you define a multi column cursor that is used to keep the state/init the Input where you wanted it to start
4. backoff_*: let's you define the polling behaviour for when you get to the end of the results in your query (it uses SQLAlchemy batching and streaming of results while the query still has results but when you get to the real time data you need to poll the DB for extra results that are coming in)

simple example usage:
```
sql_input = SQLInput(
        connection_string=connection_uri,
        query="SELECT \"timestamp\", \"signal_1\" FROM \"table_1\" WHERE \"timestamp\" > :timestamp"
        starting_cursors={"timestamp": start_time},
    )
```

This returns a stream of events of this type:
`{"timestamp": datetime.datetime(*), "signal_1": <signal_value>}`

The query requirement is that it needs to select the cursors and the variables in the query need to have the same name of the selected cursors. (I still don't check this)
In the example I gave this happens because I select `"timestamp"` and in my WHERE I have a `:timestamp` variable.

If there is interest in this I can add tests and docs too!

