### PR TITLE
Update orderbook.py to use level2_batch

### DIFF
--- a/examples/orderbook.py
+++ b/examples/orderbook.py
@@ -17,7 +17,7 @@ class CoinfbaseSource(StatefulSource):
                 {
                     "type": "subscribe",
                     "product_ids": [product_id],
-                    "channels": ["level2"],
+                    "channels": ["level2_batch"],
                 }
             )
         )

--- a/examples/orderbook.py
+++ b/examples/orderbook.py
@@ -24,8 +24,8 @@ class CoinfbaseSource(StatefulSource):
         # The first msg is just a confirmation that we have subscribed.
         print(self.ws.recv())
 
-    def next(self):
-        return self.ws.recv()
+    def next_batch(self):
+        return [self.ws.recv()]
 
     def snapshot(self):
         return None


### PR DESCRIPTION
Update orderbook example to use level2_batch. https://docs.cloud.coinbase.com/exchange/docs/websocket-channels#level2-batch-channel

Fix suggested in slack:
> Incase anyone is following the [Real-Time Financial Exchange Order Book](https://bytewax.io/guides/real-time-financial-exchange-order-book-application?utm_source=pocket_saves) guide it appears Coinbase made an update to their API
{'type': 'error', 'message': 'Failed to subscribe', 'reason': 'level2, level3, and full channels now require authentication. https://docs.cloud.coinbase.com/exchange/docs/websocket-auth'} if you update the channel to level2_batch everything still works. (edited)