### PR TITLE
Add window metadata object to the output of windowing operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file. For help wi
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+
+- *Breaking change* Window operators now emit WindowMetadata
+  objects downstream. These objects can be used to introspect
+  the open_time and close_time of windows.
+  This changes the output type of windowing operators from:
+  `(key, values)` to `(key, (metadata, values))`.
+
 - *Breaking change* IO classes and connectors have been renamed to
   better reflect their semantics and match up with documentation.
 

--- a/examples/apriori.py
+++ b/examples/apriori.py
@@ -3,7 +3,7 @@ import operator
 from collections import Counter
 from datetime import datetime, timedelta, timezone
 
-from bytewax.connectors.files import DirSource
+from bytewax.connectors.files import FileSource
 from bytewax.dataflow import Dataflow
 from bytewax.testing import TestingSink, run_main
 from bytewax.window import SystemClockConfig, TumblingWindow
@@ -46,7 +46,7 @@ wc = TumblingWindow(
 # first pass - count products
 out = []
 flow = Dataflow()
-flow.input("inp", DirSource("examples/sample_data/apriori.txt"))
+flow.input("inp", FileSource("examples/sample_data/apriori.txt"))
 flow.map("lower", lower)
 flow.flat_map("tokenize", tokenize)
 flow.map("initial_count", initial_count)
@@ -56,7 +56,7 @@ flow.output("out", TestingSink(out))
 # second pass - count pairs
 out2 = []
 flow2 = Dataflow()
-flow2.input("input", DirSource("examples/sample_data/apriori.txt"))
+flow2.input("input", FileSource("examples/sample_data/apriori.txt"))
 flow2.map("lower", lower)
 flow2.filter(
     "is_most_common", is_most_common
@@ -69,7 +69,7 @@ flow2.output("out", TestingSink(out2))
 
 run_main(flow)
 for item in out:
-    pair, count = item
+    pair, (metadata, count) = item
     product_counter[pair] = count
 
 print("most popular products:")
@@ -82,7 +82,7 @@ for product, count in product_counter.most_common(3):
 most_popular_pairs: Counter = Counter()
 run_main(flow2)
 for item in out2:
-    pair, count = item
+    pair, (metadata, count) = item
     most_popular_pairs[pair] = count
 
 print("most popular pairs:")

--- a/examples/event_time_processing.py
+++ b/examples/event_time_processing.py
@@ -48,7 +48,7 @@ def extract_sensor_type(event):
     return event["type"], event
 
 
-flow.map(extract_sensor_type)
+flow.map("extract_type", extract_sensor_type)
 
 
 # Here is where we use the event time processing, with
@@ -85,7 +85,7 @@ flow.fold_window("running_average", cc, wc, list, acc_values)
 # Calculate the average of the values for each window, and
 # format the data to a string
 def format_event(event):
-    key, data = event
+    key, (metadata, data) = event
     values = [x[0] for x in data]
     dates = [datetime.fromisoformat(x[1]) for x in data]
     return (

--- a/examples/events_to_parquet.py
+++ b/examples/events_to_parquet.py
@@ -36,13 +36,14 @@ class FakeWebEventsSource(FixedPartitionedSource):
 
 
 class ParquetPartition(StatefulSinkPartition):
-    def write(self, value):
-        table = Table.from_pandas(value)
-        parquet.write_to_dataset(
-            table,
-            root_path="parquet_demo_out",
-            partition_cols=["year", "month", "day", "page_url_path"],
-        )
+    def write_batch(self, batch):
+        for (_metadata, value) in batch:
+            table = Table.from_pandas(value)
+            parquet.write_to_dataset(
+                table,
+                root_path="parquet_demo_out",
+                partition_cols=["year", "month", "day", "page_url_path"],
+            )
 
     def snapshot(self):
         return None

--- a/examples/subflow.py
+++ b/examples/subflow.py
@@ -26,12 +26,12 @@ def calc_counts(flow):
 
 
 def get_count(word_count):
-    word, count = word_count
+    word, (metadata, count) = word_count
     return count
 
 
 def format_output(count_count):
-    times_appearing, num_words_with_the_same_count = count_count
+    times_appearing, (metadata, num_words_with_the_same_count) = count_count
     if num_words_with_the_same_count == 1:
         return f"There was one word with a count of {times_appearing}"
     else:

--- a/examples/wikistream.py
+++ b/examples/wikistream.py
@@ -43,7 +43,8 @@ def initial_count(data_dict):
     return data_dict["server_name"], 1
 
 
-def keep_max(max_count, new_count):
+def keep_max(max_count, metadata__new_count):
+    _metadata, new_count = metadata__new_count
     new_max = max(max_count, new_count)
     # print(f"Just got {new_count}, old max was {max_count}, new max is {new_max}")
     return new_max, new_max
@@ -64,7 +65,7 @@ flow.reduce_window(
     ),
     operator.add,
 )
-# ("server.name", sum_per_window)
+# ("server.name", (metadata, sum_per_window))
 flow.stateful_map("keep_max", lambda: 0, keep_max)
 # ("server.name", max_per_window)
 flow.map("format", lambda x: (x[0], f"{x[0]}, {x[1]}"))

--- a/pysrc/bytewax/window.py
+++ b/pysrc/bytewax/window.py
@@ -77,6 +77,7 @@ from .bytewax import (  # noqa: F401
     SystemClockConfig,
     TumblingWindow,
     WindowConfig,
+    WindowMetadata,
 )
 
 __all__ = [
@@ -87,4 +88,5 @@ __all__ = [
     "SystemClockConfig",
     "TumblingWindow",
     "WindowConfig",
+    "WindowMetadata",
 ]

--- a/pysrc/bytewax/window.py
+++ b/pysrc/bytewax/window.py
@@ -48,6 +48,13 @@ worker processes and threads all reading relevant data simultaneously,
 you have to specifically collect and manually sort data that you need
 to process in strict time order.
 
+Output
+------
+
+Output from windowing operators is in the form of
+`(key, (metadata, values))` where metadata is an instance of
+`bytewax.window.WindowMetadata`.
+
 Recovery
 --------
 

--- a/pytests/test_event_time.py
+++ b/pytests/test_event_time.py
@@ -38,7 +38,7 @@ def test_event_time_processing():
     flow.input("inp", TestingSource(inp))
     flow.map("extract_sensor_type", extract_sensor_type)
     flow.fold_window("running_average", cc, wc, list, acc_values)
-    flow.map("format_output", lambda x: {f"{x[0]}_avg": sum(x[1]) / len(x[1])})
+    flow.map("format_output", lambda x: {f"{x[0]}_avg": sum(x[1][1]) / len(x[1][1])})
     out = []
     flow.output("out", TestingSink(out))
     run_main(flow)

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -7,6 +7,7 @@ from bytewax.window import (
     SessionWindow,
     SlidingWindow,
     TumblingWindow,
+    WindowMetadata,
 )
 
 
@@ -49,9 +50,36 @@ def test_session_window():
     run_main(flow)
     assert sorted(out) == sorted(
         [
-            ("ALL", ["a", "b"]),
-            ("ALL", ["c", "d", "e", "f"]),
-            ("ALL", ["g"]),
+            (
+                "ALL",
+                (
+                    WindowMetadata(
+                        align_to + timedelta(seconds=1),
+                        align_to + timedelta(seconds=5),
+                    ),
+                    ["a", "b"],
+                ),
+            ),
+            (
+                "ALL",
+                (
+                    WindowMetadata(
+                        align_to + timedelta(seconds=11),
+                        align_to + timedelta(seconds=14),
+                    ),
+                    ["c", "d", "e", "f"],
+                ),
+            ),
+            (
+                "ALL",
+                (
+                    WindowMetadata(
+                        align_to + timedelta(seconds=20),
+                        align_to + timedelta(seconds=20),
+                    ),
+                    ["g"],
+                ),
+            ),
         ]
     )
 
@@ -102,11 +130,56 @@ def test_sliding_window():
     run_main(flow)
     assert sorted(out) == sorted(
         [
-            ("ALL", ["a", "b"]),
-            ("ALL", ["a", "b", "c"]),
-            ("ALL", ["c", "d", "e", "f"]),
-            ("ALL", ["d", "e", "f", "g"]),
-            ("ALL", ["g"]),
+            (
+                "ALL",
+                (
+                    WindowMetadata(
+                        align_to - timedelta(seconds=5),
+                        align_to + timedelta(seconds=5),
+                    ),
+                    ["a", "b"],
+                ),
+            ),
+            (
+                "ALL",
+                (
+                    WindowMetadata(
+                        align_to,
+                        align_to + timedelta(seconds=10),
+                    ),
+                    ["a", "b", "c"],
+                ),
+            ),
+            (
+                "ALL",
+                (
+                    WindowMetadata(
+                        align_to + timedelta(seconds=5),
+                        align_to + timedelta(seconds=15),
+                    ),
+                    ["c", "d", "e", "f"],
+                ),
+            ),
+            (
+                "ALL",
+                (
+                    WindowMetadata(
+                        align_to + timedelta(seconds=10),
+                        align_to + timedelta(seconds=20),
+                    ),
+                    ["d", "e", "f", "g"],
+                ),
+            ),
+            (
+                "ALL",
+                (
+                    WindowMetadata(
+                        align_to + timedelta(seconds=15),
+                        align_to + timedelta(seconds=25),
+                    ),
+                    ["g"],
+                ),
+            ),
         ]
     )
 
@@ -143,4 +216,24 @@ def test_tumbling_window():
 
     run_main(flow)
 
-    assert sorted(out) == sorted([("ALL", ["a", "b", "c"]), ("ALL", ["d", "e"])])
+    assert sorted(out) == sorted(
+        [
+            (
+                "ALL",
+                (
+                    WindowMetadata(align_to, align_to + timedelta(seconds=10)),
+                    ["a", "b", "c"],
+                ),
+            ),
+            (
+                "ALL",
+                (
+                    WindowMetadata(
+                        align_to + timedelta(seconds=10),
+                        align_to + timedelta(seconds=20),
+                    ),
+                    ["d", "e"],
+                ),
+            ),
+        ]
+    )

--- a/pytests/test_window.py
+++ b/pytests/test_window.py
@@ -1,3 +1,4 @@
+import pickle
 from datetime import datetime, timedelta, timezone
 
 from bytewax.dataflow import Dataflow
@@ -237,3 +238,10 @@ def test_tumbling_window():
             ),
         ]
     )
+
+
+def test_windowmetadata_pickles():
+    meta = WindowMetadata(datetime.now(timezone.utc), datetime.now(timezone.utc))
+
+    dumped = pickle.dumps(meta)
+    assert pickle.loads(dumped) == meta

--- a/src/pyo3_extensions/mod.rs
+++ b/src/pyo3_extensions/mod.rs
@@ -4,6 +4,7 @@ use crate::errors::PythonException;
 use crate::recovery::StateKey;
 use crate::try_unwrap;
 use crate::unwrap_any;
+use crate::window::WindowMetadata;
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -242,6 +243,14 @@ pub(crate) fn extract_state_pair(key_value_pytuple: TdPyAny) -> (StateKey, TdPyA
 
 /// Turn a Rust 2-tuple of `(key, value)` into a Python 2-tuple.
 pub(crate) fn wrap_state_pair(key_value: (StateKey, TdPyAny)) -> TdPyAny {
+    Python::with_gil(|py| {
+        let key_value_pytuple: Py<PyAny> = key_value.into_py(py);
+        key_value_pytuple.into()
+    })
+}
+
+/// Turn a Rust 2-tuple of `(key, (WindowMetadata, value))` into a Python tuple.
+pub(crate) fn wrap_window_state_pair(key_value: (StateKey, (WindowMetadata, TdPyAny))) -> TdPyAny {
     Python::with_gil(|py| {
         let key_value_pytuple: Py<PyAny> = key_value.into_py(py);
         key_value_pytuple.into()

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -206,6 +206,28 @@ impl WindowMetadata {
         )
     }
 
+    /// Return a representation of this class as a PyDict for pickling.
+    fn __getstate__(&self) -> HashMap<&str, Py<PyAny>> {
+        Python::with_gil(|py| {
+            HashMap::from([
+                ("open_time", self.open_time.into_py(py)),
+                ("close_time", self.close_time.into_py(py)),
+            ])
+        })
+    }
+
+    /// Required boilerplate for unpickling
+    fn __getnewargs__(&self) -> (DateTime<Utc>, DateTime<Utc>) {
+        (Utc::now(), Utc::now())
+    }
+
+    /// Unpickle from a PyDict of arguments.
+    fn __setstate__(&mut self, state: &PyAny) -> PyResult<()> {
+        self.open_time = state.get_item("open_time")?.extract()?;
+        self.close_time = state.get_item("close_time")?.extract()?;
+        Ok(())
+    }
+
     /// Comparisons between WindowMetadata instances should use their
     /// close times.
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -38,6 +38,7 @@ use std::task::Poll;
 use chrono::prelude::*;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
+use pyo3::pyclass::CompareOp;
 use pyo3::types::PyDict;
 use serde::Deserialize;
 use serde::Serialize;
@@ -155,6 +156,74 @@ impl IntoPy<PyObject> for WindowKey {
     }
 }
 
+/// Metadata object for a window.
+///
+///  Args:
+///    key (WindowKey):
+///      Internal window ID
+///    open_time (datetime.datetime)
+///      The time that the window starts.
+///    close_time (datetime.datetime)
+///      The time that the window closes. For some window
+///      types(SessionWindow), this value can change as new
+///      data is received.
+///
+/// Returns:
+///   WindowMetadata object
+#[pyclass(module = "bytewax.window")]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct WindowMetadata {
+    #[pyo3(get)]
+    pub(crate) open_time: DateTime<Utc>,
+    #[pyo3(get)]
+    pub(crate) close_time: DateTime<Utc>,
+}
+
+impl From<(&WindowKey, &(DateTime<Utc>, DateTime<Utc>))> for WindowMetadata {
+    fn from(value: (&WindowKey, &(DateTime<Utc>, DateTime<Utc>))) -> Self {
+        let (_key, (open_time, close_time)) = value;
+        Self {
+            open_time: *open_time,
+            close_time: *close_time,
+        }
+    }
+}
+
+#[pymethods]
+impl WindowMetadata {
+    #[new]
+    fn new(open_time: DateTime<Utc>, close_time: DateTime<Utc>) -> Self {
+        Self {
+            open_time,
+            close_time,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "WindowMetadata(open_time: {}, close_time: {})",
+            self.open_time, self.close_time
+        )
+    }
+
+    /// Comparisons between WindowMetadata instances should use their
+    /// close times.
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.close_time < other.close_time),
+            CompareOp::Le => Ok(self.close_time <= other.close_time),
+            CompareOp::Eq => {
+                Ok(self.close_time == other.close_time && self.open_time == other.open_time)
+            }
+            CompareOp::Ne => {
+                Ok(self.close_time != other.close_time && self.open_time != other.open_time)
+            }
+            CompareOp::Gt => Ok(self.close_time > other.close_time),
+            CompareOp::Ge => Ok(self.close_time >= other.close_time),
+        }
+    }
+}
+
 /// An error that can occur when windowing an item.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum InsertError {
@@ -170,8 +239,7 @@ pub(crate) enum InsertError {
 /// A separate instance of this is created for each key in the
 /// stateful stream. There is no way to interact across keys.
 pub(crate) trait Windower {
-    /// Attempt to insert an incoming value into a window, creating it
-    /// if necessary.
+    /// Attempt to insert close_time incoming value into a close_time, creating it
     ///
     /// If the current item is "late" for all windows, return
     /// [`WindowError::Late`].
@@ -185,10 +253,13 @@ pub(crate) trait Windower {
 
     /// Look at the current watermark, determine which windows are now
     /// closed, return them, and remove them from internal state.
-    fn drain_closed(&mut self, watermark: &DateTime<Utc>) -> Vec<WindowKey>;
+    fn drain_closed(&mut self, watermark: &DateTime<Utc>) -> Vec<(WindowKey, WindowMetadata)>;
 
     /// Is this windower currently tracking any windows?
     fn is_empty(&self) -> bool;
+
+    /// Return the window metadata for a given key.
+    fn get_metadata(&self, key: &WindowKey) -> Option<WindowMetadata>;
 
     /// Return the system time estimate of the next window close, if
     /// any.
@@ -212,7 +283,7 @@ pub(crate) enum WindowError<V> {
 
 /// Impl this trait to create a windowing operator.
 ///
-/// A separate instance of this will be create for each window a
+/// A separate instance of this will be created for each window a
 /// [`Windower`] creates. There is no way to interact across windows
 /// or keys.
 pub(crate) trait WindowLogic<V, R, I>
@@ -314,15 +385,22 @@ where
     }
 }
 
-impl<V, R, I, L, LB> StatefulLogic<V, Result<R, WindowError<V>>, Vec<Result<R, WindowError<V>>>>
-    for WindowStatefulLogic<V, R, I, L, LB>
+impl<V, R, I, L, LB>
+    StatefulLogic<
+        V,
+        Result<(WindowMetadata, R), WindowError<V>>,
+        Vec<Result<(WindowMetadata, R), WindowError<V>>>,
+    > for WindowStatefulLogic<V, R, I, L, LB>
 where
     V: Data + Debug,
     I: IntoIterator<Item = R>,
     L: WindowLogic<V, R, I>,
     LB: Fn(Option<TdPyAny>) -> L,
 {
-    fn on_awake(&mut self, next_value: Poll<Option<V>>) -> Vec<Result<R, WindowError<V>>> {
+    fn on_awake(
+        &mut self,
+        next_value: Poll<Option<V>>,
+    ) -> Vec<Result<(WindowMetadata, R), WindowError<V>>> {
         let mut output = Vec::new();
 
         let watermark = self.clock.watermark(&next_value);
@@ -345,21 +423,32 @@ where
                             .current_state
                             .entry(window_key)
                             .or_insert_with(|| (self.logic_builder)(None));
-                        let window_output = logic.with_next(Some((value, item_time)));
-                        output.extend(window_output.into_iter().map(Ok));
+                        let metadata = self
+                            .windower
+                            .get_metadata(&window_key)
+                            .expect("No window metadata found");
+                        let window_output = logic
+                            .with_next(Some((value, item_time)))
+                            .into_iter()
+                            .map(|output| Ok((metadata, output)));
+
+                        output.extend(window_output);
                     }
                 }
             }
         }
 
-        for closed_window in self.windower.drain_closed(&watermark) {
+        for (key, metadata) in self.windower.drain_closed(&watermark) {
             let mut logic = self
                 .current_state
-                .remove(&closed_window)
+                .remove(&key)
                 .expect("No logic for closed window");
 
-            let window_output = logic.with_next(None);
-            output.extend(window_output.into_iter().map(Ok));
+            let window_output = logic
+                .with_next(None)
+                .into_iter()
+                .map(|output| Ok((metadata, output)));
+            output.extend(window_output);
         }
 
         output
@@ -435,7 +524,7 @@ where
     ///
     /// # Output
     ///
-    /// The output will be a stream of `(key, value)` output
+    /// The output will be a stream of `(key, (metadat, value))` output
     /// 2-tuples. Values emitted by [`WindowLogic::exec`] will
     /// automatically be paired with the key in the output stream.
     #[allow(clippy::type_complexity)]
@@ -448,7 +537,7 @@ where
         resume_epoch: ResumeEpoch,
         loads: &Stream<S, Snapshot>,
     ) -> (
-        Stream<S, (StateKey, Result<R, WindowError<V>>)>,
+        Stream<S, (StateKey, Result<(WindowMetadata, R), WindowError<V>>)>,
         Stream<S, Snapshot>,
     )
     where
@@ -475,7 +564,7 @@ where
         resume_epoch: ResumeEpoch,
         loads: &Stream<S, Snapshot>,
     ) -> (
-        Stream<S, (StateKey, Result<R, WindowError<V>>)>,
+        Stream<S, (StateKey, Result<(WindowMetadata, R), WindowError<V>>)>,
         Stream<S, Snapshot>,
     )
     where
@@ -503,5 +592,6 @@ pub(crate) fn register(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<TumblingWindow>()?;
     m.add_class::<SlidingWindow>()?;
     m.add_class::<SessionWindow>()?;
+    m.add_class::<WindowMetadata>()?;
     Ok(())
 }

--- a/src/window/sliding_window.rs
+++ b/src/window/sliding_window.rs
@@ -84,7 +84,7 @@ pub(crate) struct SlidingWindower {
     length: Duration,
     offset: Duration,
     align_to: DateTime<Utc>,
-    close_times: HashMap<WindowKey, DateTime<Utc>>,
+    close_times: HashMap<WindowKey, (DateTime<Utc>, DateTime<Utc>)>,
 }
 
 impl SlidingWindower {
@@ -108,7 +108,10 @@ impl SlidingWindower {
 
     /// Yields all windows and their close times that intersect a
     /// given time. Close time is exclusive.
-    fn intersects(&self, time: &DateTime<Utc>) -> impl Iterator<Item = (WindowKey, DateTime<Utc>)> {
+    fn intersects(
+        &self,
+        time: &DateTime<Utc>,
+    ) -> impl Iterator<Item = (WindowKey, DateTime<Utc>, DateTime<Utc>)> {
         let since_close_of_first_window = *time - (self.align_to + self.length);
         let first_window_idx = Integer::div_floor(
             &since_close_of_first_window.num_milliseconds(),
@@ -127,26 +130,31 @@ impl SlidingWindower {
         let length = self.length;
         (0..num_windows).flat_map(move |i| {
             let window_idx = first_window_idx + i;
-            let window_open = align_to + offset * window_idx as i32;
-            if time < window_open {
+            let open_time = align_to + offset * window_idx as i32;
+            if time < open_time {
                 None
             } else {
-                let window_close = window_open + length;
-                Some((WindowKey(window_idx), window_close))
+                let close_time = open_time + length;
+                Some((WindowKey(window_idx), open_time, close_time))
             }
         })
     }
 
-    fn insert_window(&mut self, key: WindowKey, close_time: DateTime<Utc>) {
+    fn insert_window(
+        &mut self,
+        key: WindowKey,
+        open_time: DateTime<Utc>,
+        close_time: DateTime<Utc>,
+    ) {
         self.close_times
             .entry(key)
-            .and_modify(|existing| {
+            .and_modify(|(current_open_time, current_close_time)| {
                 assert!(
-                    existing == &close_time,
+                    close_time == *current_close_time && *current_open_time == open_time,
                     "SlidingWindower is not generating consistent boundaries"
                 )
             })
-            .or_insert(close_time);
+            .or_insert((open_time, close_time));
     }
 }
 
@@ -157,30 +165,41 @@ impl Windower for SlidingWindower {
         item_time: &DateTime<Utc>,
     ) -> Vec<Result<WindowKey, InsertError>> {
         self.intersects(item_time)
-            .map(|(key, close_time)| {
+            .map(|(key, open_time, close_time)| {
                 tracing::trace!("Intersects with {key:?} closing at {close_time:?}");
                 if close_time < *watermark {
                     Err(InsertError::Late(key))
                 } else {
-                    self.insert_window(key, close_time);
+                    self.insert_window(key, open_time, close_time);
                     Ok(key)
                 }
             })
             .collect()
     }
 
+    /// Return the window metadata for a given key.
+    fn get_metadata(&self, key: &WindowKey) -> Option<WindowMetadata> {
+        self.close_times.get_key_value(key).map(|m| m.into())
+    }
+
     /// Look at the current watermark, determine which windows are now
     /// closed, return them, and remove them from internal state.
-    fn drain_closed(&mut self, watermark: &DateTime<Utc>) -> Vec<WindowKey> {
+    fn drain_closed(&mut self, watermark: &DateTime<Utc>) -> Vec<(WindowKey, WindowMetadata)> {
         let mut future_close_times = HashMap::new();
         let mut closed_keys = Vec::new();
 
-        for (key, close_at) in self.close_times.iter() {
-            if close_at < watermark {
-                tracing::trace!("{key:?} closed at {close_at:?}");
-                closed_keys.push(*key);
+        for (key, (open_time, close_time)) in self.close_times.iter() {
+            if close_time < watermark {
+                tracing::trace!("{key:?} closed at {:?}", close_time);
+                closed_keys.push((
+                    *key,
+                    WindowMetadata {
+                        open_time: *open_time,
+                        close_time: *close_time,
+                    },
+                ));
             } else {
-                future_close_times.insert(*key, *close_at);
+                future_close_times.insert(*key, (*open_time, *close_time));
             }
         }
 
@@ -193,7 +212,11 @@ impl Windower for SlidingWindower {
     }
 
     fn next_close(&self) -> Option<DateTime<Utc>> {
-        self.close_times.values().min().cloned()
+        self.close_times
+            .values()
+            .min_by(|(_x_open, x_close), (_y_open, y_close)| x_close.cmp(y_close))
+            .cloned()
+            .map(|(_open_time, close_time)| close_time)
     }
 
     fn snapshot(&self) -> TdPyAny {
@@ -222,13 +245,15 @@ fn test_intersect_overlap_offset_divisible_by_length_bulk_positive() {
         vec![
             (
                 WindowKey(1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 15).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 05).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 15).unwrap(),
             ),
             (
                 WindowKey(2),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 20).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 20).unwrap(),
             ),
-        ],
+        ]
     );
 }
 
@@ -253,11 +278,13 @@ fn test_intersect_overlap_offset_divisible_by_length_bulk_negative() {
         vec![
             (
                 WindowKey(-2),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 0).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 50).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 0).unwrap(),
             ),
             (
                 WindowKey(-1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 5).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 55).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 5).unwrap(),
             ),
         ],
     );
@@ -284,11 +311,13 @@ fn test_intersect_overlap_offset_divisible_by_length_bulk_zero_negative() {
         vec![
             (
                 WindowKey(-1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 5).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 55).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 5).unwrap(),
             ),
             (
                 WindowKey(0),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 00).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
             ),
         ],
     );
@@ -315,12 +344,14 @@ fn test_intersect_overlap_offset_divisible_by_length_bulk_zero_positive() {
         vec![
             (
                 WindowKey(0),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 00).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
             ),
             (
                 WindowKey(1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 15).unwrap()
-            ),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 05).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 15).unwrap(),
+            )
         ],
     );
 }
@@ -347,11 +378,13 @@ fn test_intersect_overlap_offset_divisible_by_length_edge_positive() {
         vec![
             (
                 WindowKey(2),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 20).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 20).unwrap(),
             ),
             (
                 WindowKey(3),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 25).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 15).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 25).unwrap(),
             ),
         ]
     );
@@ -378,11 +411,13 @@ fn test_intersect_overlap_offset_divisible_by_length_edge_negative() {
         vec![
             (
                 WindowKey(-2),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 0).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 50).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 0).unwrap(),
             ),
             (
                 WindowKey(-1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 05).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 55).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 05).unwrap(),
             ),
         ]
     );
@@ -409,11 +444,13 @@ fn test_intersect_overlap_offset_divisible_by_length_edge_start_zero() {
         vec![
             (
                 WindowKey(-1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 5).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 55).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 5).unwrap(),
             ),
             (
                 WindowKey(0),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 00).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
             ),
         ]
     );
@@ -440,11 +477,13 @@ fn test_intersect_overlap_offset_divisible_by_length_edge_end_zero() {
         vec![
             (
                 WindowKey(1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 15).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 05).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 15).unwrap(),
             ),
             (
                 WindowKey(2),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 20).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 20).unwrap(),
             ),
         ]
     );
@@ -472,15 +511,18 @@ fn test_intersect_overlap_offset_indivisible_by_length_bulk_positive() {
         vec![
             (
                 WindowKey(1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 13).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 03).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 13).unwrap(),
             ),
             (
                 WindowKey(2),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 16).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 06).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 16).unwrap(),
             ),
             (
                 WindowKey(3),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 19).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 09).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 19).unwrap(),
             ),
         ],
     );
@@ -508,15 +550,18 @@ fn test_intersect_overlap_offset_indivisible_by_length_bulk_negative() {
         vec![
             (
                 WindowKey(-3),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 1).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 51).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 1).unwrap(),
             ),
             (
                 WindowKey(-2),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 4).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 54).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 4).unwrap(),
             ),
             (
                 WindowKey(-1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 7).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 57).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 7).unwrap(),
             ),
         ],
     );
@@ -544,15 +589,18 @@ fn test_intersect_overlap_offset_indivisible_by_length_bulk_zero() {
         vec![
             (
                 WindowKey(-1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 7).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 57).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 7).unwrap(),
             ),
             (
                 WindowKey(0),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 00).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
             ),
             (
                 WindowKey(1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 13).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 03).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 13).unwrap(),
             ),
         ],
     );
@@ -578,11 +626,13 @@ fn test_intersect_overlap_offset_indivisible_by_length_edge_start_positive() {
         vec![
             (
                 WindowKey(1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 17).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 07).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 17).unwrap(),
             ),
             (
                 WindowKey(2),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 24).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 14).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 24).unwrap(),
             ),
         ],
     );
@@ -608,11 +658,13 @@ fn test_intersect_overlap_offset_indivisible_by_length_edge_start_negative() {
         vec![
             (
                 WindowKey(-2),
-                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 56).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 46).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 56).unwrap(),
             ),
             (
                 WindowKey(-1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 3).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 53).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 3).unwrap(),
             ),
         ],
     );
@@ -638,11 +690,13 @@ fn test_intersect_overlap_offset_indivisible_by_length_edge_start_zero() {
         vec![
             (
                 WindowKey(-1),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 3).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 53).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 3).unwrap(),
             ),
             (
                 WindowKey(0),
-                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap()
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 00).unwrap(),
+                Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
             ),
         ],
     );
@@ -667,7 +721,8 @@ fn test_intersect_overlap_offset_indivisible_by_length_edge_end_positive() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(2),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 24).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 14).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 24).unwrap(),
         )],
     );
 }
@@ -691,8 +746,9 @@ fn test_intersect_overlap_offset_indivisible_by_length_edge_end_negative() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(-1),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 3).unwrap()
-        ),],
+            Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 53).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 3).unwrap(),
+        )],
     );
 }
 
@@ -715,7 +771,8 @@ fn test_intersect_overlap_offset_indivisible_by_length_edge_end_zero() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(1),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 17).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 7).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 17).unwrap(),
         )],
     );
 }
@@ -739,7 +796,8 @@ fn test_intersect_tumble_bulk_positive() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(1),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 20).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 20).unwrap(),
         )],
     );
 }
@@ -763,7 +821,8 @@ fn test_intersect_tumble_bulk_negative() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(-1),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 0).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 50).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 0).unwrap(),
         )],
     );
 }
@@ -787,7 +846,8 @@ fn test_intersect_tumble_bulk_zero() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(0),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 00).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
         )],
     );
 }
@@ -812,7 +872,8 @@ fn test_intersect_tumble_edge_positive() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(2),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 30).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 20).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 30).unwrap(),
         )],
     );
 }
@@ -837,7 +898,8 @@ fn test_intersect_tumble_edge_negative() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(-1),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 0).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 50).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 0).unwrap(),
         )],
     );
 }
@@ -861,7 +923,8 @@ fn test_intersect_tumble_edge_zero_start() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(0),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 00).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
         )],
     );
 }
@@ -886,7 +949,8 @@ fn test_intersect_tumble_edge_zero_end() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(1),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 20).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 20).unwrap(),
         )],
     );
 }
@@ -910,7 +974,8 @@ fn test_intersect_gap_bulk_positive() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(1),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 23).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 13).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 23).unwrap(),
         )],
     );
 }
@@ -934,7 +999,8 @@ fn test_intersect_gap_bulk_negative() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(-1),
-            Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 57).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 47).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 57).unwrap(),
         )],
     );
 }
@@ -958,7 +1024,8 @@ fn test_intersect_gap_bulk_zero() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(0),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap(),
         )],
     );
 }
@@ -1016,7 +1083,8 @@ fn test_intersect_gap_edge_start_positive() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(1),
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 23).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 13).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 23).unwrap(),
         )],
     );
 }
@@ -1040,7 +1108,8 @@ fn test_intersect_gap_edge_start_negative() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(-1),
-            Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 57).unwrap()
+            Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 47).unwrap(),
+            Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 57).unwrap(),
         )],
     );
 }
@@ -1064,6 +1133,7 @@ fn test_intersect_gap_edge_start_zero() {
         windower.intersects(&item_time).collect::<Vec<_>>(),
         vec![(
             WindowKey(0),
+            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 0).unwrap(),
             Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 10).unwrap()
         )],
     );
@@ -1170,5 +1240,14 @@ fn test_drain_closed() {
     let _ = windower.insert(&watermark1, &item_time);
 
     let watermark2 = Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 17).unwrap();
-    assert_eq!(windower.drain_closed(&watermark2), vec![WindowKey(1)]);
+    assert_eq!(
+        windower.drain_closed(&watermark2),
+        vec![(
+            WindowKey(1),
+            WindowMetadata {
+                open_time: Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 5).unwrap(),
+                close_time: Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 15).unwrap()
+            }
+        )]
+    );
 }

--- a/src/window/sliding_window.rs
+++ b/src/window/sliding_window.rs
@@ -214,9 +214,9 @@ impl Windower for SlidingWindower {
     fn next_close(&self) -> Option<DateTime<Utc>> {
         self.close_times
             .values()
-            .min_by(|(_x_open, x_close), (_y_open, y_close)| x_close.cmp(y_close))
+            .min_by(|(_, x_close), (_, y_close)| x_close.cmp(y_close))
             .cloned()
-            .map(|(_open_time, close_time)| close_time)
+            .map(|(_, close_time)| close_time)
     }
 
     fn snapshot(&self) -> TdPyAny {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -40,6 +40,7 @@ use crate::operators::*;
 use crate::outputs::*;
 use crate::pyo3_extensions::extract_state_pair;
 use crate::pyo3_extensions::wrap_state_pair;
+use crate::pyo3_extensions::wrap_window_state_pair;
 use crate::recovery::*;
 use crate::timely::AsWorkerExt;
 use crate::window::clock::ClockBuilder;
@@ -299,7 +300,7 @@ where
                         // For now, filter to just reductions and
                         // ignore late values.
                         .ok()
-                        .map(wrap_state_pair);
+                        .map(wrap_window_state_pair);
                     snaps.push(snap);
                 }
                 Step::Input {
@@ -416,7 +417,7 @@ where
                         // For now, filter to just reductions and
                         // ignore late values.
                         .ok()
-                        .map(wrap_state_pair);
+                        .map(wrap_window_state_pair);
                     snaps.push(snap);
                 }
                 Step::Inspect { inspector } => {
@@ -475,7 +476,7 @@ where
                         // For now, filter to just reductions and
                         // ignore late values.
                         .ok()
-                        .map(wrap_state_pair);
+                        .map(wrap_window_state_pair);
                     snaps.push(snap);
                 }
                 Step::StatefulMap {


### PR DESCRIPTION
Introduces `WindowMetadata`, to be emitted downstream along with the values contained in a window.

Changes the output of window operators from:
`(key, values)` 
to `(key, (metadata, values))`

WindowMetadata contains the open_time, and close_time of the window values it's emitted with.

Fixes https://github.com/bytewax/bytewax/issues/270