### PR TITLE
Fix tiny typo in comment

### DIFF
--- a/src/window/session_window.rs
+++ b/src/window/session_window.rs
@@ -58,7 +58,7 @@ impl WindowBuilder for SessionWindow {
 }
 
 pub(crate) struct SessionWindower {
-    /// How long to wait before cosidering
+    /// How long to wait before considering
     /// the session closed.
     gap: Duration,
 


### PR DESCRIPTION
Thanks for this amazing tool! 🙏 

I was perusing the source code and found a tiny typo in a comment.