### PR TITLE
Output batch

### DIFF
--- a/examples/anomaly_detector.py
+++ b/examples/anomaly_detector.py
@@ -11,7 +11,7 @@ class RandomMetricSource(StatefulSource):
 
     def next_batch(self):
         next(self.iterator)
-        return ["ALL", random.randrange(0, 10)]
+        return [("ALL", random.randrange(0, 10))]
 
     def snapshot(self):
         return None

--- a/examples/batch_output.py
+++ b/examples/batch_output.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timezone, timedelta
+
+from bytewax.dataflow import Dataflow
+from bytewax.outputs import (
+    StatelessSink,
+    DynamicOutput,
+    PartitionedOutput,
+    StatefulSink,
+)
+from bytewax.inputs import (
+    StatelessSource,
+    DynamicInput,
+    PartitionedInput,
+    StatefulSource,
+)
+from bytewax.connectors.stdio import StdOutput
+
+
+class Source(StatefulSource):
+    def __init__(self, name, counter):
+        self._name = name
+        self._counter = counter
+        self._next_awake = datetime.now(timezone.utc)
+
+    def next_batch(self):
+        self._next_awake += timedelta(seconds=0.1)
+        self._counter += 1
+        return [(f"{self._counter % 5}", self._counter)]
+
+    def next_awake(self):
+        return self._next_awake
+
+    def snapshot(self):
+        return {"counter": self._counter}
+
+
+class In(PartitionedInput):
+    def list_parts(self):
+        return ["1", "2", "3", "4", "5"]
+
+    def build_part(self, for_part, resume_state):
+        resume_state = resume_state or {"counter": 0}
+        return Source(for_part, resume_state["counter"])
+
+
+class Sink(StatefulSink):
+    def __init__(self, name):
+        self._name = name
+
+    def write_batch(self, values):
+        print(f"Values from {self._name}: {[i[1] for i in values]}")
+        return values
+
+
+class Out(PartitionedOutput):
+    def list_parts(self):
+        return ["1", "2", "3", "4", "5"]
+
+    def build_part(self, for_part, resume_state):
+        return Sink(for_part)
+
+
+flow = Dataflow()
+flow.input("in", In())
+flow.output("out", Out(), min_batch_size=10, timeout=timedelta(seconds=2.0))

--- a/examples/batch_output.py
+++ b/examples/batch_output.py
@@ -1,19 +1,8 @@
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
 from bytewax.dataflow import Dataflow
-from bytewax.outputs import (
-    StatelessSink,
-    DynamicOutput,
-    PartitionedOutput,
-    StatefulSink,
-)
-from bytewax.inputs import (
-    StatelessSource,
-    DynamicInput,
-    PartitionedInput,
-    StatefulSource,
-)
-from bytewax.connectors.stdio import StdOutput
+from bytewax.inputs import PartitionedInput, StatefulSource
+from bytewax.outputs import PartitionedOutput, StatefulSink
 
 
 class Source(StatefulSource):

--- a/examples/batch_output.py
+++ b/examples/batch_output.py
@@ -51,4 +51,4 @@ class Out(PartitionedOutput):
 
 flow = Dataflow()
 flow.input("in", In())
-flow.output("out", Out(), min_batch_size=10, timeout=timedelta(seconds=2.0))
+flow.output("out", Out(), min_batch_size=5, timeout=timedelta(seconds=2.0))

--- a/examples/orderbook.py
+++ b/examples/orderbook.py
@@ -39,7 +39,7 @@ class CoinbaseFeedInput(PartitionedInput):
         self.product_ids = product_ids
 
     def list_parts(self):
-        return set(self.product_ids)
+        return self.product_ids
 
     def build_part(self, for_key, resume_state):
         assert resume_state is None

--- a/pysrc/bytewax/connectors/files.py
+++ b/pysrc/bytewax/connectors/files.py
@@ -215,7 +215,7 @@ class _FileSink(StatefulSink):
         self._end = end
 
     def write_batch(self, items):
-        for item in items:
+        for (_key, item) in items:
             self._f.write(item)
             self._f.write(self._end)
         self._f.flush()

--- a/pysrc/bytewax/connectors/files.py
+++ b/pysrc/bytewax/connectors/files.py
@@ -220,6 +220,8 @@ class _FileSink(StatefulSink):
             self._f.write(self._end)
         self._f.flush()
         os.fsync(self._f.fileno())
+        # Pass items through
+        return items
 
     def snapshot(self):
         return self._f.tell()

--- a/pysrc/bytewax/connectors/kafka.py
+++ b/pysrc/bytewax/connectors/kafka.py
@@ -199,8 +199,8 @@ class _KafkaSink(StatelessSink):
         self._producer = producer
         self._topic = topic
 
-    def write_batch(self, batch):
-        for key, value in batch:
+    def write_batch(self, items):
+        for key, value in items:
             self._producer.produce(self._topic, value, key)
         self._producer.flush()
         # Pass items through

--- a/pysrc/bytewax/connectors/kafka.py
+++ b/pysrc/bytewax/connectors/kafka.py
@@ -76,7 +76,7 @@ class _KafkaSource(StatefulSource):
                     break
                 else:
                     # Discard all the messages in this batch too
-                    msg = f"error consuming from Kafka topic `{self.topic!r}`: "
+                    msg = f"error consuming from Kafka topic `{self._topic!r}`: "
                     f"{msg.error()}"
                     raise RuntimeError(msg)
             batch.append((msg.key(), msg.value()))
@@ -203,6 +203,8 @@ class _KafkaSink(StatelessSink):
         for key, value in batch:
             self._producer.produce(self._topic, value, key)
         self._producer.flush()
+        # Pass items through
+        return items
 
     def close(self):
         self._producer.flush()

--- a/pysrc/bytewax/connectors/stdio.py
+++ b/pysrc/bytewax/connectors/stdio.py
@@ -10,6 +10,7 @@ class _PrintSink(StatelessSink):
     def write_batch(self, items):
         for item in items:
             print(item)
+        return items
 
 
 class StdOutput(DynamicOutput):

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -75,6 +75,7 @@ class _ListSink(StatelessSink):
 
     def write_batch(self, items):
         self._ls += items
+        return items
 
 
 class TestingOutput(DynamicOutput):

--- a/pytests/connectors/test_files.py
+++ b/pytests/connectors/test_files.py
@@ -223,18 +223,18 @@ def test_file_output_resume_state(tmp_path):
 
     out = FileOutput(file_path)
     part = out.build_part(str(file_path), None)
-    part.write_batch(["one1"])
-    part.write_batch(["one2"])
-    part.write_batch(["one3"])
+    part.write_batch([("ALL", "one1")])
+    part.write_batch([("ALL", "one2")])
+    part.write_batch([("ALL", "one3")])
     resume_state = part.snapshot()
-    part.write_batch(["one4"])
+    part.write_batch([("ALL", "one4")])
     part.close()
 
     out = FileOutput(file_path)
     part = out.build_part(str(file_path), resume_state)
     assert part.snapshot() == resume_state
-    part.write_batch(["two4"])
-    part.write_batch(["two5"])
+    part.write_batch([("ALL", "two4")])
+    part.write_batch([("ALL", "two5")])
     part.close()
 
     with open(file_path, "rt") as f:

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -122,6 +122,11 @@ impl Dataflow {
     ///   min_batch_size (int):
     ///       minimum number of messages to receive before writing
     ///       to the output (default = 1)
+    ///   timeout (Optional[timedelta]):
+    ///       timeout after which items are emitted even if
+    ///       `min_batch_size` is not reached.
+    ///       If this is not set, items won't be emitted until
+    ///       `min_batch_size` is reached.
     #[pyo3(signature = (step_id, output, min_batch_size = 1, timeout = None))]
     fn output(
         &mut self,

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -814,10 +814,17 @@ impl Dataflow {
                     step_dict.set_item("builder", builder)?;
                     step_dict.set_item("mapper", mapper)?;
                 }
-                Step::Output { step_id, output } => {
+                Step::Output {
+                    step_id,
+                    output,
+                    min_batch_size,
+                    timeout,
+                } => {
                     step_dict.set_item("type", "Output")?;
                     step_dict.set_item("step_id", step_id)?;
                     step_dict.set_item("output", output)?;
+                    step_dict.set_item("min_batch_size", min_batch_size)?;
+                    step_dict.set_item("timeout", timeout)?;
                 }
             }
             steps.append(step_dict)?;

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -119,8 +119,23 @@ impl Dataflow {
     ///       Uniquely identifies this step for recovery.
     ///   output (bytewax.outputs.Output):
     ///       Output definition.
-    fn output(&mut self, step_id: StepId, output: Output) {
-        self.steps.push(Step::Output { step_id, output });
+    ///   min_batch_size (int):
+    ///       minimum number of messages to receive before writing
+    ///       to the output (default = 1)
+    #[pyo3(signature = (step_id, output, min_batch_size = 1, timeout = None))]
+    fn output(
+        &mut self,
+        step_id: StepId,
+        output: Output,
+        min_batch_size: usize,
+        timeout: Option<chrono::Duration>,
+    ) {
+        self.steps.push(Step::Output {
+            step_id,
+            output,
+            min_batch_size,
+            timeout: timeout.unwrap_or_else(|| chrono::Duration::milliseconds(1)),
+        });
     }
 
     /// Filter selectively keeps only some items.
@@ -873,6 +888,8 @@ pub(crate) enum Step {
     Output {
         step_id: StepId,
         output: Output,
+        min_batch_size: usize,
+        timeout: chrono::Duration,
     },
 }
 

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -134,7 +134,7 @@ impl Dataflow {
             step_id,
             output,
             min_batch_size,
-            timeout: timeout.unwrap_or_else(|| chrono::Duration::milliseconds(1)),
+            timeout,
         });
     }
 
@@ -889,7 +889,7 @@ pub(crate) enum Step {
         step_id: StepId,
         output: Output,
         min_batch_size: usize,
-        timeout: chrono::Duration,
+        timeout: Option<chrono::Duration>,
     },
 }
 

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -21,7 +21,6 @@ use timely::progress::Timestamp;
 use crate::errors::tracked_err;
 use crate::errors::PythonException;
 use crate::pyo3_extensions::extract_state_pair;
-use crate::pyo3_extensions::wrap_state_pair;
 use crate::pyo3_extensions::TdPyAny;
 use crate::pyo3_extensions::TdPyCallable;
 use crate::recovery::*;
@@ -295,10 +294,10 @@ where
                                         .or_insert_with(BTreeMap::new)
                                         .entry(part.clone())
                                         .or_insert_with(Vec::new)
-                                        .extend(items.clone());
+                                        .append(items);
                                     None
                                 } else {
-                                    Some(((*worker, part.clone()), items.clone()))
+                                    Some(((*worker, part.clone()), items.drain(..).collect()))
                                 }
                             })
                             .collect();

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -273,7 +273,7 @@ where
                         for (worker, (part, item)) in incoming.take() {
                             routed_tmp
                                 .entry((worker, part))
-                                .or_insert_with(Vec::new)
+                                .or_insert_with(|| Vec::with_capacity(min_batch_size))
                                 .push(item);
                         }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -427,10 +427,22 @@ where
                     stream = output.map(wrap_state_pair);
                     snaps.push(snap);
                 }
-                Step::Output { step_id, output } => {
+                Step::Output {
+                    step_id,
+                    output,
+                    min_batch_size,
+                    timeout,
+                } => {
                     if let Ok(output) = output.extract(py) {
                         let (output, snap) = stream
-                            .partitioned_output(py, step_id, output, &loads)
+                            .partitioned_output(
+                                py,
+                                step_id,
+                                output,
+                                &loads,
+                                min_batch_size,
+                                timeout,
+                            )
                             .reraise("error building PartitionedOutput")?;
                         let clock = output.map(|_| ());
 
@@ -439,7 +451,7 @@ where
                         stream = output;
                     } else if let Ok(output) = output.extract(py) {
                         let output = stream
-                            .dynamic_output(py, step_id, output)
+                            .dynamic_output(py, step_id, output, min_batch_size, timeout)
                             .reraise("error building DynamicOutput")?;
                         let clock = output.map(|_| ());
 


### PR DESCRIPTION
### Output batching

This PR adds the option to batch output directly in the `output` operator, so the feature works for any connector. It builds upon the `write_batch` requirement for output connectors introduced by david in the previous PR.

The option is used through 2 parameters in the `output` operator: `min_batch_size` and `timeout`

The `write_batch` function is called when either of the two conditions is met.
The first parameter is called `min_batch_size`, because the batch could actually be bigger. I can force a fixed, precise batch size, but I didn't yet, not knowing if it's useful or not.

The `timeout` parameter can be optionally used to force a batch to be emitted even if the `min_batch_size` is not reached when the specified time has passed since the last batch was emitted.
By default the `output` operator acts as before, by setting a `min_batch_size` of `1` and no `timeout`.

### Items pass-through
This stretches the scope of this PR a bit, so if we want to discuss this separately I can move it to a separate PR.

Another change introduced in this PR is the requirement for output operators to return the items they want to pass to the next operator. Outputs can return all the items to act like they did before by default, but also for example filter items with errors, send them to a dead letter queue, and only pass valid items to the next operator, or enrich items with data returned from the output sink before passing them through (like adding a db generated id). The caveat is that the key of each item will be passed along to the output, so another required change for existing stateful operators to keep the same behavior, is to unpack items and ignore the keys before writing to the output sink itself.


