### PR TITLE
Move Python multiprocessing execution mode to the testing namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file. For help wi
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Moves the ability to start multiple Python processes with the
+  `-p` or `--processes` to the testing namespace.
+
 ## v0.17.1
 
 - Adds the `batch` operator to Dataflows. Calling `Dataflow.batch`

--- a/docs/articles/getting-started/execution.md
+++ b/docs/articles/getting-started/execution.md
@@ -126,7 +126,7 @@ by changing only the command:
 $ python -m bytewax.run -w3 simple:flow
 ```
 
-## Manually Handled Cluster
+## Multi-Process Cluster
 
 If you want to run multiple processes on a single machine, or different machines on
 the same network, you can use the `-i/--process-id`,`-a/--addresses` parameters.

--- a/docs/articles/getting-started/execution.md
+++ b/docs/articles/getting-started/execution.md
@@ -8,8 +8,8 @@ dataflow. Workers can be grouped into separate **processes**, but
 refer to the individual threads within.
 
 Bytewax's execution model uses identical workers. Workers execute all
-steps in a dataflow and automatically trade data to ensure the
-semantics of the operators. If a dataflow is run on multiple
+steps (including input and output) in a dataflow and automatically
+trade data to ensure the semantics of the operators. If a dataflow is run on multiple
 processes, there will be a slight overhead added to aggregating
 operators due to pickling and network communication, but it will allow
 you to read from input partitions in parallel for higher throughput.
@@ -116,28 +116,26 @@ run_main(flow)
 
 ## Local Cluster
 
-By changing the `-p/--processes` and `-w/--workers-per-process` arguments,
-you can spawn multiple processes, and mulitple workers per process,
-letting `bytewax.run` handle the communication between them.
+By changing the `-w/--workers-per-process` argument,
+you can spawn multiple workers within a single process.
 
-For example you can run the previous dataflow with 2 processes, and 3 workers
-per process, for a total of 6 workers using the exact same file, changing
-only the command:
+For example you can run the previous dataflow with 3 workers
+by changing only the command:
 
 ```
-$ python -m bytewax.run -p2 -w3 simple:flow
+$ python -m bytewax.run -w3 simple:flow
 ```
 
 ## Manually Handled Cluster
 
-If you want to run single processes on possibly different machines on the same network,
-you can use the `-i/--process-id`,`-a/--addresses` parameters.
+If you want to run multiple processes on a single machine, or different machines on
+the same network, you can use the `-i/--process-id`,`-a/--addresses` parameters.
 
 It allows you to start up a single process within a cluster
 of processes that you are manually coordinating. We recommend you
 checkout the documentation for [waxctl](/docs/deployment/waxctl/) our
-command line tool which facilitates running a dataflow on Kubernetes.
-
+command line tool which facilitates running a multiple dataflow processes
+locally, or on Kubernetes.
 
 The `-a/--addresses` parameter represents a list of addresses for all the processes,
 separated by a ';'.
@@ -156,6 +154,3 @@ And on the `cluster_two` machine as:
 ```
 $ python -m bytewax.run simple:flow -w3 -i1 -a "cluster_one:2101;cluster_two:2101"
 ```
-
-This is only needed if you want to run the dataflow on multiple machines,
-or if you need better control of the addresses/ports used by default by the run script.

--- a/docs/articles/getting-started/execution.md
+++ b/docs/articles/getting-started/execution.md
@@ -114,7 +114,7 @@ run_main(flow)
 3
 ```
 
-## Local Cluster
+## Single Process Cluster
 
 By changing the `-w/--workers-per-process` argument,
 you can spawn multiple workers within a single process.

--- a/docs/articles/getting-started/execution.md
+++ b/docs/articles/getting-started/execution.md
@@ -131,9 +131,11 @@ $ python -m bytewax.run -w3 simple:flow
 If you want to run multiple processes on a single machine, or different machines on
 the same network, you can use the `-i/--process-id`,`-a/--addresses` parameters.
 
-It allows you to start up a single process within a cluster
-of processes that you are manually coordinating. We recommend you
-checkout the documentation for [waxctl](/docs/deployment/waxctl/) our
+Each invocation of `bytewax.run` with `-i` starts up a single
+process. By executing this command multiple times, you can create a
+cluster of Bytewax processes on one machine or multiple machines. We
+recommend you checkout the documentation for
+[waxctl](/docs/deployment/waxctl/) our
 command line tool which facilitates running a multiple dataflow processes
 locally, or on Kubernetes.
 

--- a/docs/articles/reference/glossary.md
+++ b/docs/articles/reference/glossary.md
@@ -185,7 +185,7 @@ cluster and might not necessarily be on the same machine.
 
 ## Resume (Execution)
 
-An execution which is
+An execution which is started from a snapshot of a previous execution.
 
 ## Snapshot(, State)
 

--- a/docs/articles/reference/glossary.md
+++ b/docs/articles/reference/glossary.md
@@ -185,7 +185,9 @@ cluster and might not necessarily be on the same machine.
 
 ## Resume (Execution)
 
-An execution which is started from a snapshot of a previous execution.
+An execution which is started using the recovery data from a previous execution. It will "pick up" near where the previous execution left off.
+
+The progress of this new execution begins from the resume epoch. All relevant state snapshots are re-loaded.
 
 ## Snapshot(, State)
 

--- a/pysrc/bytewax/run.py
+++ b/pysrc/bytewax/run.py
@@ -35,18 +35,16 @@ $ python -m bytewax.run "my_dataflow:get_flow('/tmp/file')"
 By default this script will run a single worker on a single process.
 You can modify this by using other parameters:
 
-### Local cluster
+### Multiple worker threads
 
-You can run multiple processes, and multiple workers for each process, by
-adding the `-p/--processes` and `-w/--workers-per-process` parameters, without
+You can run a single processes with multiple worker threads, by
+adding the `-w/--workers-per-process` parameter, without
 changing anything in the code:
 
 ```
-# Runs 3 processes, with 2 workers each, for a total of 6 workers
-$ python -m bytewax.run my_dataflow -p3 -w2
+# Runs a process with 2 workers:
+$ python -m bytewax.run my_dataflow -w2
 ```
-
-Bytewax will handle the communication setup between processes/workers.
 
 ### Manual cluster
 
@@ -263,7 +261,12 @@ def _parse_timedelta(s):
     return timedelta(seconds=int(s))
 
 
-def _parse_args():
+def _create_arg_parser():
+    """Create and return an argparse instance.
+
+    This function returns the parser, as we add options for scaling
+    that are used only for testing in the testing namespace.
+    """
     parser = argparse.ArgumentParser(
         prog="python -m bytewax.run", description="Run a bytewax dataflow"
     )
@@ -274,36 +277,6 @@ def _parse_args():
         "<module_name>[:<dataflow_variable_or_factory>] "
         "Example: src.dataflow or src.dataflow:flow or "
         "src.dataflow:get_flow('string_argument')",
-    )
-    scaling = parser.add_argument_group(
-        "Scaling",
-        "You should use either '-p' to spawn multiple processes "
-        "on this same machine, or '-i/-a' to spawn a single process "
-        "on different machines",
-    )
-    scaling.add_argument(
-        "-w",
-        "--workers-per-process",
-        type=int,
-        help="Number of workers for each process",
-        action=_EnvDefault,
-        envvar="BYTEWAX_WORKERS_PER_PROCESS",
-    )
-    scaling.add_argument(
-        "-i",
-        "--process-id",
-        type=int,
-        help="Process id",
-        action=_EnvDefault,
-        envvar="BYTEWAX_PROCESS_ID",
-    )
-    scaling.add_argument(
-        "-a",
-        "--addresses",
-        help="Addresses of other processes, separated by semicolon:\n"
-        '-a "localhost:2021;localhost:2022;localhost:2023" ',
-        action=_EnvDefault,
-        envvar="BYTEWAX_ADDRESSES",
     )
 
     recovery = parser.add_argument_group(
@@ -340,7 +313,46 @@ def _parse_args():
         envvar="BYTEWAX_RECOVERY_BACKUP_INTERVAL",
     )
 
-    args = parser.parse_args()
+    return parser
+
+
+def _parse_args():
+    arg_parser = _create_arg_parser()
+
+    # Add scaling arguments for the run namespace
+    scaling = arg_parser.add_argument_group(
+        "Scaling",
+        "You should use either '-p' to spawn multiple processes "
+        "on this same machine, or '-i/-a' to spawn a single process "
+        "on different machines",
+    )
+    scaling.add_argument(
+        "-w",
+        "--workers-per-process",
+        type=int,
+        help="Number of workers for each process",
+        action=_EnvDefault,
+        envvar="BYTEWAX_WORKERS_PER_PROCESS",
+    )
+    scaling.add_argument(
+        "-i",
+        "--process-id",
+        type=int,
+        help="Process id",
+        action=_EnvDefault,
+        envvar="BYTEWAX_PROCESS_ID",
+    )
+    scaling.add_argument(
+        "-a",
+        "--addresses",
+        help="Addresses of other processes, separated by semicolon:\n"
+        '-a "localhost:2021;localhost:2022;localhost:2023" ',
+        action=_EnvDefault,
+        envvar="BYTEWAX_ADDRESSES",
+    )
+
+    args = arg_parser.parse_args()
+
     args.import_str = _prepare_import(args.import_str)
 
     # First of all check if a process_id was set with a different
@@ -366,14 +378,15 @@ def _parse_args():
                     [address.strip() for address in hostfile if address.strip() != ""]
                 )
         else:
-            parser.error("the addresses option is required if a process_id is passed")
+            arg_parser.error(
+                "the addresses option is required if a process_id is passed"
+            )
 
     return args
 
 
 if __name__ == "__main__":
     kwargs = vars(_parse_args())
-
     kwargs["epoch_interval"] = kwargs.pop("snapshot_interval")
 
     recovery_directory, backup_interval = kwargs.pop("recovery_directory"), kwargs.pop(

--- a/pysrc/bytewax/run.py
+++ b/pysrc/bytewax/run.py
@@ -46,7 +46,7 @@ changing anything in the code:
 $ python -m bytewax.run my_dataflow -w2
 ```
 
-### Manual cluster
+### Multiple processes
 
 You can also manually handle the multiple processes, and run them on different
 machines, by using the `-a/--addresses` and `-i/--process-id` parameters.

--- a/pysrc/bytewax/run.py
+++ b/pysrc/bytewax/run.py
@@ -275,20 +275,11 @@ def _parse_args():
         "Example: src.dataflow or src.dataflow:flow or "
         "src.dataflow:get_flow('string_argument')",
     )
-
     scaling = parser.add_argument_group(
         "Scaling",
         "You should use either '-p' to spawn multiple processes "
         "on this same machine, or '-i/-a' to spawn a single process "
         "on different machines",
-    )
-    scaling.add_argument(
-        "-p",
-        "--processes",
-        type=int,
-        help="Number of separate processes to run",
-        action=_EnvDefault,
-        envvar="BYTEWAX_PROCESSES",
     )
     scaling.add_argument(
         "-w",
@@ -376,21 +367,6 @@ def _parse_args():
                 )
         else:
             parser.error("the addresses option is required if a process_id is passed")
-
-    # The dataflow should either run as a local multiprocess cluster,
-    # or a single process with urls for the others, so we manually
-    # validate the options to avoid confusion.
-    if args.processes is not None and (
-        args.process_id is not None or args.addresses is not None
-    ):
-        import warnings
-
-        warnings.warn(
-            "Both '-p' and '-a/-i' specified. "
-            "Ignoring the '-p' option, but this should be fixed",
-            stacklevel=1,
-        )
-        args.processes = None
 
     return args
 

--- a/pysrc/bytewax/run.py
+++ b/pysrc/bytewax/run.py
@@ -35,9 +35,9 @@ $ python -m bytewax.run "my_dataflow:get_flow('/tmp/file')"
 By default this script will run a single worker on a single process.
 You can modify this by using other parameters:
 
-### Multiple worker threads
+### Multiple workers
 
-You can run a single processes with multiple worker threads, by
+You can run a single processes with multiple workers, by
 adding the `-w/--workers-per-process` parameter, without
 changing anything in the code:
 
@@ -322,9 +322,8 @@ def _parse_args():
     # Add scaling arguments for the run namespace
     scaling = arg_parser.add_argument_group(
         "Scaling",
-        "You should use either '-p' to spawn multiple processes "
-        "on this same machine, or '-i/-a' to spawn a single process "
-        "on different machines",
+        "You should use either '-w' to spawn multiple workers "
+        "within a process, or '-i/-a' to manage multiple processes",
     )
     scaling.add_argument(
         "-w",

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -215,7 +215,6 @@ if __name__ == "__main__":
     if recovery_directory is not None:
         kwargs["recovery_config"] = RecoveryConfig(recovery_directory, backup_interval)
 
-
     # Import the dataflow
     module_str, _, attrs_str = kwargs.pop("import_str").partition(":")
     kwargs["flow"] = _locate_dataflow(module_str, attrs_str)

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -177,7 +177,7 @@ def _parse_args():
     # Add scaling arguments for the testing namespace
     scaling = parser.add_argument_group(
         "Scaling",
-        "This testing entrypoint supports using '-p' to spawn multiple ",
+        "This testing entrypoint supports using '-p' to spawn multiple "
         "processes, and '-w' to run multiple workers within a process.",
     )
     scaling.add_argument(

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -215,10 +215,6 @@ if __name__ == "__main__":
     if recovery_directory is not None:
         kwargs["recovery_config"] = RecoveryConfig(recovery_directory, backup_interval)
 
-    # Prepare addresses
-    addresses = kwargs.pop("addresses")
-    if addresses is not None:
-        kwargs["addresses"] = addresses.split(";")
 
     # Import the dataflow
     module_str, _, attrs_str = kwargs.pop("import_str").partition(":")

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -1,6 +1,8 @@
 """Helper tools for testing dataflows."""
+import argparse
 from datetime import datetime, timedelta, timezone
 from itertools import islice
+from pathlib import Path
 from typing import Any, Iterable, Iterator
 
 from bytewax.inputs import (
@@ -9,8 +11,14 @@ from bytewax.inputs import (
     batch,
 )
 from bytewax.outputs import DynamicOutput, StatelessSink
+from bytewax.recovery import RecoveryConfig
+from bytewax.run import _EnvDefault, _locate_dataflow, _parse_timedelta, _prepare_import
 
-from .bytewax import cluster_main, run_main
+from .bytewax import (
+    cluster_main,
+    run_main,
+    test_cluster,
+)
 
 __all__ = [
     "run_main",
@@ -158,3 +166,110 @@ def poll_next_batch(source: StatefulSource, timeout=timedelta(seconds=5)):
             raise TimeoutError()
         batch = source.next_batch()
     return batch
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        prog="python -m bytewax.run", description="Run a bytewax dataflow"
+    )
+    parser.add_argument(
+        "import_str",
+        type=str,
+        help="Dataflow import string in the format "
+        "<module_name>[:<dataflow_variable_or_factory>] "
+        "Example: src.dataflow or src.dataflow:flow or "
+        "src.dataflow:get_flow('string_argument')",
+    )
+    scaling = parser.add_argument_group(
+        "Scaling",
+        "You should use either '-p' to spawn multiple processes "
+        "on this same machine, or '-i/-a' to spawn a single process "
+        "on different machines",
+    )
+    scaling.add_argument(
+        "-w",
+        "--workers-per-process",
+        type=int,
+        help="Number of workers for each process",
+        action=_EnvDefault,
+        envvar="BYTEWAX_WORKERS_PER_PROCESS",
+    )
+    scaling.add_argument(
+        "-p",
+        "--processes",
+        type=int,
+        help="Number of separate processes to run",
+        action=_EnvDefault,
+        envvar="BYTEWAX_PROCESSES",
+    )
+    scaling.add_argument(
+        "-a",
+        "--addresses",
+        help="Addresses of other processes, separated by semicolon:\n"
+        '-a "localhost:2021;localhost:2022;localhost:2023" ',
+        action=_EnvDefault,
+        envvar="BYTEWAX_ADDRESSES",
+    )
+
+    recovery = parser.add_argument_group(
+        "Recovery", """See the `bytewax.recovery` module docstring for more info."""
+    )
+    recovery.add_argument(
+        "-r",
+        "--recovery-directory",
+        type=Path,
+        help="""Local file system directory to look for pre-initialized recovery
+        partitions; see `python -m bytewax.recovery` for how to init partitions""",
+        action=_EnvDefault,
+        envvar="BYTEWAX_RECOVERY_DIRECTORY",
+    )
+    parser.add_argument(
+        "-s",
+        "--snapshot-interval",
+        type=_parse_timedelta,
+        default=timedelta(seconds=10),
+        help="""System time duration in seconds to snapshot state for recovery;
+        defaults to 10 sec""",
+        action=_EnvDefault,
+        envvar="BYTEWAX_SNAPSHOT_INTERVAL",
+    )
+    recovery.add_argument(
+        "-b",
+        "--backup-interval",
+        type=_parse_timedelta,
+        default=timedelta(days=1),
+        help="""System time duration in seconds to keep extra state snapshots around;
+        set this to the interval at which you are backing up recovery partitions;
+        defaults to 1 day""",
+        action=_EnvDefault,
+        envvar="BYTEWAX_RECOVERY_BACKUP_INTERVAL",
+    )
+
+    args = parser.parse_args()
+    args.import_str = _prepare_import(args.import_str)
+
+    return args
+
+
+if __name__ == "__main__":
+    kwargs = vars(_parse_args())
+
+    kwargs["epoch_interval"] = kwargs.pop("snapshot_interval")
+
+    recovery_directory, backup_interval = kwargs.pop("recovery_directory"), kwargs.pop(
+        "backup_interval"
+    )
+    kwargs["recovery_config"] = None
+    if recovery_directory is not None:
+        kwargs["recovery_config"] = RecoveryConfig(recovery_directory, backup_interval)
+
+    # Prepare addresses
+    addresses = kwargs.pop("addresses")
+    if addresses is not None:
+        kwargs["addresses"] = addresses.split(";")
+
+    # Import the dataflow
+    module_str, _, attrs_str = kwargs.pop("import_str").partition(":")
+    kwargs["flow"] = _locate_dataflow(module_str, attrs_str)
+
+    test_cluster(**kwargs)

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -177,9 +177,8 @@ def _parse_args():
     # Add scaling arguments for the testing namespace
     scaling = parser.add_argument_group(
         "Scaling",
-        "You should use either '-p' to spawn multiple processes "
-        "on this same machine, or '-i/-a' to spawn a single process "
-        "on different machines",
+        "This testing entrypoint supports using '-p' to spawn multiple ",
+        "processes, and '-w' to run multiple workers within a process.",
     )
     scaling.add_argument(
         "-w",
@@ -196,14 +195,6 @@ def _parse_args():
         help="Number of separate processes to run",
         action=_EnvDefault,
         envvar="BYTEWAX_PROCESSES",
-    )
-    scaling.add_argument(
-        "-a",
-        "--addresses",
-        help="Addresses of other processes, separated by semicolon:\n"
-        '-a "localhost:2021;localhost:2022;localhost:2023" ',
-        action=_EnvDefault,
-        envvar="BYTEWAX_ADDRESSES",
     )
 
     args = parser.parse_args()

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -60,7 +60,7 @@ def test_cluster_can_be_ctrl_c():
         [
             "python",
             "-m",
-            "bytewax.run",
+            "bytewax.testing",
             flow_path,
             # Spawn 2 processes
             "-p",

--- a/src/run.rs
+++ b/src/run.rs
@@ -358,11 +358,11 @@ pub(crate) fn cli_main(
     Ok(())
 }
 
-/// Execute a dataflow over multiple processes.
+/// Execute a Dataflow by spawning multiple Python processes.
 ///
 /// Blocks until execution is complete.
 ///
-/// This function is only used for testing.
+/// This function should only be used for testing purposes.
 ///
 #[pyfunction]
 #[pyo3(


### PR DESCRIPTION
This PR moves the Python multiprocess mode of execution to the testing namespace.

The original feature has caused some confusion about the execution models of Bytewax, and is incompatible with metrics collection when there are several independent Python subprocesses.