### PR TITLE
Batch operator

### DIFF
--- a/examples/batch_operator.py
+++ b/examples/batch_operator.py
@@ -1,24 +1,70 @@
-from datetime import timedelta
-from time import sleep
+from datetime import datetime, timedelta, timezone
 
 from bytewax.connectors.stdio import StdOutput
 from bytewax.dataflow import Dataflow
-from bytewax.testing import TestingInput
+from bytewax.inputs import DynamicInput, StatelessSource
+from bytewax.outputs import PartitionedOutput, StatefulSink
 
 
-def slow_iterator():
-    for i in range(50):
-        sleep(0.2)
-        yield i
+class Source(StatelessSource):
+    def __init__(self, worker_index):
+        self._worker_index = worker_index
+        self._counter = 0
+        self._next_awake = datetime.now(timezone.utc)
+
+    def next_batch(self):
+        if self._worker_index != 0:
+            raise StopIteration()
+
+        self._next_awake += timedelta(seconds=0.2)
+        self._counter += 1
+
+        if self._counter >= 20:
+            raise StopIteration()
+
+        return [self._counter]
+
+    def next_awake(self):
+        return self._next_awake
+
+
+class In(DynamicInput):
+    def build(self, worker_index, worker_count):
+        return Source(worker_index)
+
+
+class Sink(StatefulSink):
+    def __init__(self, name):
+        self._name = name
+
+    def write_batch(self, values):
+        for i in values:
+            print(f"Output part {self._name}: {i}")
+
+
+class Out(PartitionedOutput):
+    def list_parts(self):
+        return ["1", "2", "3", "4", "5"]
+
+    def build_part(self, for_part, resume_state):
+        return Sink(for_part)
 
 
 flow = Dataflow()
-flow.input("in", TestingInput(slow_iterator()))
+flow.input("in", In())
 # Add key for stateful operator
 flow.map(lambda x: ("ALL", x))
 flow.batch("batch", size=10, timeout=timedelta(seconds=1))
-# Remove key to allow dynamic output batching, otherwise
-# the key will be seen as the first element of the batch,
-# and the whole batch will be seen as the second element.
+flow.output("out", Out(), batched_input=True)
+
+# Rebatch again after the output unpacked the items, use a
+# dynamic output this time
+flow.batch("batch", size=3, timeout=timedelta(seconds=1))
+# XXX: To work with a dynamic output, we need to remove the key, otherwise the key
+# will be seen as the first element of the batch, and the whole batch will be
+# seen as the second element.
 flow.map(lambda key__batch: key__batch[1])
+# Map the items to show a different label. We have a batch here, so we need to
+# trea it like such
+flow.map(lambda batch: [f"Dynamic out: {i}" for i in batch])
 flow.output("out", StdOutput(), batched_input=True)

--- a/examples/batch_operator.py
+++ b/examples/batch_operator.py
@@ -55,13 +55,12 @@ flow.input("in", In())
 # Add key for stateful operator
 flow.map(lambda x: ("ALL", x))
 flow.batch("batch", size=10, timeout=timedelta(seconds=1))
-flow.flat_map(lambda x: x[1])
-flow.map(lambda x: ("ALL", x))
+flow.flat_map(lambda x: [("ALL", i) for i in x[1]])
 flow.output("out", Out())
 
 # Rebatch again after the output unpacked the items, use a
 # dynamic output this time
-flow.batch("batch", size=3, timeout=timedelta(seconds=1))
+flow.batch("batch", size=3, timeout=timedelta(seconds=2))
 # Map to a string, and show the batches rather than the single items
-flow.map(lambda x: f"Dynamic out: {x}")
+flow.map(lambda x: f"Dynamic out batch: {x[1]}")
 flow.output("out", StdOutput())

--- a/examples/batch_operator.py
+++ b/examples/batch_operator.py
@@ -1,0 +1,24 @@
+from datetime import timedelta
+from time import sleep
+
+from bytewax.connectors.stdio import StdOutput
+from bytewax.dataflow import Dataflow
+from bytewax.testing import TestingInput
+
+
+def slow_iterator():
+    for i in range(50):
+        sleep(0.2)
+        yield i
+
+
+flow = Dataflow()
+flow.input("in", TestingInput(slow_iterator()))
+# Add key for stateful operator
+flow.map(lambda x: ("ALL", x))
+flow.batch("batch", size=10, timeout=timedelta(seconds=1))
+# Remove key to allow dynamic output batching, otherwise
+# the key will be seen as the first element of the batch,
+# and the whole batch will be seen as the second element.
+flow.map(lambda key__batch: key__batch[1])
+flow.output("out", StdOutput(), batched_input=True)

--- a/pysrc/bytewax/connectors/kafka.py
+++ b/pysrc/bytewax/connectors/kafka.py
@@ -202,6 +202,7 @@ class _KafkaSink(StatelessSink):
     def write_batch(self, batch):
         for key, value in batch:
             self._producer.produce(self._topic, value, key)
+            self._producer.poll(0)
         self._producer.flush()
 
     def close(self):

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -3,7 +3,13 @@ from datetime import datetime, timedelta, timezone
 from itertools import islice
 from typing import Any, Iterable, Iterator
 
-from bytewax.inputs import PartitionedInput, StatefulSource, batch
+from bytewax.inputs import (
+    DynamicInput,
+    PartitionedInput,
+    StatefulSource,
+    StatelessSource,
+    batch,
+)
 from bytewax.outputs import DynamicOutput, StatelessSink
 
 from .bytewax import cluster_main, run_main
@@ -154,3 +160,62 @@ def poll_next_batch(source: StatefulSource, timeout=timedelta(seconds=5)):
             raise TimeoutError()
         batch = source.next_batch()
     return batch
+
+
+class _PeriodicSource(StatelessSource):
+    def __init__(self, should_emit, frequency, limit, cb):
+        self._should_emit = should_emit
+        self._counter = 0
+        self._next_awake = datetime.now(timezone.utc)
+        self._frequency = frequency
+        self._limit = limit
+        self._cb = cb
+
+    def next_batch(self):
+        if not self._should_emit:
+            raise StopIteration()
+
+        self._next_awake += self._frequency
+        self._counter += 1
+
+        if self._limit is not None and self._counter >= self._limit:
+            raise StopIteration()
+
+        return [self._cb(self._counter)]
+
+    def next_awake(self):
+        return self._next_awake
+
+
+class TestingPeriodicInput(DynamicInput):
+    """An input that emits an increasing counter at the requested frequency.
+
+    The counter can be optionally passed to a user provided callback
+    so that items can be modified as needed before being emitted.
+
+    Elements are only emitted on the first worker, all other workers do nothing.
+
+    Args:
+        frequency: The period at which items will be emitted.
+
+        limit: [optional] how many items to emit before stopping.
+
+        cb: [optional] a callback that will be called for each item with the
+            item itself as first and only argument
+    """
+
+    __test__ = False
+
+    def __init__(self, frequency, *, limit=None, cb=None):
+        self._frequency = frequency
+        self._limit = limit
+
+        def default_cb(x):
+            return x
+
+        self._cb = cb or default_cb
+
+    def build(self, worker_index, worker_count):
+        return _PeriodicSource(
+            worker_index == 0, self._frequency, self._limit, self._cb
+        )

--- a/pytests/test_operators.py
+++ b/pytests/test_operators.py
@@ -11,6 +11,26 @@ from pytest import raises
 ZERO_TD = timedelta(seconds=0)
 
 
+def test_batch_operator():
+    in_data = [("ALL", x) for x in range(10)]
+    flow = Dataflow()
+    flow.input("in", TestingInput(in_data))
+    # Use a long timeout to avoid triggering that.
+    # We can't easily test system time based behavior.
+    flow.batch("batch", size=3, timeout=timedelta(seconds=10))
+    out = []
+    flow.output("out", TestingOutput(out))
+    run_main(flow)
+    assert sorted(out) == sorted(
+        [
+            ("ALL", [0, 1, 2]),
+            ("ALL", [3, 4, 5]),
+            ("ALL", [6, 7, 8]),
+            ("ALL", [9]),
+        ]
+    )
+
+
 def test_requires_input():
     flow = Dataflow()
     out = []

--- a/pytests/test_operators.py
+++ b/pytests/test_operators.py
@@ -17,7 +17,7 @@ def test_batch_operator():
     flow.input("in", TestingInput(in_data))
     # Use a long timeout to avoid triggering that.
     # We can't easily test system time based behavior.
-    flow.batch("batch", size=3, timeout=timedelta(seconds=10))
+    flow.batch("batch", max_size=3, timeout=timedelta(seconds=10))
     out = []
     flow.output("out", TestingOutput(out))
     run_main(flow)

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -106,14 +106,23 @@ impl Dataflow {
 
     /// Batch incoming items until either a batch size has been reached or a timeout has passed.
     /// This is a stateful operator.
-    fn batch(&mut self, step_id: StepId, size: usize, timeout: chrono::Duration) {
+    ///
+    /// Args:
+    ///   step_id (str):
+    ///       Uniquely identifies this step for recovery.
+    ///   max_size (int):
+    ///       Maximum size of the batch.
+    ///   timeout (datetime.timedelta):
+    ///       Timeout before emitting the batch, even if max_size
+    ///       was not reached yet.
+    fn batch(&mut self, step_id: StepId, max_size: usize, timeout: chrono::Duration) {
         assert!(
             timeout >= chrono::Duration::zero(),
             "batch timeout should be a positive timedelta"
         );
         self.steps.push(Step::Batch {
             step_id,
-            size,
+            max_size,
             timeout,
         });
     }
@@ -718,12 +727,12 @@ impl Dataflow {
             match step {
                 Step::Batch {
                     step_id,
-                    size,
+                    max_size,
                     timeout,
                 } => {
                     step_dict.set_item("type", "Batch")?;
                     step_dict.set_item("step_id", step_id)?;
-                    step_dict.set_item("size", size)?;
+                    step_dict.set_item("max_size", max_size)?;
                     step_dict.set_item("timeout", timeout)?;
                 }
                 Step::Redistribute => {
@@ -842,7 +851,7 @@ impl Dataflow {
 pub(crate) enum Step {
     Batch {
         step_id: StepId,
-        size: usize,
+        max_size: usize,
         timeout: chrono::Duration,
     },
     Redistribute,

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -37,7 +37,10 @@ impl Dataflow {
     }
 
     fn batch(&mut self, step_id: StepId, size: usize, timeout: chrono::Duration) {
-        assert!(timeout > chrono::Duration::zero());
+        assert!(
+            timeout >= chrono::Duration::zero(),
+            "batch timeout should be a positive timedelta"
+        );
         self.steps.push(Step::Batch {
             step_id,
             size,
@@ -128,6 +131,7 @@ impl Dataflow {
     ///       Uniquely identifies this step for recovery.
     ///   output (bytewax.outputs.Output):
     ///       Output definition.
+    #[pyo3(signature = (step_id, output, *, batched_input = false))]
     fn output(&mut self, step_id: StepId, output: Output, batched_input: bool) {
         self.steps.push(Step::Output {
             step_id,

--- a/src/operators/batch.rs
+++ b/src/operators/batch.rs
@@ -23,9 +23,7 @@ impl BatchLogic {
                 .and_then(|state| -> Option<Vec<TdPyAny>> {
                     unwrap_any!(Python::with_gil(|py| state.extract(py)))
                 })
-                // Since we know the max size of the vec, allocate
-                // with all the necessary capacity here.
-                .unwrap_or_else(|| Vec::with_capacity(size));
+                .unwrap_or_else(Vec::new);
             Self {
                 size,
                 acc,

--- a/src/operators/batch.rs
+++ b/src/operators/batch.rs
@@ -20,10 +20,8 @@ impl BatchLogic {
     pub(crate) fn builder(size: usize, timeout: Duration) -> impl Fn(Option<TdPyAny>) -> Self {
         move |resume_snapshot| {
             let acc = resume_snapshot
-                .and_then(|state| {
-                    let state: Option<Vec<TdPyAny>> =
-                        unwrap_any!(Python::with_gil(|py| state.extract(py)));
-                    state
+                .and_then(|state| -> Option<Vec<TdPyAny>> {
+                    unwrap_any!(Python::with_gil(|py| state.extract(py)))
                 })
                 .unwrap_or_default();
             Self {

--- a/src/operators/batch.rs
+++ b/src/operators/batch.rs
@@ -23,7 +23,7 @@ impl BatchLogic {
                 .and_then(|state| -> Option<Vec<TdPyAny>> {
                     unwrap_any!(Python::with_gil(|py| state.extract(py)))
                 })
-                .unwrap_or_else(Vec::new);
+                .unwrap_or_default();
             Self {
                 size,
                 acc,

--- a/src/operators/batch.rs
+++ b/src/operators/batch.rs
@@ -77,10 +77,8 @@ impl StatefulLogic<TdPyAny, TdPyAny, Option<TdPyAny>> for BatchLogic {
 
     fn next_awake(&self) -> Option<chrono::DateTime<chrono::Utc>> {
         // Request an awake when the timeout expires
-        Some(
-            chrono::Utc::now()
-                + chrono::Duration::from_std(self.timeout + self.last_drain.elapsed()).unwrap(),
-        )
+        let remaining_time = self.timeout.saturating_sub(self.last_drain.elapsed());
+        Some(chrono::Utc::now() + chrono::Duration::from_std(remaining_time).unwrap())
     }
 
     fn snapshot(&self) -> TdPyAny {

--- a/src/operators/batch.rs
+++ b/src/operators/batch.rs
@@ -1,0 +1,86 @@
+use std::{
+    task::Poll,
+    time::{Duration, Instant},
+};
+
+use pyo3::{Python, ToPyObject};
+
+use crate::{pyo3_extensions::TdPyAny, unwrap_any};
+
+use super::stateful_unary::{LogicFate, StatefulLogic};
+
+pub(crate) struct BatchLogic {
+    size: usize,
+    timeout: Duration,
+    last_activation: Instant,
+    acc: Vec<TdPyAny>,
+}
+
+impl BatchLogic {
+    pub(crate) fn builder(size: usize, timeout: Duration) -> impl Fn(Option<TdPyAny>) -> Self {
+        move |resume_snapshot| {
+            let acc = resume_snapshot
+                .and_then(|state| {
+                    let state: Option<Vec<TdPyAny>> =
+                        unwrap_any!(Python::with_gil(|py| state.extract(py)));
+                    state
+                })
+                .unwrap_or_default();
+            Self {
+                size,
+                acc,
+                timeout,
+                last_activation: Instant::now(),
+            }
+        }
+    }
+}
+
+impl StatefulLogic<TdPyAny, TdPyAny, Option<TdPyAny>> for BatchLogic {
+    fn on_awake(&mut self, next_value: Poll<Option<TdPyAny>>) -> Option<TdPyAny> {
+        if let Poll::Ready(Some(value)) = next_value {
+            self.acc.push(value);
+            if self.acc.len() >= self.size || self.last_activation.elapsed() >= self.timeout {
+                Python::with_gil(|py| {
+                    Some(
+                        self.acc
+                            .drain(..)
+                            .collect::<Vec<TdPyAny>>()
+                            .to_object(py)
+                            .into(),
+                    )
+                })
+            } else {
+                None
+            }
+        } else if self.last_activation.elapsed() >= self.timeout {
+            Python::with_gil(|py| {
+                Some(
+                    self.acc
+                        .drain(..)
+                        .collect::<Vec<TdPyAny>>()
+                        .to_object(py)
+                        .into(),
+                )
+            })
+        } else {
+            None
+        }
+    }
+
+    fn fate(&self) -> super::stateful_unary::LogicFate {
+        if self.acc.is_empty() {
+            LogicFate::Discard
+        } else {
+            LogicFate::Retain
+        }
+    }
+
+    fn next_awake(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        None
+    }
+
+    fn snapshot(&self) -> TdPyAny {
+        Python::with_gil(|py| self.acc.to_object(py).into())
+    }
+}

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -18,6 +18,7 @@ use crate::timely::WorkerIndex;
 use crate::try_unwrap;
 use crate::unwrap_any;
 
+pub(crate) mod batch;
 pub(crate) mod collect_window;
 pub(crate) mod fold_window;
 pub(crate) mod reduce;

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -264,12 +264,32 @@ where
                         incoming.swap(&mut routed_tmp);
                         for (worker, (part, (key, value))) in routed_tmp.drain(..) {
                             assert!(worker == this_worker);
-                            items_inbuf
-                                .entry(*epoch)
-                                .or_insert_with(BTreeMap::new)
-                                .entry(part)
-                                .or_insert_with(Vec::new)
-                                .push((key, value));
+
+                            if batched_input {
+                                items_inbuf
+                                    .entry(*epoch)
+                                    .or_insert_with(BTreeMap::new)
+                                    .entry(part)
+                                    .or_insert_with(Vec::new)
+                                    .extend(Python::with_gil(|py| {
+                                        // `value` here has to be a python type
+                                        // that can be converted to a vec.
+                                        // We extract each element and add the key to each.
+                                        value
+                                            .extract::<Vec<TdPyAny>>(py)
+                                            .expect("Batch input should be an iterable")
+                                            .into_iter()
+                                            .map(|value| (key.clone(), value))
+                                            .collect::<Vec<(StateKey, TdPyAny)>>()
+                                    }));
+                            } else {
+                                items_inbuf
+                                    .entry(*epoch)
+                                    .or_insert_with(BTreeMap::new)
+                                    .entry(part)
+                                    .or_insert_with(Vec::new)
+                                    .push((key, value));
+                            }
                         }
 
                         ncater.notify_at(*epoch);
@@ -494,13 +514,12 @@ where
                         if batched_input {
                             tmp_incoming = tmp_incoming
                                 .drain(..)
-                                .flat_map(|batch| {
-                                    let res: Vec<TdPyAny> = Python::with_gil(|py| {
-                                        batch
-                                            .extract(py)
-                                            .expect("Batch input should be an iterable")
-                                    });
-                                    res
+                                .flat_map(|batch| -> Vec<TdPyAny> {
+                                    Python::with_gil(|py| {
+                                        batch.extract(py).expect(
+                                            "batched input for output should be an iterable",
+                                        )
+                                    })
                                 })
                                 .collect();
                         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -445,14 +445,10 @@ where
                     stream = output.map(wrap_state_pair);
                     snaps.push(snap);
                 }
-                Step::Output {
-                    step_id,
-                    output,
-                    batched_input,
-                } => {
+                Step::Output { step_id, output } => {
                     if let Ok(output) = output.extract(py) {
                         let (output, snap) = stream
-                            .partitioned_output(py, step_id, output, &loads, batched_input)
+                            .partitioned_output(py, step_id, output, &loads)
                             .reraise("error building PartitionedOutput")?;
                         let clock = output.map(|_| ());
 
@@ -461,7 +457,7 @@ where
                         stream = output;
                     } else if let Ok(output) = output.extract(py) {
                         let output = stream
-                            .dynamic_output(py, step_id, output, batched_input)
+                            .dynamic_output(py, step_id, output)
                             .reraise("error building DynamicOutput")?;
                         let clock = output.map(|_| ());
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -244,7 +244,7 @@ where
             match step {
                 Step::Batch {
                     step_id,
-                    size,
+                    max_size: size,
                     timeout,
                 } => {
                     let (output, snap) = stream.map(extract_state_pair).stateful_unary(


### PR DESCRIPTION
Given the discussion in #286 this PR introduces a `flow.batch(step_id, size, timeout)` operator that takes items in input and emits them as a batch when either the requested batch size is reached or when the timeout expires.
