### PR TITLE
Add initial metrics implementation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,9 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "opentelemetry-otlp",
+ "opentelemetry-prometheus",
+ "opentelemetry_sdk",
+ "prometheus",
  "pyo3",
  "rusqlite",
  "rusqlite_migration",
@@ -974,6 +977,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-prometheus"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d81bc254e2d572120363a2b16cdb0d715d301b5789be0cfc26ad87e4e10e53"
+dependencies = [
+ "once_cell",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1162,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,6 +1198,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "pyo3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,12 @@ bincode = { version = "1.3.3" }
 chrono = { version = "0.4", default_features = false, features = ["clock", "serde"] }
 fastrand = { version = "1.9.0" }
 num = { version = "0.4.0" }
-opentelemetry = { version = "0.20", features = ["rt-tokio"] }
+opentelemetry = { version = "0.20", features = ["rt-tokio", "metrics"] }
+opentelemetry_sdk = { version = "0.20", features = ["metrics"] }
 opentelemetry-jaeger = { version = "0.19", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.13", features = ["trace", "reqwest-client", "grpc-tonic"] }
+opentelemetry-prometheus = "0.13.0"
+prometheus = "0.13.3"
 pyo3 = { version = "0.19.2", features = ["macros", "chrono"] }
 rusqlite = { version = "0.29.0", features = ["bundled", "series"] }
 rusqlite_migration = { version = "1.0.2" }

--- a/docs/articles/getting-started/design-patterns.md
+++ b/docs/articles/getting-started/design-patterns.md
@@ -74,7 +74,7 @@ flow = Dataflow()
 flow.input("inp", TestingInput(inp))
 
 # Operate on input
-flow.flat_map("str split", str.split)
+flow.flat_map("str_split", str.split)
 
 flow.output("out", StdOutput())
 run_main(flow)
@@ -163,11 +163,11 @@ def user_reducer(all_events, new_events):
 
 def collect_user_events(flow, clock, window):
     # event
-    flow.map("key by user_id", lambda e: (e["user_id"], [e["type"]]))
+    flow.map("key_by_user_id", lambda e: (e["user_id"], [e["type"]]))
     # (user_id, [event])
     flow.reduce_window("reducer", clock, window, user_reducer)
     # (user_id, events_for_user)
-    flow.map("collected events", lambda e: {"user_id": e[0], "all_events": e[1]})
+    flow.map("collected_events", lambda e: {"user_id": e[0], "all_events": e[1]})
 
 
 clock = SystemClockConfig()

--- a/docs/articles/getting-started/design-patterns.md
+++ b/docs/articles/getting-started/design-patterns.md
@@ -40,7 +40,7 @@ flow = Dataflow()
 flow.input("inp", TestingInput(inp))
 
 # Operate on input
-flow.flat_map(split_sentence)
+flow.flat_map("split", split_sentence)
 
 flow.output("out", StdOutput())
 run_main(flow)
@@ -57,7 +57,7 @@ flow = Dataflow()
 flow.input("inp", TestingInput(inp))
 
 # Operate on input
-flow.flat_map(lambda s: s.split())
+flow.flat_map("split", lambda s: s.split())
 
 flow.output("out", StdOutput())
 run_main(flow)
@@ -74,7 +74,7 @@ flow = Dataflow()
 flow.input("inp", TestingInput(inp))
 
 # Operate on input
-flow.flat_map(str.split)
+flow.flat_map("str split", str.split)
 
 flow.output("out", StdOutput())
 run_main(flow)
@@ -163,11 +163,11 @@ def user_reducer(all_events, new_events):
 
 def collect_user_events(flow, clock, window):
     # event
-    flow.map(lambda e: (e["user_id"], [e["type"]]))
+    flow.map("key by user_id", lambda e: (e["user_id"], [e["type"]]))
     # (user_id, [event])
     flow.reduce_window("reducer", clock, window, user_reducer)
     # (user_id, events_for_user)
-    flow.map(lambda e: {"user_id": e[0], "all_events": e[1]})
+    flow.map("collected events", lambda e: {"user_id": e[0], "all_events": e[1]})
 
 
 clock = SystemClockConfig()

--- a/docs/articles/getting-started/execution.md
+++ b/docs/articles/getting-started/execution.md
@@ -43,7 +43,7 @@ from bytewax.connectors.stdio import StdOutput
 
 flow = Dataflow()
 flow.input("inp", TestingInput(range(3)))
-flow.map(lambda item: item + 1)
+flow.map("add one", lambda item: item + 1)
 flow.output("out", StdOutput())
 ```
 
@@ -71,7 +71,7 @@ from bytewax.connectors.stdio import StdOutput
 def get_flow(input_range):
     flow = Dataflow()
     flow.input("inp", TestingInput(range(input_range)))
-    flow.map(lambda item: item + 1)
+    flow.map("add one", lambda item: item + 1)
     flow.output("out", StdOutput())
     return flow
 ```

--- a/docs/articles/getting-started/execution.md
+++ b/docs/articles/getting-started/execution.md
@@ -43,7 +43,7 @@ from bytewax.connectors.stdio import StdOutput
 
 flow = Dataflow()
 flow.input("inp", TestingInput(range(3)))
-flow.map("add one", lambda item: item + 1)
+flow.map("add_one", lambda item: item + 1)
 flow.output("out", StdOutput())
 ```
 
@@ -71,7 +71,7 @@ from bytewax.connectors.stdio import StdOutput
 def get_flow(input_range):
     flow = Dataflow()
     flow.input("inp", TestingInput(range(input_range)))
-    flow.map("add one", lambda item: item + 1)
+    flow.map("add_one", lambda item: item + 1)
     flow.output("out", StdOutput())
     return flow
 ```

--- a/docs/articles/getting-started/simple-example.md
+++ b/docs/articles/getting-started/simple-example.md
@@ -49,9 +49,9 @@ window_config = TumblingWindow(
 
 flow = Dataflow()
 flow.input("inp", FileInput("wordcount.txt"))
-flow.map("lowercase words", lower)
-flow.flat_map("tokenize input", tokenize)
-flow.map("initial count", initial_count)
+flow.map("lowercase_words", lower)
+flow.flat_map("tokenize_input", tokenize)
+flow.map("initial_count", initial_count)
 flow.reduce_window("sum", clock_config, window_config, add)
 flow.output("out", StdOutput())
 ```

--- a/docs/articles/getting-started/simple-example.md
+++ b/docs/articles/getting-started/simple-example.md
@@ -49,9 +49,9 @@ window_config = TumblingWindow(
 
 flow = Dataflow()
 flow.input("inp", FileInput("wordcount.txt"))
-flow.map(lower)
-flow.flat_map(tokenize)
-flow.map(initial_count)
+flow.map("lowercase words", lower)
+flow.flat_map("tokenize input", tokenize)
+flow.map("initial count", initial_count)
 flow.reduce_window("sum", clock_config, window_config, add)
 flow.output("out", StdOutput())
 ```
@@ -142,7 +142,7 @@ def lower(line):
     return line.lower()
 
 
-flow.map(lower)
+flow.map("lowercase_words", lower)
 ```
 
 For each item that our generator produces, the map operator will use the [built-in string function `lower()`](https://docs.python.org/3/library/stdtypes.html#str.lower) to emit downstream a copy of the string with all characters converted to lowercase.
@@ -174,7 +174,7 @@ results in:
 To make use of `tokenize` function, we'll use the [flat map operator](/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow.flat_map):
 
 ```python
-flow.flat_map(tokenize)
+flow.flat_map("tokenize", tokenize)
 ```
 
 The flat map operator defines a step which calls a function on each input item. Each word in the list we return from our function will then be emitted downstream individually.
@@ -200,7 +200,7 @@ window_config = TumblingWindow(
     length=timedelta(seconds=5), align_to=datetime(2023, 1, 1, tzinfo=timezone.utc)
 )
 
-flow.map(initial_count)
+flow.map("initial_count", initial_count)
 flow.reduce_window("sum", clock_config, window_config, add)
 ```
 

--- a/examples/apriori.py
+++ b/examples/apriori.py
@@ -47,9 +47,9 @@ wc = TumblingWindow(
 out = []
 flow = Dataflow()
 flow.input("inp", FileInput("examples/sample_data/apriori.txt"))
-flow.map(lower)
-flow.flat_map(tokenize)
-flow.map(initial_count)
+flow.map("lower", lower)
+flow.flat_map("tokenize", tokenize)
+flow.map("initial_count", initial_count)
 flow.reduce_window("reduce", cc, wc, operator.add)
 flow.output("out", TestingOutput(out))
 
@@ -57,10 +57,12 @@ flow.output("out", TestingOutput(out))
 out2 = []
 flow2 = Dataflow()
 flow2.input("input", FileInput("examples/sample_data/apriori.txt"))
-flow2.map(lower)
-flow2.filter(is_most_common)  # count basket only with popular products
-flow2.flat_map(build_pairs)
-flow2.map(initial_count)
+flow2.map("lower", lower)
+flow2.filter(
+    "is_most_common", is_most_common
+)  # count basket only with popular products
+flow2.flat_map("build_pairs", build_pairs)
+flow2.map("initial_count", initial_count)
 flow2.reduce_window("reduce", cc, wc, operator.add)
 flow2.output("out", TestingOutput(out2))
 

--- a/examples/event_time_processing.py
+++ b/examples/event_time_processing.py
@@ -39,7 +39,7 @@ def parse_value(key__data):
     return json.loads(data)
 
 
-flow.map(parse_value)
+flow.map("parse_value", parse_value)
 
 
 # Divide the readings by sensor type, so that we only
@@ -96,5 +96,5 @@ def format_event(event):
     )
 
 
-flow.map(format_event)
+flow.map("format_event", format_event)
 flow.output("out", StdOutput())

--- a/examples/events_to_parquet.py
+++ b/examples/events_to_parquet.py
@@ -93,11 +93,11 @@ wc = TumblingWindow(
 
 flow = Dataflow()
 flow.input("input", FakeWebEventsInput())
-flow.map(json.loads)
+flow.map("load_json", json.loads)
 # {"page_url_path": "/path", "event_timestamp": "2022-01-02 03:04:05", ...}
-flow.map(add_date_columns)
+flow.map("add_date_columns", add_date_columns)
 # {"page_url_path": "/path", "year": 2022, "month": 1, "day": 5, ... }
-flow.map(group_by_page)
+flow.map("group_by_page", group_by_page)
 # ("/path", DataFrame([{
 #     "page_url_path": "/path",
 #     "year": 2022,

--- a/examples/orderbook.py
+++ b/examples/orderbook.py
@@ -120,14 +120,14 @@ class OrderBook:
 
 flow = Dataflow()
 flow.input("input", CoinbaseFeedInput(["BTC-USD", "ETH-USD", "BTC-EUR", "ETH-EUR"]))
-flow.map(json.loads)
+flow.map("load_json", json.loads)
 # {
 #     'type': 'l2update',
 #     'product_id': 'BTC-USD',
 #     'changes': [['buy', '36905.39', '0.00334873']],
 #     'time': '2022-05-05T17:25:09.072519Z',
 # }
-flow.map(key_on_product)
+flow.map("key_on_product", key_on_product)
 # ('BTC-USD', {
 #     'type': 'l2update',
 #     'product_id': 'BTC-USD',

--- a/examples/recovery_wordcount.py
+++ b/examples/recovery_wordcount.py
@@ -32,11 +32,11 @@ def add(running_count, new_count):
 flow = Dataflow()
 flow.input("inp", FileInput("examples/sample_data/wordcount.txt"))
 # "Here, we have FULL sentences."
-flow.map(lower)
+flow.map("lower", lower)
 # "here, we have lowercase sentences."
-flow.flat_map(tokenize)
+flow.flat_map("tokenize", tokenize)
 # "words"
-flow.map(initial_count)
+flow.map("initial_count", initial_count)
 # ("word", 1)
 flow.stateful_map("running_count", count_builder, add)
 # ("word", running_count)

--- a/examples/redpanda_anomaly_detection.py
+++ b/examples/redpanda_anomaly_detection.py
@@ -36,7 +36,7 @@ def group_instance_and_normalize(key__data):
     return data["instance"], data
 
 
-flow.map(group_instance_and_normalize)
+flow.map("group_and_normalize", group_instance_and_normalize)
 
 
 class AnomalyDetector(anomaly.HalfSpaceTrees):
@@ -86,6 +86,6 @@ def format_output(event):
     )
 
 
-flow.filter(lambda x: bool(x[1][4]))
-flow.map(format_output)
+flow.filter("filter_anomalies", lambda x: bool(x[1][4]))
+flow.map("format", format_output)
 flow.output("out", StdOutput())

--- a/examples/search_session.py
+++ b/examples/search_session.py
@@ -102,17 +102,17 @@ def calc_ctr(search_session):
 flow = Dataflow()
 flow.input("inp", TestingInput(IMAGINE_THESE_EVENTS_STREAM_FROM_CLIENTS))
 # event
-flow.map(initial_session)
+flow.map("initial_session", initial_session)
 # (user, [event])
 # TODO: reduce_window with clock so we can get the mean CTR per minute.
 flow.reduce("sessionizer", operator.add, session_has_closed)
 # (user, [event, ...])
-flow.map(remove_key)
+flow.map("remove_key", remove_key)
 # [event, ...]
 # Take a user session and split it up into a search session, one per
 # search.
-flow.flat_map(split_into_searches)
-flow.filter(has_search)
+flow.flat_map("split_into_searches", split_into_searches)
+flow.filter("filter_search", has_search)
 # Calculate search CTR per search.
-flow.map(calc_ctr)
+flow.map("calc_ctr", calc_ctr)
 flow.output("out", StdOutput())

--- a/examples/simple_kafka_in_and_out.py
+++ b/examples/simple_kafka_in_and_out.py
@@ -21,10 +21,10 @@ def serialize_with_key(key_payload):
     return new_key_bytes, json.dumps(payload).encode("utf-8")
 
 
-flow.map(deserialize)
+flow.map("deserialize", deserialize)
 flow.output("out", StdOutput())
 
-flow.map(serialize_with_key)
+flow.map("serialize_with_key", serialize_with_key)
 flow.output(
     "out",
     KafkaOutput(

--- a/examples/subflow.py
+++ b/examples/subflow.py
@@ -13,7 +13,7 @@ def calc_counts(flow):
     """Add steps to this flow which counts the frequencies of input
     items and emits (item, count) tuples downstream."""
     # `str` format required for reduce_window key
-    flow.map(lambda x: (str(x), 1))
+    flow.map("add_key", lambda x: (str(x), 1))
     flow.reduce_window(
         "sum",
         SystemClockConfig(),
@@ -44,13 +44,13 @@ def format_output(count_count):
 flow = Dataflow()
 flow.input("inp", FileInput("examples/sample_data/wordcount.txt"))
 # "at this point we have full sentences as items in the dataflow"
-flow.flat_map(str.split)
+flow.flat_map("split", str.split)
 # "words"
 calc_counts(flow)
 # ("word", count)
-flow.map(get_count)
+flow.map("get_count", get_count)
 # count
 calc_counts(flow)
-flow.map(format_output)
+flow.map("format_output", format_output)
 # (that_same_count, num_words_with_the_same_count)
 flow.output("out", StdOutput())

--- a/examples/tracing.py
+++ b/examples/tracing.py
@@ -35,7 +35,7 @@ def stringy(x):
 
 flow = Dataflow()
 flow.input("inp", TestingInput(inp()))
-flow.map(double)
-flow.map(minus_one)
-flow.map(stringy)
+flow.map("double", double)
+flow.map("minus_one", minus_one)
+flow.map("stringy", stringy)
 flow.output("out", StdOutput())

--- a/examples/wikistream.py
+++ b/examples/wikistream.py
@@ -4,15 +4,10 @@ from datetime import datetime, timedelta, timezone
 
 # pip install aiohttp-sse-client
 from aiohttp_sse_client.client import EventSource
-from bytewax.connectors.files import FileOutput
+from bytewax.connectors.stdio import StdOutput
 from bytewax.dataflow import Dataflow
 from bytewax.inputs import PartitionedInput, StatefulSource, batch_async
-from bytewax.tracing import setup_tracing
 from bytewax.window import SystemClockConfig, TumblingWindow
-
-tracer = setup_tracing(
-    log_level="TRACE",
-)
 
 
 async def _sse_agen(url):
@@ -73,4 +68,4 @@ flow.reduce_window(
 flow.stateful_map("keep_max", lambda: 0, keep_max)
 # ("server.name", max_per_window)
 flow.map("format", lambda x: (x[0], f"{x[0]}, {x[1]}"))
-flow.output("out", FileOutput("wikifile.txt"))
+flow.output("out", StdOutput())

--- a/examples/wordcount.py
+++ b/examples/wordcount.py
@@ -28,11 +28,11 @@ wc = TumblingWindow(
 flow = Dataflow()
 flow.input("inp", FileInput("examples/sample_data/wordcount.txt"))
 # Full line WITH uppercase
-flow.map(lower)
+flow.map("lower", lower)
 # full line lowercased
-flow.flat_map(tokenize)
+flow.flat_map("tokenize", tokenize)
 # word
-flow.map(initial_count)
+flow.map("initial_count", initial_count)
 # ("word, 1")
 flow.reduce_window(
     "sum",

--- a/pytests/test_encoder.py
+++ b/pytests/test_encoder.py
@@ -72,20 +72,28 @@ def test_encoding_custom_input():
 
 def test_encoding_map():
     flow = Dataflow()
-    flow.map(lambda x: x + 1)
+    flow.map("add_one", lambda x: x + 1)
 
     assert encode_dataflow(flow) == json.dumps(
-        {"type": "Dataflow", "steps": [{"type": "Map", "mapper": "<lambda>"}]},
+        {
+            "type": "Dataflow",
+            "steps": [{"type": "Map", "step_id": "add_one", "mapper": "<lambda>"}],
+        },
         sort_keys=True,
     )
 
 
 def test_encoding_filter():
     flow = Dataflow()
-    flow.filter(lambda x: x == 1)
+    flow.filter("filter_one", lambda x: x == 1)
 
     assert encode_dataflow(flow) == json.dumps(
-        {"type": "Dataflow", "steps": [{"type": "Filter", "predicate": "<lambda>"}]},
+        {
+            "type": "Dataflow",
+            "steps": [
+                {"type": "Filter", "step_id": "filter_one", "predicate": "<lambda>"}
+            ],
+        },
         sort_keys=True,
     )
 
@@ -112,10 +120,13 @@ def test_encoding_reduce():
 
 def test_encoding_flat_map():
     flow = Dataflow()
-    flow.flat_map(lambda x: x + 1)
+    flow.flat_map("add_one", lambda x: x + 1)
 
     assert encode_dataflow(flow) == json.dumps(
-        {"type": "Dataflow", "steps": [{"type": "FlatMap", "mapper": "<lambda>"}]},
+        {
+            "type": "Dataflow",
+            "steps": [{"type": "FlatMap", "step_id": "add_one", "mapper": "<lambda>"}],
+        },
         sort_keys=True,
     )
 
@@ -178,9 +189,12 @@ def test_encoding_fold_window():
 
 def test_encoding_method_descriptor():
     flow = Dataflow()
-    flow.flat_map(str.split)
+    flow.flat_map("split", str.split)
 
     assert encode_dataflow(flow) == json.dumps(
-        {"type": "Dataflow", "steps": [{"type": "FlatMap", "mapper": "split"}]},
+        {
+            "type": "Dataflow",
+            "steps": [{"type": "FlatMap", "step_id": "split", "mapper": "split"}],
+        },
         sort_keys=True,
     )

--- a/pytests/test_event_time.py
+++ b/pytests/test_event_time.py
@@ -36,9 +36,9 @@ def test_event_time_processing():
 
     flow = Dataflow()
     flow.input("inp", TestingInput(inp))
-    flow.map(extract_sensor_type)
+    flow.map("extract_sensor_type", extract_sensor_type)
     flow.fold_window("running_average", cc, wc, list, acc_values)
-    flow.map(lambda x: {f"{x[0]}_avg": sum(x[1]) / len(x[1])})
+    flow.map("format_output", lambda x: {f"{x[0]}_avg": sum(x[1]) / len(x[1])})
     out = []
     flow.output("out", TestingOutput(out))
     run_main(flow)

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -12,7 +12,7 @@ def test_run(entry_point):
     flow = Dataflow()
     inp = range(3)
     flow.input("inp", TestingInput(inp))
-    flow.map(lambda x: x + 1)
+    flow.map("add one", lambda x: x + 1)
     out = []
     flow.output("out", TestingOutput(out))
 
@@ -33,7 +33,7 @@ def test_reraises_exception(entry_point):
         else:
             return item
 
-    flow.map(boom)
+    flow.map("explode", boom)
     out = []
     flow.output("out", TestingOutput(out))
 

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -12,7 +12,7 @@ def test_run(entry_point):
     flow = Dataflow()
     inp = range(3)
     flow.input("inp", TestingInput(inp))
-    flow.map("add one", lambda x: x + 1)
+    flow.map("add_one", lambda x: x + 1)
     out = []
     flow.output("out", TestingOutput(out))
 

--- a/pytests/test_flows/simple.py
+++ b/pytests/test_flows/simple.py
@@ -11,6 +11,6 @@ def get_flow(path):
     def mapper(item):
         return "ALL", f"{item}"
 
-    flow.map(mapper)
+    flow.map("all_mapper", mapper)
     flow.output("out", FileOutput(path))
     return flow

--- a/pytests/test_operators.py
+++ b/pytests/test_operators.py
@@ -38,7 +38,7 @@ def test_map():
     def add_one(item):
         return item + 1
 
-    flow.map(add_one)
+    flow.map("add_one", add_one)
 
     out = []
     flow.output("out", TestingOutput(out))
@@ -59,7 +59,7 @@ def test_filter_map():
             return None
         return item + 1
 
-    flow.filter_map(make_odd)
+    flow.filter_map("make_odd", make_odd)
 
     out = []
     flow.output("out", TestingOutput(out))
@@ -78,7 +78,7 @@ def test_flat_map():
     def split_into_words(sentence):
         return sentence.split()
 
-    flow.flat_map(split_into_words)
+    flow.flat_map("split_into_words", split_into_words)
 
     out = []
     flow.output("out", TestingOutput(out))
@@ -97,7 +97,7 @@ def test_filter():
     def is_odd(item):
         return item % 2 != 0
 
-    flow.filter(is_odd)
+    flow.filter("is_odd", is_odd)
 
     out = []
     flow.output("out", TestingOutput(out))
@@ -171,12 +171,12 @@ def test_reduce(recovery_config):
         else:
             return [item]
 
-    flow.flat_map(trigger)
+    flow.flat_map("trigger", trigger)
 
     def user_as_key(event):
         return (event["user"], [event])
 
-    flow.map(user_as_key)
+    flow.map("user_as_key", user_as_key)
 
     def extend_session(session, event):
         return session + event
@@ -248,12 +248,12 @@ def test_stateful_map(recovery_config):
         else:
             return [item]
 
-    flow.flat_map(trigger)
+    flow.flat_map("trigger", trigger)
 
     def add_key(item):
         return item, item
 
-    flow.map(add_key)
+    flow.map("add_key", add_key)
 
     def build_seen():
         return set()
@@ -274,7 +274,7 @@ def test_stateful_map(recovery_config):
         else:
             return []
 
-    flow.flat_map(remove_seen)
+    flow.flat_map("remove_seen", remove_seen)
 
     out = []
     flow.output("out", TestingOutput(out))
@@ -350,7 +350,7 @@ def test_stateful_map_error_on_non_string_key():
         # strings.
         return event["user"], event
 
-    flow.map(add_key)
+    flow.map("add_key", add_key)
 
     def running_count(type_to_count, event):
         type_to_count[event["type"]] += 1
@@ -400,7 +400,7 @@ def test_reduce_window(recovery_config):
         else:
             return [item]
 
-    flow.flat_map(trigger)
+    flow.flat_map("trigger", trigger)
 
     clock_config = EventClockConfig(
         lambda e: e["time"], wait_for_system_duration=timedelta(0)
@@ -417,7 +417,7 @@ def test_reduce_window(recovery_config):
         key, event = key__event
         return (key, event["val"])
 
-    flow.map(extract_val)
+    flow.map("extract_val", extract_val)
 
     out = []
     flow.output("out", TestingOutput(out))
@@ -473,12 +473,12 @@ def test_fold_window(recovery_config):
         else:
             return [item]
 
-    flow.flat_map(trigger)
+    flow.flat_map("trigger", trigger)
 
     def key_off_user(event):
         return (event["user"], event)
 
-    flow.map(key_off_user)
+    flow.map("key_off_user", key_off_user)
 
     clock_config = EventClockConfig(
         lambda e: e["time"], wait_for_system_duration=timedelta(seconds=0)
@@ -545,7 +545,7 @@ def test_collect_window(recovery_config):
         else:
             return [item]
 
-    flow.flat_map(trigger)
+    flow.flat_map("trigger", trigger)
 
     clock_config = EventClockConfig(
         lambda e: e["time"], wait_for_system_duration=timedelta(0)

--- a/pytests/test_recovery.py
+++ b/pytests/test_recovery.py
@@ -36,7 +36,7 @@ def build_keep_max_dataflow(inp, explode_on):
             raise RuntimeError(msg)
         return key, value
 
-    flow.map(trigger)
+    flow.map("trigger", trigger)
 
     def keep_max(previous_max, new_item):
         if previous_max is None:

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -146,7 +146,7 @@ impl Dataflow {
     /// >>> flow.input("inp", TestingInput(range(4)))
     /// >>> def is_odd(item):
     /// ...     return item % 2 != 0
-    /// >>> flow.filter("filter odd", is_odd)
+    /// >>> flow.filter("filter_odd", is_odd)
     /// >>> flow.output("out", StdOutput())
     /// >>> run_main(flow)
     /// 1

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -593,7 +593,7 @@ impl DynamicInput {
         let meter = global::meter("dataflow");
         let counter = meter.u64_counter("dynamic_input.items_total").init();
         let worker_index_label = KeyValue::new("worker_index", worker_index.0.to_string());
-        let step_label = KeyValue::new("step_id", step_id.0.to_string());
+        let step_label = KeyValue::new("step_id", step_id.0);
         let metric_labels = vec![step_label, worker_index_label];
         let histogram = meter
             .f64_histogram("dynamic_input.next_batch.duration")

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -211,10 +211,12 @@ impl PartitionedInput {
         let all_parts = local_parts.into_broadcast(scope, S::Timestamp::minimum());
         let primary_updates = all_parts.assign_primaries(format!("{step_id}.assign_primaries"));
 
-        let meter = global::meter("dataflow");
-        let counter = meter.u64_counter("partitioned_input.items_total").init();
+        let meter = global::meter("bytewax");
+        let counter = meter
+            .u64_counter("bytewax_partitioned_input_items_total")
+            .init();
         let histogram = meter
-            .f64_histogram("partitioned_input.next_batch.duration")
+            .f64_histogram("bytewax_partitioned_input_next_batch_duration_seconds")
             .with_description("Partitioned input next_batch duration in seconds")
             .init();
 
@@ -592,13 +594,15 @@ impl DynamicInput {
         let info = op_builder.operator_info();
         let activator = scope.activator_for(&info.address[..]);
 
-        let meter = global::meter("dataflow");
-        let counter = meter.u64_counter("dynamic_input.items_total").init();
+        let meter = global::meter("bytewax");
+        let counter = meter
+            .u64_counter("bytewax_dynamic_input_items_total")
+            .init();
         let worker_index_label = KeyValue::new("worker_id", worker_index.0.to_string());
         let step_label = KeyValue::new("step_id", step_id.0);
         let metric_labels = vec![step_label, worker_index_label];
         let histogram = meter
-            .f64_histogram("dynamic_input.next_batch.duration")
+            .f64_histogram("bytewax_dynamic_input_next_batch_duration_seconds")
             .with_description("dynamic_input next_batch duration in seconds")
             .init();
 

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -194,6 +194,7 @@ impl PartitionedInput {
 
         let local_parts = self.list_parts(py).reraise("error listing partitions")?;
         let step_label = KeyValue::new("step_id", step_id.0.to_string());
+        let worker_index_label = KeyValue::new("worker_id", this_worker.0.to_string());
         let part_label_map: HashMap<StateKey, Vec<KeyValue>> = local_parts
             .iter()
             .map(|state_key| {
@@ -201,6 +202,7 @@ impl PartitionedInput {
                     state_key.clone(),
                     vec![
                         step_label.clone(),
+                        worker_index_label.clone(),
                         KeyValue::new("part_id", state_key.0.to_string()),
                     ],
                 )
@@ -592,7 +594,7 @@ impl DynamicInput {
 
         let meter = global::meter("dataflow");
         let counter = meter.u64_counter("dynamic_input.items_total").init();
-        let worker_index_label = KeyValue::new("worker_index", worker_index.0.to_string());
+        let worker_index_label = KeyValue::new("worker_id", worker_index.0.to_string());
         let step_label = KeyValue::new("step_id", step_id.0);
         let metric_labels = vec![step_label, worker_index_label];
         let histogram = meter

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -5,10 +5,13 @@
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::collections::HashMap;
 
 use chrono::DateTime;
 use chrono::Duration;
 use chrono::Utc;
+use opentelemetry::global;
+use opentelemetry::KeyValue;
 use pyo3::exceptions::PyStopIteration;
 use pyo3::exceptions::PyTypeError;
 use pyo3::intern;
@@ -27,6 +30,7 @@ use crate::pyo3_extensions::TdPyAny;
 use crate::recovery::*;
 use crate::timely::*;
 use crate::unwrap_any;
+use crate::with_timer;
 
 const DEFAULT_COOLDOWN: Duration = Duration::milliseconds(1);
 
@@ -189,8 +193,28 @@ impl PartitionedInput {
         let this_worker = scope.w_index();
 
         let local_parts = self.list_parts(py).reraise("error listing partitions")?;
+        let step_label = KeyValue::new("step_id", step_id.0.to_string());
+        let part_label_map: HashMap<StateKey, Vec<KeyValue>> = local_parts
+            .iter()
+            .map(|state_key| {
+                (
+                    state_key.clone(),
+                    vec![
+                        step_label.clone(),
+                        KeyValue::new("part_id", state_key.0.to_string()),
+                    ],
+                )
+            })
+            .collect();
         let all_parts = local_parts.into_broadcast(scope, S::Timestamp::minimum());
         let primary_updates = all_parts.assign_primaries(format!("{step_id}.assign_primaries"));
+
+        let meter = global::meter("dataflow");
+        let counter = meter.u64_counter("partitioned_input.items_total").init();
+        let histogram = meter
+            .f64_histogram("partitioned_input.next_batch.duration")
+            .with_description("Partitioned input next_batch duration in seconds")
+            .init();
 
         let routed_loads = loads
             .filter_snaps(step_id.clone())
@@ -332,14 +356,23 @@ impl PartitionedInput {
                                 *part_state.downstream_cap.time() == *part_state.snap_cap.time()
                             );
                             let epoch = part_state.downstream_cap.time();
+                            let metric_labels = part_label_map
+                                .get(part_key)
+                                .expect("No metric labels found for part key {part_key}");
 
                             if !probe.less_than(epoch) && now >= part_state.next_awake {
                                 if let Some(mut batch) =
-                                    unwrap_any!(Python::with_gil(|py| part_state
-                                        .part
-                                        .next_batch(py).reraise("error getting next input batch")))
+                                    with_timer!(
+                                        histogram, metric_labels,
+                                        unwrap_any!(
+                                            Python::with_gil(|py| part_state
+                                                             .part
+                                                             .next_batch(py).reraise("error getting next input batch"))
+                                        )
+                                    )
                                 {
                                     if !batch.is_empty() {
+                                        counter.add(batch.len() as u64, metric_labels);
                                         handle
                                             .session(&part_state.downstream_cap)
                                             .give_vec(&mut batch);
@@ -557,6 +590,16 @@ impl DynamicInput {
         let info = op_builder.operator_info();
         let activator = scope.activator_for(&info.address[..]);
 
+        let meter = global::meter("dataflow");
+        let counter = meter.u64_counter("dynamic_input.items_total").init();
+        let worker_index_label = KeyValue::new("worker_index", worker_index.0.to_string());
+        let step_label = KeyValue::new("step_id", step_id.0.to_string());
+        let metric_labels = vec![step_label, worker_index_label];
+        let histogram = meter
+            .f64_histogram("dynamic_input.next_batch.duration")
+            .with_description("dynamic_input next_batch duration in seconds")
+            .init();
+
         op_builder.build(move |mut init_caps| {
             let now = Utc::now();
 
@@ -585,12 +628,16 @@ impl DynamicInput {
                         let epoch = part_state.output_cap.time();
 
                         if !probe.less_than(epoch) && now >= part_state.next_awake {
-                            if let Some(mut batch) = unwrap_any!(Python::with_gil(|py| part_state
-                                .part
-                                .next_batch(py)
-                                .reraise("error getting next input batch")))
-                            {
+                            if let Some(mut batch) = with_timer!(
+                                histogram,
+                                metric_labels,
+                                unwrap_any!(Python::with_gil(|py| part_state
+                                    .part
+                                    .next_batch(py)
+                                    .reraise("error getting next input batch")))
+                            ) {
                                 if !batch.is_empty() {
+                                    counter.add(batch.len() as u64, &metric_labels);
                                     output_wrapper
                                         .activate()
                                         .session(&part_state.output_cap)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 pub(crate) mod dataflow;
 pub(crate) mod errors;
 pub(crate) mod inputs;
+pub(crate) mod metrics;
 pub(crate) mod operators;
 pub(crate) mod outputs;
 pub(crate) mod pyo3_extensions;

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -45,7 +45,7 @@ pub(crate) fn initialize_metrics() -> PyResult<()> {
                     record_min_max: true,
                 }),
             )
-            .unwrap(),
+            .map_err(|err| PyErr::new::<PyRuntimeError, _>(err.to_string()))?,
         )
         .build();
     global::set_meter_provider(provider);

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,10 +1,6 @@
 use opentelemetry::{
     global,
-    sdk::{
-        metrics::{Aggregation, Instrument, MeterProvider, Stream},
-        Resource,
-    },
-    KeyValue,
+    sdk::metrics::{Aggregation, Instrument, MeterProvider, Stream},
 };
 use prometheus::default_registry;
 use pyo3::{exceptions::PyRuntimeError, PyErr, PyResult};
@@ -33,10 +29,9 @@ pub(crate) fn initialize_metrics() -> PyResult<()> {
     // Create a global MeterProvider
     let provider = MeterProvider::builder()
         .with_reader(exporter)
-        .with_resource(Resource::new([KeyValue::new("service.name", "dataflow")])) // TODO: Dataflow name here?
         .with_view(
             opentelemetry_sdk::metrics::new_view(
-                Instrument::new().name("*.duration"), // Must match histogram name
+                Instrument::new().name("*duration*"), // Must match histogram name
                 Stream::new().aggregation(Aggregation::ExplicitBucketHistogram {
                     boundaries: vec![
                         0.0, 0.0005, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0,

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,0 +1,53 @@
+use opentelemetry::{
+    global,
+    sdk::{
+        metrics::{Aggregation, Instrument, MeterProvider, Stream},
+        Resource,
+    },
+    KeyValue,
+};
+use prometheus::default_registry;
+use pyo3::{exceptions::PyRuntimeError, PyErr, PyResult};
+
+#[macro_export]
+macro_rules! with_timer {
+    ($histogram: expr, $labels: expr, $body: expr) => {{
+        let now = std::time::Instant::now();
+        let res = $body;
+        $histogram.record(now.elapsed().as_secs_f64(), &$labels);
+        res
+    }};
+}
+
+/// Initialize the global registry for Prometheus metrics,
+/// and create a global MeterProvider.
+pub(crate) fn initialize_metrics() -> PyResult<()> {
+    // Initialize the global default registry for prometheus metrics
+    // as internally it's a lazy static.
+    let registry = default_registry();
+    let exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .build()
+        .map_err(|err| PyErr::new::<PyRuntimeError, _>(err.to_string()))?;
+
+    // Create a global MeterProvider
+    let provider = MeterProvider::builder()
+        .with_reader(exporter)
+        .with_resource(Resource::new([KeyValue::new("service.name", "dataflow")])) // TODO: Dataflow name here?
+        .with_view(
+            opentelemetry_sdk::metrics::new_view(
+                Instrument::new().name("*.duration"), // Must match histogram name
+                Stream::new().aggregation(Aggregation::ExplicitBucketHistogram {
+                    boundaries: vec![
+                        0.0, 0.0005, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0,
+                        2.5, 5.0, 7.5, 10.0,
+                    ],
+                    record_min_max: true,
+                }),
+            )
+            .unwrap(),
+        )
+        .build();
+    global::set_meter_provider(provider.clone());
+    Ok(())
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -48,6 +48,6 @@ pub(crate) fn initialize_metrics() -> PyResult<()> {
             .unwrap(),
         )
         .build();
-    global::set_meter_provider(provider.clone());
+    global::set_meter_provider(provider);
     Ok(())
 }

--- a/src/operators/stateful_unary.rs
+++ b/src/operators/stateful_unary.rs
@@ -198,9 +198,9 @@ where
         let partd_self = self.partition(format!("{step_id}.self_partition"), &workers, self_pf);
         let partd_loads = loads.partition(format!("{step_id}.load_partition"), &workers, loads_pf);
 
-        let meter = global::meter("dataflow");
+        let meter = global::meter("bytewax");
         let logic_histogram = meter
-            .f64_histogram("stateful_unary.logic.duration")
+            .f64_histogram("bytewax_stateful_unary_logic_duration_seconds")
             .with_description("stateful_unary logic duration in seconds")
             .init();
         let labels = vec![
@@ -209,7 +209,7 @@ where
         ];
 
         let snapshot_histogram = meter
-            .f64_histogram("stateful_unary.snapshot.duration")
+            .f64_histogram("bytewax_stateful_unary_snapshot_duration_seconds")
             .with_description("stateful_unary logic snapshot duration in seconds")
             .init();
 

--- a/src/operators/stateful_unary.rs
+++ b/src/operators/stateful_unary.rs
@@ -20,6 +20,8 @@ use std::task::Poll;
 
 use chrono::DateTime;
 use chrono::Utc;
+use opentelemetry::global;
+use opentelemetry::KeyValue;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
@@ -38,6 +40,7 @@ use crate::timely::*;
 
 pub(crate) use crate::recovery::*;
 use crate::unwrap_any;
+use crate::with_timer;
 
 /// If a [`StatefulLogic`] for a key should be retained by
 /// [`StatefulUnary::stateful_unary`].
@@ -194,6 +197,21 @@ where
         let loads_pf = BuildHasherDefault::<DefaultHasher>::default();
         let partd_self = self.partition(format!("{step_id}.self_partition"), &workers, self_pf);
         let partd_loads = loads.partition(format!("{step_id}.load_partition"), &workers, loads_pf);
+
+        let meter = global::meter("dataflow");
+        let logic_histogram = meter
+            .f64_histogram("stateful_unary.logic.duration")
+            .with_description("stateful_unary logic duration in seconds")
+            .init();
+        let labels = vec![
+            KeyValue::new("step_id", step_id.0.to_string()),
+            KeyValue::new("worker_id", this_worker.0.to_string()),
+        ];
+
+        let snapshot_histogram = meter
+            .f64_histogram("stateful_unary.snapshot.duration")
+            .with_description("stateful_unary logic snapshot duration in seconds")
+            .init();
 
         let op_name = format!("{step_id}.stateful_unary");
         let mut op_builder = OperatorBuilder::new(op_name.clone(), self.scope());
@@ -418,7 +436,7 @@ where
                                 let mut logic = current_logic
                                     .remove(&key)
                                     .unwrap_or_else(|| logic_builder(None));
-                                let output = logic.on_awake(next_value);
+                                let output = with_timer!(logic_histogram, labels, logic.on_awake(next_value));
                                 output_session.give_iterator(
                                     output.into_iter().map(|item| (key.clone(), item)),
                                 );
@@ -474,7 +492,7 @@ where
                                     // awake at value, if any.
                                     let change = if let Some(logic) = current_logic.get(&state_key)
                                     {
-                                        let logic_state = logic.snapshot();
+                                        let logic_state = with_timer!(snapshot_histogram, labels, logic.snapshot());
                                         let next_awake =
                                             current_next_awake.get(&state_key).cloned();
                                         let state = unwrap_any!(Python::with_gil(

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -219,6 +219,7 @@ where
         let meter = global::meter("dataflow");
         let counter = meter.u64_counter("partitioned_output.items_total").init();
         let step_label = KeyValue::new("step_id", step_id.0.to_string());
+        let worker_index_label = KeyValue::new("worker_id", this_worker.0.to_string());
         let histogram = meter
             .f64_histogram("partitioned_output.duration")
             .with_description("Partitioned output duration in seconds")
@@ -233,6 +234,7 @@ where
                     state_key.clone(),
                     vec![
                         step_label.clone(),
+                        worker_index_label.clone(),
                         KeyValue::new("part_id", state_key.0.to_string()),
                     ],
                 )

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -216,12 +216,14 @@ where
         let this_worker = self.scope().w_index();
 
         // Set up metrics for this output
-        let meter = global::meter("dataflow");
-        let counter = meter.u64_counter("partitioned_output.items_total").init();
+        let meter = global::meter("bytewax");
+        let counter = meter
+            .u64_counter("bytewax_partitioned_output_items_total")
+            .init();
         let step_label = KeyValue::new("step_id", step_id.0.to_string());
         let worker_index_label = KeyValue::new("worker_id", this_worker.0.to_string());
         let histogram = meter
-            .f64_histogram("partitioned_output.duration")
+            .f64_histogram("bytewax_partitioned_output_duration_seconds")
             .with_description("Partitioned output duration in seconds")
             .init();
 
@@ -513,13 +515,15 @@ where
         let worker_count = self.scope().w_count();
         let mut sink = Some(output.build(py, worker_index, worker_count)?);
 
-        let meter = global::meter("dataflow");
-        let counter = meter.u64_counter("dynamic_output.items_total").init();
-        let worker_index_label = KeyValue::new("worker_index", worker_index.0.to_string());
+        let meter = global::meter("bytewax");
+        let counter = meter
+            .u64_counter("bytewax_dynamic_output_items_total")
+            .init();
         let step_label = KeyValue::new("step_id", step_id.0.to_string());
+        let worker_index_label = KeyValue::new("worker_index", worker_index.0.to_string());
         let metric_labels = vec![step_label, worker_index_label];
         let histogram = meter
-            .f64_histogram("dynamic_output.duration")
+            .f64_histogram("dynamic_output_duration_seconds")
             .with_description("Dynamic output duration in seconds")
             .init();
 

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -512,9 +512,7 @@ where
         let mut sink = Some(output.build(py, worker_index, worker_count)?);
 
         let meter = global::meter("dataflow");
-        let counter = meter
-            .u64_counter(format!("dynamic_output.{step_id}.items_total"))
-            .init();
+        let counter = meter.u64_counter("dynamic_output.items_total").init();
         let worker_index_label = KeyValue::new("worker_index", worker_index.0.to_string());
         let step_label = KeyValue::new("step_id", step_id.0.to_string());
         let metric_labels = vec![step_label, worker_index_label];

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -7,6 +7,7 @@ use std::cell::RefCell;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::ffi::OsStr;
+use std::fmt;
 use std::fmt::Debug;
 use std::fs;
 use std::hash::BuildHasherDefault;
@@ -54,6 +55,12 @@ use crate::unwrap_any;
 /// The inner value will be up to [`PartitionCount`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub(crate) struct PartitionIndex(usize);
+
+impl fmt::Display for PartitionIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 /// Total number of recovery partitions.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, FromPyObject)]

--- a/src/run.rs
+++ b/src/run.rs
@@ -24,6 +24,7 @@ use crate::errors::prepend_tname;
 use crate::errors::tracked_err;
 use crate::errors::PythonException;
 use crate::inputs::EpochInterval;
+use crate::metrics::initialize_metrics;
 use crate::recovery::RecoveryConfig;
 use crate::unwrap_any;
 use crate::webserver::run_webserver;
@@ -57,6 +58,9 @@ fn start_server_runtime(df: &Py<Dataflow>) -> PyResult<Runtime> {
 
         Ok(dataflow_json)
     })?;
+
+    // Start the metrics subsystem
+    initialize_metrics()?;
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(2)
@@ -337,6 +341,7 @@ pub(crate) fn cli_main(
     }
 
     let mut server_rt = None;
+
     // Initialize the tokio runtime for the webserver if we needed.
     if std::env::var("BYTEWAX_DATAFLOW_API_ENABLED").is_ok() {
         server_rt = Some(start_server_runtime(&flow)?);

--- a/src/timely.rs
+++ b/src/timely.rs
@@ -878,7 +878,7 @@ where
 
         let meter = global::meter("dataflow");
         let histogram = meter
-            .f64_histogram("partd_write.duration")
+            .f64_histogram("bytewax_partd_write_duration_seconds")
             .with_description("partitioned state write duration in seconds")
             .init();
         let worker_label = KeyValue::new("worker_id", this_worker.0.to_string());
@@ -1109,7 +1109,7 @@ where
 
         let meter = global::meter("dataflow");
         let histogram = meter
-            .f64_histogram("partd_load.builder.duration")
+            .f64_histogram("bytewax_partd_load_builder_duration_seconds")
             .with_description("partitioned state load duration in seconds")
             .init();
         let worker_label = KeyValue::new("worker_id", this_worker.0.to_string());

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -4,6 +4,8 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Duration;
 
+use opentelemetry::global;
+use opentelemetry::KeyValue;
 use pyo3::exceptions::PyTypeError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -42,6 +44,7 @@ use crate::timely::AsWorkerExt;
 use crate::window::clock::ClockBuilder;
 use crate::window::StatefulWindowUnary;
 use crate::window::WindowBuilder;
+use crate::with_timer;
 
 /// Bytewax worker.
 ///
@@ -234,6 +237,9 @@ where
         // input later.
         let mut stream = empty(scope);
 
+        // Top level metrics meter
+        let meter = global::meter("dataflow");
+
         for step in &flow.steps {
             // All these closure lifetimes are static, so tell
             // Python's GC that there's another pointer to the
@@ -305,18 +311,43 @@ where
                         return Err(tracked_err::<PyTypeError>("unknown input type"));
                     }
                 }
-                Step::Map { mapper } => {
-                    stream = stream.map(move |item| map(&mapper, item));
+                Step::Map { step_id, mapper } => {
+                    let histogram = meter
+                        .f64_histogram("map.mapper.duration")
+                        .with_description("map step duration in seconds")
+                        .init();
+                    let labels = vec![KeyValue::new("step_id", step_id.0)];
+                    stream =
+                        stream.map(move |item| with_timer!(histogram, labels, map(&mapper, item)));
                 }
-                Step::FlatMap { mapper } => {
-                    stream = stream.flat_map(move |item| flat_map(&mapper, item));
+                Step::FlatMap { step_id, mapper } => {
+                    let histogram = meter
+                        .f64_histogram("flat_map.mapper.duration")
+                        .with_description("flat_map duration in seconds")
+                        .init();
+                    let labels = vec![KeyValue::new("step_id", step_id.0)];
+                    stream = stream.flat_map(move |item| {
+                        with_timer!(histogram, labels, flat_map(&mapper, item))
+                    });
                 }
-                Step::Filter { predicate } => {
-                    stream = stream.filter(move |item| filter(&predicate, item));
+                Step::Filter { step_id, predicate } => {
+                    let histogram = meter
+                        .f64_histogram("filter.predicate.duration")
+                        .with_description("filter predicate duration in seconds")
+                        .init();
+                    let labels = vec![KeyValue::new("step_id", step_id.0)];
+                    stream = stream.filter(move |item| {
+                        with_timer!(histogram, labels, filter(&predicate, item))
+                    });
                 }
-                Step::FilterMap { mapper } => {
+                Step::FilterMap { step_id, mapper } => {
+                    let histogram = meter
+                        .f64_histogram("filter_map.mapper.duration")
+                        .with_description("filter_map mapper duration in seconds")
+                        .init();
+                    let labels = vec![KeyValue::new("step_id", step_id.0)];
                     stream = stream
-                        .map(move |item| map(&mapper, item))
+                        .map(move |item| with_timer!(histogram, labels, map(&mapper, item)))
                         .filter(move |item| Python::with_gil(|py| !item.is_none(py)));
                 }
                 Step::FoldWindow {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -239,7 +239,7 @@ where
         let mut stream = empty(scope);
 
         // Top level metrics meter
-        let meter = global::meter("dataflow");
+        let meter = global::meter("bytewax");
 
         for step in &flow.steps {
             // All these closure lifetimes are static, so tell
@@ -314,8 +314,8 @@ where
                 }
                 Step::Map { step_id, mapper } => {
                     let histogram = meter
-                        .f64_histogram("map.mapper.duration")
-                        .with_description("map step duration in seconds")
+                        .f64_histogram("bytewax_map_duration_seconds")
+                        .with_description("map mapper fn duration in seconds")
                         .init();
                     let labels = vec![
                         KeyValue::new("step_id", step_id.0),
@@ -326,8 +326,8 @@ where
                 }
                 Step::FlatMap { step_id, mapper } => {
                     let histogram = meter
-                        .f64_histogram("flat_map.mapper.duration")
-                        .with_description("flat_map duration in seconds")
+                        .f64_histogram("bytewax_flat_map_duration_seconds")
+                        .with_description("flat_map mapper fn duration in seconds")
                         .init();
                     let labels = vec![
                         KeyValue::new("step_id", step_id.0),
@@ -339,7 +339,7 @@ where
                 }
                 Step::Filter { step_id, predicate } => {
                     let histogram = meter
-                        .f64_histogram("filter.predicate.duration")
+                        .f64_histogram("bytewax_filter_duration_seconds")
                         .with_description("filter predicate duration in seconds")
                         .init();
                     let labels = vec![
@@ -352,7 +352,7 @@ where
                 }
                 Step::FilterMap { step_id, mapper } => {
                     let histogram = meter
-                        .f64_histogram("filter_map.mapper.duration")
+                        .f64_histogram("bytewax_filter_map_duration_seconds")
                         .with_description("filter_map mapper duration in seconds")
                         .init();
                     let labels = vec![


### PR DESCRIPTION
This PR adds a basic metrics implementation, and a Prometheus compatible endpoint for the webserver at `/metrics`.

I decided to use the new opentelemetry metrics implementation, after looking at some alternatives. I decided against using the built-in timely event logging subsystem, as I don't believe that it gives us the granularity that we desire. I also noted that the materialize codebase didn't seem to use that subsystem for metrics collection.

I believe that using the opentelemetry metrics implementation gives us the ability to collect [exemplars](https://grafana.com/docs/grafana/latest/fundamentals/exemplars/) from the traces we collect with that library, although a [note](https://github.com/open-telemetry/opentelemetry-rust/blob/b6e91a9baf4474571b92693ec87f65835eb45385/opentelemetry-prometheus/src/lib.rs#L443-L444) in the opentelemetry codebase made me feel like I should wait for support to land there before adding it.

I added a `StepId` to many of the functions I wanted to collect metrics from. I considered getting the name of the function from the Python function passed, as Federico suggested, but function names may not be unique in a dataflow execution, and lambda functions aren't named. This is an unfortunate breaking change in the API.

Finally, this PR doesn't address the problem that using multiple workers or processes will cause the metrics endpoint to return no useful metrics. Early on, we discussed removing some of the entrypoints that make this behavior possible, but I am not including that work as a part of this PR.