### PR TITLE
Flushes StdOutSink

### DIFF
--- a/pysrc/bytewax/connectors/stdio.py
+++ b/pysrc/bytewax/connectors/stdio.py
@@ -1,4 +1,6 @@
 """Connectors to console IO."""
+import sys
+
 from bytewax.outputs import DynamicSink, StatelessSinkPartition
 
 __all__ = [
@@ -9,7 +11,10 @@ __all__ = [
 class _PrintSinkPartition(StatelessSinkPartition):
     def write_batch(self, items):
         for item in items:
-            print(item)
+            line = str(item)
+            sys.stdout.write(line)
+            sys.stdout.write("\n")
+        sys.stdout.flush()
 
 
 class StdOutSink(DynamicSink):


### PR DESCRIPTION
Converts `StdOutSink` to use `sys.stdout` so we can `flush` it after
each batch. This output is going to be used for examples and debugging
and so we shouldn't let the vagueries of buffering behavior make this
more mysterious.
