### PR TITLE
Next awake

### DIFF
--- a/examples/next_awake.py
+++ b/examples/next_awake.py
@@ -1,22 +1,30 @@
-from random import random
 from datetime import datetime, timedelta, timezone
 
 from bytewax.dataflow import Dataflow
 from bytewax.connectors.stdio import StdOutput
-from bytewax.inputs import DynamicInput, StatelessSource
+from bytewax.inputs import (
+    DynamicInput,
+    StatelessSource,
+    PartitionedInput,
+    StatefulSource,
+)
 
 
 class PeriodicSource(StatelessSource):
     def __init__(self, frequency):
-        self._next_awake = datetime.now(timezone.utc)
         self.frequency = frequency
-
-    def next(self):
-        self._next_awake += self.frequency
-        return [random()]
+        self._next_awake = datetime.now(timezone.utc)
+        self._i = 0
 
     def next_awake(self):
         return self._next_awake
+
+    def next(self):
+        self._i += 1
+        if self._i >= 10:
+            raise StopIteration()
+        self._next_awake += self.frequency
+        return ["VALUE"]
 
 
 class PeriodicInput(DynamicInput):
@@ -27,6 +35,51 @@ class PeriodicInput(DynamicInput):
         return PeriodicSource(frequency=self.frequency)
 
 
-flow = Dataflow()
-flow.input("periodic", PeriodicInput(timedelta(seconds=5)))
-flow.output("stdout", StdOutput())
+stateless_flow = Dataflow()
+stateless_flow.input("periodic", PeriodicInput(timedelta(seconds=1)))
+stateless_flow.output("stdout", StdOutput())
+
+
+class StatefulPeriodicSource(StatefulSource):
+    def __init__(self, frequency, next_awake):
+        self.frequency = frequency
+        self._next_awake = next_awake
+        self._i = 0
+
+    def next(self):
+        self._i += 1
+        if self._i >= 10:
+            raise StopIteration()
+        self._next_awake += self.frequency
+        return ["VALUE"]
+
+    def snapshot(self):
+        return {
+            "frequency": self.frequency,
+            "_next_awake": self._next_awake.isoformat(),
+        }
+
+    def next_awake(self):
+        return self._next_awake
+
+
+class PeriodicPartitionedInput(PartitionedInput):
+    def __init__(self, frequency):
+        self.frequency = frequency
+
+    def list_parts(self):
+        return {"singleton"}
+
+    def build_part(self, for_part, resume_state):
+        assert for_part == "singleton"
+        resume_state = resume_state or {}
+        frequency = resume_state.get("frequency", self.frequency)
+        next_awake = datetime.fromisoformat(
+            resume_state.get("_next_awake", datetime.now(timezone.utc).isoformat())
+        )
+        return StatefulPeriodicSource(frequency, next_awake)
+
+
+stateful_flow = Dataflow()
+stateful_flow.input("periodic", PeriodicPartitionedInput(timedelta(seconds=1)))
+stateful_flow.output("stdout", StdOutput())

--- a/examples/next_awake.py
+++ b/examples/next_awake.py
@@ -24,7 +24,7 @@ class PeriodicSource(StatelessSource):
         if self._i >= 10:
             raise StopIteration()
         self._next_awake += self.frequency
-        return ["VALUE"]
+        return [f"{self._i}"]
 
 
 class PeriodicInput(DynamicInput):

--- a/examples/next_awake.py
+++ b/examples/next_awake.py
@@ -41,22 +41,23 @@ stateless_flow.output("stdout", StdOutput())
 
 
 class StatefulPeriodicSource(StatefulSource):
-    def __init__(self, frequency, next_awake):
+    def __init__(self, frequency, next_awake, i):
         self.frequency = frequency
         self._next_awake = next_awake
-        self._i = 0
+        self._i = i
 
     def next(self):
         self._i += 1
         if self._i >= 10:
             raise StopIteration()
         self._next_awake += self.frequency
-        return ["VALUE"]
+        return [f"{self._i}"]
 
     def snapshot(self):
         return {
             "frequency": self.frequency,
             "_next_awake": self._next_awake.isoformat(),
+            "_i": self._i,
         }
 
     def next_awake(self):
@@ -77,7 +78,8 @@ class PeriodicPartitionedInput(PartitionedInput):
         next_awake = datetime.fromisoformat(
             resume_state.get("_next_awake", datetime.now(timezone.utc).isoformat())
         )
-        return StatefulPeriodicSource(frequency, next_awake)
+        i = resume_state.get("_i", 0)
+        return StatefulPeriodicSource(frequency, next_awake, i)
 
 
 stateful_flow = Dataflow()

--- a/examples/next_awake.py
+++ b/examples/next_awake.py
@@ -1,0 +1,32 @@
+from random import random
+from datetime import datetime, timedelta, timezone
+
+from bytewax.dataflow import Dataflow
+from bytewax.connectors.stdio import StdOutput
+from bytewax.inputs import DynamicInput, StatelessSource
+
+
+class PeriodicSource(StatelessSource):
+    def __init__(self, frequency):
+        self._next_awake = datetime.now(timezone.utc)
+        self.frequency = frequency
+
+    def next(self):
+        self._next_awake += self.frequency
+        return [random()]
+
+    def next_awake(self):
+        return self._next_awake
+
+
+class PeriodicInput(DynamicInput):
+    def __init__(self, frequency):
+        self.frequency = frequency
+
+    def build(self, worker_index, worker_count):
+        return PeriodicSource(frequency=self.frequency)
+
+
+flow = Dataflow()
+flow.input("periodic", PeriodicInput(timedelta(seconds=5)))
+flow.output("stdout", StdOutput())

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -95,12 +95,18 @@ class StatefulSource(ABC):
         """Return the time for the next poll of the input.
         By default this is `now`, which means the input will
         be polled continously.
-        This will be called right after `self.next`, and it can be
-        customized to make the input operator sleep for a variable
-        amount of time.
 
-        This method should be used instead of a `time.sleep` call in
-        `self.next` to put the operator to sleep.
+        This function is called before `self.next`, and if the
+        datetime returned is in the future, `self.next` won't be
+        called immediately, and the input operator will be put to
+        rest until it's time to wake up.
+
+        Always use this method to wait for input rather than
+        using a `time.sleep` inside `self.next`
+
+        Returns:
+
+            Datetime for the next activation
 
         """
         return datetime.now(timezone.utc)
@@ -211,12 +217,18 @@ class StatelessSource(ABC):
         """Return the time for the next poll of the input.
         By default this is `now`, which means the input will
         be polled continously.
-        This will be called right after `self.next`, and it can be
-        customized to make the input operator sleep for a variable
-        amount of time.
 
-        This method should be used instead of a `time.sleep` call in
-        `self.next` to put the operator to sleep.
+        This function is called before `self.next`, and if the
+        datetime returned is in the future, `self.next` won't be
+        called immediately, and the input operator will be put to
+        rest until it's time to wake up.
+
+        Always use this method to wait for input rather than
+        using a `time.sleep` inside `self.next`
+
+        Returns:
+
+            Datetime for the next activation
 
         """
         return datetime.now(timezone.utc)

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -91,10 +91,12 @@ class StatefulSource(ABC):
         """
         pass
 
-    def next_awake(self) -> datetime:
-        """Return the time for the next poll of the input.
-        By default this is `now`, which means the input will
-        be polled continously.
+    def next_awake(self) -> Optional[datetime]:
+        """Return the time for the next poll of the input
+        or None for immediate activation.
+        By default this is `datetime.now`, which means the
+        input will be polled continously, with a cooldown that
+        helps avoid high cpu load if there's no work to do.
 
         This function is called before `self.next`, and if the
         datetime returned is in the future, `self.next` won't be
@@ -104,9 +106,15 @@ class StatefulSource(ABC):
         Always use this method to wait for input rather than
         using a `time.sleep` inside `self.next`
 
+        Beware, always returning None will make the worker
+        spin as fast as possible, possibly consuming all the
+        available cpu. It's usually better to use the default
+        implementation.
+
         Returns:
 
-            Datetime for the next activation
+            Datetime for the next activation,
+            or None for immediate activation
 
         """
         return datetime.now(timezone.utc)
@@ -213,10 +221,12 @@ class StatelessSource(ABC):
         """
         pass
 
-    def next_awake(self) -> datetime:
-        """Return the time for the next poll of the input.
-        By default this is `now`, which means the input will
-        be polled continously.
+    def next_awake(self) -> Optional[datetime]:
+        """Return the time for the next poll of the input
+        or None for immediate activation.
+        By default this is `datetime.now`, which means the
+        input will be polled continously, with a cooldown that
+        helps avoid high cpu load if there's no work to do.
 
         This function is called before `self.next`, and if the
         datetime returned is in the future, `self.next` won't be
@@ -226,9 +236,15 @@ class StatelessSource(ABC):
         Always use this method to wait for input rather than
         using a `time.sleep` inside `self.next`
 
+        Beware, always returning None will make the worker
+        spin as fast as possible, possibly consuming all the
+        available cpu. It's usually better to use the default
+        implementation.
+
         Returns:
 
-            Datetime for the next activation
+            Datetime for the next activation,
+            or None for immediate activation
 
         """
         return datetime.now(timezone.utc)

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -92,32 +92,27 @@ class StatefulSource(ABC):
         pass
 
     def next_awake(self) -> Optional[datetime]:
-        """Return the time for the next poll of the input
-        or None for immediate activation.
-        By default this is `datetime.now`, which means the
-        input will be polled continously, with a cooldown that
+        """Optionally return the time for the next poll of the input.
+
+        The default behavior (when this function returns None) is to
+        activate the input immediately if any item was returned in `next`,
+        and cooldown the source for 1ms otherwise. The cooldown
         helps avoid high cpu load if there's no work to do.
 
         This function is called before `self.next`, and if the
         datetime returned is in the future, `self.next` won't be
-        called immediately, and the input operator will be put to
-        rest until it's time to wake up.
+        called until the datetime returned here has passed.
 
         Always use this method to wait for input rather than
         using a `time.sleep` inside `self.next`
 
-        Beware, always returning None will make the worker
-        spin as fast as possible, possibly consuming all the
-        available cpu. It's usually better to use the default
-        implementation.
-
         Returns:
 
             Datetime for the next activation,
-            or None for immediate activation
+            or None for default behavior.
 
         """
-        return datetime.now(timezone.utc)
+        return None
 
 
 class PartitionedInput(Input):
@@ -222,32 +217,27 @@ class StatelessSource(ABC):
         pass
 
     def next_awake(self) -> Optional[datetime]:
-        """Return the time for the next poll of the input
-        or None for immediate activation.
-        By default this is `datetime.now`, which means the
-        input will be polled continously, with a cooldown that
+        """Optionally return the time for the next poll of the input.
+
+        The default behavior (when this function returns None) is to
+        activate the input immediately if any item was returned in `next`,
+        and cooldown the source for 1ms otherwise. The cooldown
         helps avoid high cpu load if there's no work to do.
 
         This function is called before `self.next`, and if the
         datetime returned is in the future, `self.next` won't be
-        called immediately, and the input operator will be put to
-        rest until it's time to wake up.
+        called until the datetime returned here has passed.
 
         Always use this method to wait for input rather than
         using a `time.sleep` inside `self.next`
 
-        Beware, always returning None will make the worker
-        spin as fast as possible, possibly consuming all the
-        available cpu. It's usually better to use the default
-        implementation.
-
         Returns:
 
             Datetime for the next activation,
-            or None for immediate activation
+            or None for default behavior.
 
         """
-        return datetime.now(timezone.utc)
+        return None
 
 
 class DynamicInput(Input):

--- a/pysrc/bytewax/inputs.py
+++ b/pysrc/bytewax/inputs.py
@@ -9,6 +9,7 @@ Subclass the types here to implement input for your own custom source.
 
 from abc import ABC, abstractmethod
 from typing import Any, Optional, Set, List
+from datetime import datetime, timezone
 
 __all__ = [
     "DynamicInput",
@@ -89,6 +90,20 @@ class StatefulSource(ABC):
 
         """
         pass
+
+    def next_awake(self) -> datetime:
+        """Return the time for the next poll of the input.
+        By default this is `now`, which means the input will
+        be polled continously.
+        This will be called right after `self.next`, and it can be
+        customized to make the input operator sleep for a variable
+        amount of time.
+
+        This method should be used instead of a `time.sleep` call in
+        `self.next` to put the operator to sleep.
+
+        """
+        return datetime.now(timezone.utc)
 
 
 class PartitionedInput(Input):
@@ -191,6 +206,20 @@ class StatelessSource(ABC):
 
         """
         pass
+
+    def next_awake(self) -> datetime:
+        """Return the time for the next poll of the input.
+        By default this is `now`, which means the input will
+        be polled continously.
+        This will be called right after `self.next`, and it can be
+        customized to make the input operator sleep for a variable
+        amount of time.
+
+        This method should be used instead of a `time.sleep` call in
+        `self.next` to put the operator to sleep.
+
+        """
+        return datetime.now(timezone.utc)
 
 
 class DynamicInput(Input):

--- a/pytests/test_next_awake.py
+++ b/pytests/test_next_awake.py
@@ -1,0 +1,95 @@
+from datetime import timedelta, datetime, timezone
+
+from bytewax.dataflow import Dataflow
+from bytewax.inputs import (
+    DynamicInput,
+    StatelessSource,
+    PartitionedInput,
+    StatefulSource,
+)
+from bytewax.testing import run_main, TestingOutput
+
+
+def test_next_awake_in_dynamic_input():
+    """Test that the `next` method is not called before `next_awake` time."""
+
+    class TestSource(StatelessSource):
+        def __init__(self):
+            self._next_awake = datetime.now(timezone.utc)
+            self._iter = iter(list(range(5)))
+
+        def next(self):
+            now = datetime.now(timezone.utc)
+            # Assert that `next` is only called after
+            # the `next_awake` time has passed.
+            assert now >= self._next_awake
+            # Request to awake in 0.1 seconds from now
+            self._next_awake = now + timedelta(seconds=0.1)
+            # This will raise StopIteration when the iterator is complete
+            return [next(self._iter)]
+
+        def next_awake(self):
+            return self._next_awake
+
+    class TestInput(DynamicInput):
+        def build(self, worker_index, worker_count):
+            return TestSource()
+
+    out = []
+    flow = Dataflow()
+    flow.input("in", TestInput())
+    flow.output("out", TestingOutput(out))
+    # If next is called before the next_awake time has passed,
+    # the dataflow will crash and the test won't pass.
+    run_main(flow)
+    expected = [0, 1, 2, 3, 4]
+    assert out == expected
+
+
+def test_next_awake_in_partitioned_input():
+    """Test that the `next` method is not called before `next_awake` time."""
+
+    class TestSource(StatefulSource):
+        def __init__(self, cooldown):
+            self._cooldown = cooldown
+            self._next_awake = datetime.now(timezone.utc)
+            self._iter = iter(list(range(4)))
+
+        def next(self):
+            now = datetime.now(timezone.utc)
+            # Assert that `next` is only called after
+            # the `next_awake` time has passed.
+            assert now >= self._next_awake
+
+            # Request to awake in self._cooldown seconds from now
+            self._next_awake = now + self._cooldown
+            # This will raise StopIteration when the iterator is complete
+            return [next(self._iter)]
+
+        def next_awake(self):
+            return self._next_awake
+
+        def snapshot(self):
+            pass
+
+    class TestInput(PartitionedInput):
+        def list_parts(self):
+            return {"one", "two", "three"}
+
+        def build_part(self, for_part, resume_state):
+            if for_part == "one":
+                return TestSource(cooldown=timedelta(seconds=0.1))
+            if for_part == "two":
+                return TestSource(cooldown=timedelta(seconds=0.2))
+            if for_part == "three":
+                return TestSource(cooldown=timedelta(seconds=0.3))
+
+    out = []
+    flow = Dataflow()
+    flow.input("in", TestInput())
+    flow.output("out", TestingOutput(out))
+    # If next is called before the next_awake time has passed,
+    # the dataflow will crash and the test won't pass.
+    run_main(flow)
+    expected = [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]
+    assert sorted(out) == expected

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -310,6 +310,10 @@ impl PartitionedInput {
                 });
 
                 if caps.is_some() {
+                    // Only activate when the next awake time comes.
+                    // Note the use of `.take()` here, to set the
+                    // `activate_after` value to Option::None, so that
+                    // each iteration has it's own `activate_after` time.
                     activator.activate_after(
                         activate_after
                             .take()

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -220,10 +220,10 @@ impl PartitionedInput {
                         let mut output_handle = output_wrapper.activate();
                         let mut output_session = output_handle.session(&output_cap);
                         for (key, part) in parts.iter() {
-                            let now = Utc::now();
                             // Ask the next awake time to the source.
                             let next_awake =
                                 unwrap_any!(Python::with_gil(|py| part.next_awake(py)));
+                            let now = Utc::now();
                             // Calculate for how long to wait for the next poll.
                             activate_after = Some(
                                 next_awake

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -441,9 +441,9 @@ impl DynamicInput {
 
             let mut cap_src = Some((output_cap, source));
             let mut epoch_started = Instant::now();
+            let mut next_guard = NextGuard::new();
 
             move |_input_frontiers| {
-                let mut next_guard = NextGuard::new();
                 // We can't return an error here, but we need to stop execution
                 // if we have an error in the user's code.
                 // When this happens we panic with unwrap_any! and reraise

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -459,7 +459,6 @@ impl DynamicInput {
             let mut activate_after = min_cooldown;
 
             move |_input_frontiers| {
-                let now = Utc::now();
                 // We can't return an error here, but we need to stop execution
                 // if we have an error in the user's code.
                 // When this happens we panic with unwrap_any! and reraise
@@ -471,6 +470,7 @@ impl DynamicInput {
 
                     // Ask the next awake time to the source.
                     let next_awake = unwrap_any!(Python::with_gil(|py| source.next_awake(py)));
+                    let now = Utc::now();
                     activate_after = next_awake.signed_duration_since(now).max(min_cooldown);
 
                     // Only call `next` if `next_awake` is passed.


### PR DESCRIPTION
# Next awake
This PR introduces a new method in input sources: `next_awake`.

The method is called when the input operator is activated, and if it returns a datetime in the future, the `next` method won't be called, and the operator will be asked to park itself until next_awake's returned datetime. There can be spurious activations of the input operators, but the `next` method won't be called in those cases.

By default the method returns `datetime.now(timezone.utc)`, and what used to be the fixed cooldown between activations (1ms) is now the minimum value used by default. So existing source's behaviour should not change.

I added an `examples/next_awake.py` to showcase the functionality, for example this is how you can implement a periodic source without using sleep, and without having to manually check how much time has passed:

```python
from datetime import datetime, timedelta, timezone

from bytewax.dataflow import Dataflow
from bytewax.connectors.stdio import StdOutput
from bytewax.inputs import DynamicInput, StatelessSource


class PeriodicSource(StatelessSource):
    def __init__(self, frequency):
        self.frequency = frequency
        self._next_awake = datetime.now(timezone.utc)

    def next_awake(self):
        return self._next_awake

    def next(self):
        self._next_awake += self.frequency
        return ["VALUE"]


class PeriodicInput(DynamicInput):
    def __init__(self, frequency):
        self.frequency = frequency

    def build(self, worker_index, worker_count):
        return PeriodicSource(frequency=self.frequency)


flow = Dataflow()
flow.input("periodic", PeriodicInput(timedelta(seconds=1)))
flow.output("stdout", StdOutput())
```