### PR TITLE
Kafka connector revamp, schema registry support, py-operators

### DIFF
--- a/examples/event_time_processing.py
+++ b/examples/event_time_processing.py
@@ -22,7 +22,8 @@ import json
 from datetime import datetime, timedelta, timezone
 
 from bytewax import operators as op
-from bytewax.connectors.kafka import KafkaMessage, KafkaSource
+from bytewax.connectors.kafka import KafkaSourceMessage
+from bytewax.connectors.kafka import operators as kop
 from bytewax.connectors.stdio import StdOutSink
 from bytewax.dataflow import Dataflow
 from bytewax.operators import window as window_op
@@ -32,11 +33,11 @@ from bytewax.operators.window import EventClockConfig, TumblingWindow
 flow = Dataflow("event time")
 brokers = ["localhost:19092"]
 topics = ["sensors"]
-stream = op.input("inp", flow, KafkaSource(brokers, topics, tail=False))
+stream = kop.input("inp", flow, brokers, topics, tail=False)
 
 
 # We expect a json string that represents a reading from a sensor in msg.value.
-def parse_value(msg: KafkaMessage):
+def parse_value(msg: KafkaSourceMessage):
     return json.loads(msg.value)
 
 

--- a/examples/event_time_processing.py
+++ b/examples/event_time_processing.py
@@ -22,7 +22,7 @@ import json
 from datetime import datetime, timedelta, timezone
 
 from bytewax import operators as op
-from bytewax.connectors.kafka import KafkaSource
+from bytewax.connectors.kafka import KafkaMessage, KafkaSource
 from bytewax.connectors.stdio import StdOutSink
 from bytewax.dataflow import Dataflow
 from bytewax.operators import window as window_op
@@ -35,10 +35,9 @@ topics = ["sensors"]
 stream = op.input("inp", flow, KafkaSource(brokers, topics, tail=False))
 
 
-# We expect a json string that represents a reading from a sensor.
-def parse_value(key__data):
-    _, data = key__data
-    return json.loads(data)
+# We expect a json string that represents a reading from a sensor in msg.value.
+def parse_value(msg: KafkaMessage):
+    return json.loads(msg.value)
 
 
 parsed_stream = op.map("parse_value", stream, parse_value)

--- a/examples/schema_registry_confluent.py
+++ b/examples/schema_registry_confluent.py
@@ -95,7 +95,7 @@ msgs = kop.deserialize("de", kinp.oks, key_deserializer=key_de, val_deserializer
 op.inspect("inspect-deser", msgs.errs).then(op.raises, "deser-error")
 
 
-def extract_identifier(msg: KafkaSourceMessage[Dict, Dict]) -> str:
+def extract_identifier(msg: KafkaSourceMessage) -> str:
     # Use the "identifier" field of the key as bytewax's key
     return msg.key["identifier"]
 
@@ -104,7 +104,7 @@ keyed = op.key_on("key_on_identifier", msgs.oks, extract_identifier)
 
 
 # Let's window the input
-def accumulate(acc: List[str], msg: KafkaSourceMessage[Dict, Dict]) -> List[str]:
+def accumulate(acc: List[str], msg: KafkaSourceMessage) -> List[str]:
     acc.append(msg.value["value"])
     return acc
 

--- a/examples/schema_registry_confluent.py
+++ b/examples/schema_registry_confluent.py
@@ -1,0 +1,147 @@
+"""
+Schema registry complete example.
+
+The Kafka input connector has support for schema registries.
+We support Redpanda and Confluent registries.
+This example shows how to use the clients in the kafka connector.
+
+The schems used for this example are the following:
+
+- Subject `sensor-key`:
+    {
+        "type": "record",
+        "name": "sensor_key",
+        "fields": [
+            {"name": "identifier", "type": "string", "logicalType": "uuid"},
+            {"name": "name", "type": "string"},
+        ],
+    }
+
+- Subject `sensor-value`:
+    {
+        "type": "record",
+        "name": "sensor_sample",
+        "fields": [
+            {"name": "timestamp", "type": "long", "logicalType": "timestamp-millis"},
+            {"name": "identifier", "type": "string", "logicalType": "uuid"},
+            {"name": "value", "type": "long"},
+        ],
+    }
+
+- Subject `aggregated-value`:
+    {
+        "type": "record",
+        "name": "aggregated_sensor",
+        "fields": [
+            {"name": "identifier", "type": "string", "logicalType": "uuid"},
+            {"name": "avg", "type": "long"},
+            {"name": "window_start", "type": "string"},
+            {"name": "window_end", "type": "string"},
+        ],
+    }
+
+"""
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Tuple
+
+import bytewax.operators as op
+import bytewax.operators.window as wop
+from bytewax.connectors.kafka import KafkaMessage
+from bytewax.connectors.kafka import operators as kop
+from bytewax.connectors.kafka.registry import ConfluentSchemaRegistry
+from bytewax.dataflow import Dataflow
+from bytewax.operators.window import SystemClockConfig, TumblingWindow
+from confluent_kafka.schema_registry import SchemaRegistryClient
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format=logging.BASIC_FORMAT, level=logging.WARNING)
+
+
+# Setup some more env vars first:
+KAFKA_BROKERS = os.environ.get("KAFKA_SERVER", "localhost:19092").split(";")
+IN_TOPICS = os.environ.get("KAFKA_IN_TOPIC", "in_topic").split(";")
+OUT_TOPIC = os.environ.get("KAFKA_OUT_TOPIC", "out_topic")
+CONFLUENT_URL = os.environ["CONFLUENT_URL"]
+CONFLUENT_USERINFO = os.environ["CONFLUENT_USERINFO"]
+CONFLUENT_USERNAME = os.environ["CONFLUENT_USERNAME"]
+CONFLUENT_PASSWORD = os.environ["CONFLUENT_PASSWORD"]
+
+# Pass this to both kafka_in and kafka_out
+add_config = {
+    "security.protocol": "SASL_SSL",
+    "sasl.mechanism": "PLAIN",
+    "sasl.username": CONFLUENT_USERNAME,
+    "sasl.password": CONFLUENT_PASSWORD,
+}
+
+flow = Dataflow("schema_registry")
+kinp = kop.input(
+    "kafka-in", flow, brokers=KAFKA_BROKERS, topics=IN_TOPICS, add_config=add_config
+)
+# Inspect errors and crash
+op.inspect("inspect-kafka-errors", kinp.errs).then(op.raises, "kafka-error")
+
+# ConfluentSchemaRegistry config:
+sr_conf = {"url": CONFLUENT_URL, "basic.auth.user.info": CONFLUENT_USERINFO}
+registry = ConfluentSchemaRegistry(SchemaRegistryClient(sr_conf))
+
+# Confluent's deserializer doesn't need a schema, it automatically fetches it.
+key_de = registry.deserializer()
+val_de = registry.deserializer()
+msgs = kop.deserialize("de", kinp.oks, key_deserializer=key_de, val_deserializer=val_de)
+# Inspect errors and crash
+op.inspect("inspect-deser", msgs.errs).then(op.raises, "deser-error")
+
+
+def extract_identifier(msg: KafkaMessage[Dict, Dict]) -> str:
+    # Use the "identifier" field of the key as bytewax's key
+    return msg.key["identifier"]
+
+
+keyed = op.key_on("key_on_identifier", msgs.oks, extract_identifier)
+
+# Let's window the input
+def accumulate(acc: List[str], msg: KafkaMessage[Dict, Dict]) -> List[str]:
+    acc.append(msg.value["value"])
+    return acc
+
+
+cc = SystemClockConfig()
+wc = TumblingWindow(timedelta(seconds=1), datetime(2023, 1, 1, tzinfo=timezone.utc))
+windows = wop.fold_window("calc_avg", keyed, cc, wc, list, accumulate)
+
+# And do some calculations on each window
+def calc_avg(key__wm__batch) -> Tuple[Dict, Dict]:
+    key, (wm, batch) = key__wm__batch
+    # Use the correct schemas here, or the serialization
+    # step will fail later
+    return (
+        {"identifier": key, "name": "topic_key"},
+        {
+            "identifier": key,
+            "avg": sum(batch) / len(batch),
+            "window_open": wm.open_time.isoformat(),
+            "window_start": wm.close_time.isoformat(),
+        },
+    )
+
+
+avgs = op.map("avg", windows, calc_avg)
+op.inspect("inspect-out-data", avgs)
+
+# The serializers require a specific schema instead. You can use SchemaRef too.
+key_ser = registry.serializer(100002)
+val_ser = registry.serializer(100003)
+# Serialize
+serialized = kop.serialize("ser", avgs, key_serializer=key_ser, val_serializer=val_ser)
+
+op.inspect("inspect-serialized", serialized)
+kop.output(
+    "kafka-out",
+    serialized,
+    brokers=KAFKA_BROKERS,
+    topic=OUT_TOPIC,
+    add_config=add_config,
+)

--- a/examples/schema_registry_confluent.py
+++ b/examples/schema_registry_confluent.py
@@ -44,11 +44,11 @@ The schems used for this example are the following:
 import logging
 import os
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 import bytewax.operators as op
 import bytewax.operators.window as wop
-from bytewax.connectors.kafka import KafkaSourceMessage, KafkaSinkMessage
+from bytewax.connectors.kafka import KafkaSinkMessage, KafkaSourceMessage
 from bytewax.connectors.kafka import operators as kop
 from bytewax.connectors.kafka.registry import ConfluentSchemaRegistry
 from bytewax.dataflow import Dataflow

--- a/examples/schema_registry_redpanda.py
+++ b/examples/schema_registry_redpanda.py
@@ -1,0 +1,127 @@
+"""
+Schema registry complete example.
+
+The Kafka input connector has support for schema registries.
+We support Redpanda and Confluent registries.
+This example shows how to use Redpanda client in the kafka connector.
+
+The schems used for this example are the following:
+
+- Subject `sensor-key`:
+    {
+        "type": "record",
+        "name": "sensor_key",
+        "fields": [
+            {"name": "identifier", "type": "string", "logicalType": "uuid"},
+            {"name": "name", "type": "string"},
+        ],
+    }
+
+- Subject `sensor-value`:
+    {
+        "type": "record",
+        "name": "sensor_sample",
+        "fields": [
+            {"name": "timestamp", "type": "long", "logicalType": "timestamp-millis"},
+            {"name": "identifier", "type": "string", "logicalType": "uuid"},
+            {"name": "value", "type": "long"},
+        ],
+    }
+
+- Subject `aggregated-value`:
+    {
+        "type": "record",
+        "name": "aggregated_sensor",
+        "fields": [
+            {"name": "identifier", "type": "string", "logicalType": "uuid"},
+            {"name": "avg", "type": "long"},
+            {"name": "window_start", "type": "string"},
+            {"name": "window_end", "type": "string"},
+        ],
+    }
+
+"""
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Tuple
+
+import bytewax.operators as op
+import bytewax.operators.window as wop
+from bytewax.connectors.kafka import KafkaMessage
+from bytewax.connectors.kafka import operators as kop
+from bytewax.connectors.kafka.registry import RedpandaSchemaRegistry, SchemaRef
+from bytewax.dataflow import Dataflow
+from bytewax.operators.window import SystemClockConfig, TumblingWindow
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format=logging.BASIC_FORMAT, level=logging.WARNING)
+
+KAFKA_BROKERS = os.environ.get("KAFKA_SERVER", "localhost:19092").split(";")
+IN_TOPICS = os.environ.get("KAFKA_IN_TOPIC", "in_topic").split(";")
+OUT_TOPIC = os.environ.get("KAFKA_OUT_TOPIC", "out_topic")
+REDPANDA_REGISTRY_URL = os.environ["REDPANDA_REGISTRY_URL"]
+
+
+flow = Dataflow("schema_registry")
+kinp = kop.input("kafka-in", flow, brokers=KAFKA_BROKERS, topics=IN_TOPICS)
+
+# Inspect errors and crash
+op.inspect("inspect-kafka-errors", kinp.errs).then(op.raises, "kafka-error")
+
+# Redpanda's schema registry configuration
+registry = RedpandaSchemaRegistry(REDPANDA_REGISTRY_URL)
+
+# Deserialize both key and value
+key_de = registry.deserializer(SchemaRef("sensor-key"))
+val_de = registry.deserializer(SchemaRef("sensor-value"))
+msgs = kop.deserialize("de", kinp.oks, key_deserializer=key_de, val_deserializer=val_de)
+# Inspect errors and crash
+op.inspect("inspect-deser", msgs.errs).then(op.raises, "deser-error")
+
+
+def extract_identifier(msg: KafkaMessage[Dict, Dict]) -> str:
+    # Use the "identifier" field of the key as bytewax's key
+    return msg.key["identifier"]
+
+
+keyed = op.key_on("key_on_identifier", msgs.oks, extract_identifier)
+
+# Let's window the input
+def accumulate(acc: List[str], msg: KafkaMessage[Dict, Dict]) -> List[str]:
+    acc.append(msg.value["value"])
+    return acc
+
+
+cc = SystemClockConfig()
+wc = TumblingWindow(timedelta(seconds=1), datetime(2023, 1, 1, tzinfo=timezone.utc))
+windows = wop.fold_window("calc_avg", keyed, cc, wc, list, accumulate)
+
+# And do some calculations on each window
+def calc_avg(key__wm__batch) -> Tuple[Dict, Dict]:
+    key, (wm, batch) = key__wm__batch
+    # Use the correct schemas here, or the serialization
+    # step will fail later
+    return (
+        {"identifier": key, "name": "topic_key"},
+        {
+            "identifier": key,
+            "avg": sum(batch) / len(batch),
+            "window_open": wm.open_time.isoformat(),
+            "window_start": wm.close_time.isoformat(),
+        },
+    )
+
+
+avgs = op.map("avg", windows, calc_avg)
+
+op.inspect("inspect-out-data", avgs)
+
+# Instantiate deserializers
+key_ser = registry.serializer(SchemaRef("sensor-key"))
+val_ser = registry.serializer(SchemaRef("aggregated-value"))
+# Serialize
+serialized = kop.serialize("ser", avgs, key_serializer=key_ser, val_serializer=val_ser)
+
+op.inspect("inspect-serialized", serialized)
+kop.output("kafka-out", serialized, brokers=KAFKA_BROKERS, topic=OUT_TOPIC)

--- a/examples/schema_registry_redpanda.py
+++ b/examples/schema_registry_redpanda.py
@@ -44,11 +44,11 @@ The schems used for this example are the following:
 import logging
 import os
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 import bytewax.operators as op
 import bytewax.operators.window as wop
-from bytewax.connectors.kafka import KafkaMessage
+from bytewax.connectors.kafka import KafkaSinkMessage, KafkaSourceMessage
 from bytewax.connectors.kafka import operators as kop
 from bytewax.connectors.kafka.registry import RedpandaSchemaRegistry, SchemaRef
 from bytewax.dataflow import Dataflow
@@ -80,7 +80,7 @@ msgs = kop.deserialize("de", kinp.oks, key_deserializer=key_de, val_deserializer
 op.inspect("inspect-deser", msgs.errs).then(op.raises, "deser-error")
 
 
-def extract_identifier(msg: KafkaMessage[Dict, Dict]) -> str:
+def extract_identifier(msg: KafkaSourceMessage[Dict, Dict]) -> str:
     # Use the "identifier" field of the key as bytewax's key
     return msg.key["identifier"]
 
@@ -88,7 +88,7 @@ def extract_identifier(msg: KafkaMessage[Dict, Dict]) -> str:
 keyed = op.key_on("key_on_identifier", msgs.oks, extract_identifier)
 
 # Let's window the input
-def accumulate(acc: List[str], msg: KafkaMessage[Dict, Dict]) -> List[str]:
+def accumulate(acc: List[str], msg: KafkaSourceMessage[Dict, Dict]) -> List[str]:
     acc.append(msg.value["value"])
     return acc
 
@@ -98,13 +98,13 @@ wc = TumblingWindow(timedelta(seconds=1), datetime(2023, 1, 1, tzinfo=timezone.u
 windows = wop.fold_window("calc_avg", keyed, cc, wc, list, accumulate)
 
 # And do some calculations on each window
-def calc_avg(key__wm__batch) -> Tuple[Dict, Dict]:
+def calc_avg(key__wm__batch) -> KafkaSinkMessage[Dict, Dict]:
     key, (wm, batch) = key__wm__batch
     # Use the correct schemas here, or the serialization
     # step will fail later
-    return (
-        {"identifier": key, "name": "topic_key"},
-        {
+    return KafkaSinkMessage(
+        key={"identifier": key, "name": "topic_key"},
+        value={
             "identifier": key,
             "avg": sum(batch) / len(batch),
             "window_open": wm.open_time.isoformat(),

--- a/examples/simple_kafka_in_and_out.py
+++ b/examples/simple_kafka_in_and_out.py
@@ -1,34 +1,36 @@
 import json
+from typing import Dict, Tuple
 
 from bytewax import operators as op
-from bytewax.connectors.kafka import KafkaSink, KafkaSource
+from bytewax.connectors.kafka import KafkaMessage, KafkaSink, KafkaSource
 from bytewax.connectors.stdio import StdOutSink
 from bytewax.dataflow import Dataflow
 
 flow = Dataflow("kafka_in_out")
-stream = op.input("inp", flow, KafkaSource(["localhost:9092"], ["input_topic"]))
+inp = op.input("inp", flow, KafkaSource(["localhost:9092"], ["input_topic"]))
 
 
-def deserialize(key_bytes__payload_bytes):
-    key_bytes, payload_bytes = key_bytes__payload_bytes
-    key = json.loads(key_bytes) if key_bytes else None
-    payload = json.loads(payload_bytes) if payload_bytes else None
+def deserialize(msg: KafkaMessage) -> Tuple[Dict, Dict]:
+    key = json.loads(msg.key)
+    payload = json.loads(msg.value)
     return key, payload
 
 
-def serialize_with_key(key_payload):
+deserialized = op.map("deserialize", inp, deserialize)
+op.output("out1", deserialized, StdOutSink())
+
+
+def serialize_with_key(key_payload: Tuple[Dict, Dict]) -> Tuple[bytes, bytes]:
     key, payload = key_payload
-    new_key_bytes = key if key else json.dumps("my_key").encode("utf-8")
-    return new_key_bytes, json.dumps(payload).encode("utf-8")
+    serialized_key = json.dumps(key).encode("utf-8")
+    serialized_payload = json.dumps(payload).encode("utf-8")
+    return serialized_key, serialized_payload
 
 
-stream = op.map("deserialize", stream, deserialize)
-op.output("out1", stream, StdOutSink())
-
-stream = op.map("serialize_with_key", stream, serialize_with_key)
+serialized = op.map("serialize_with_key", deserialized, serialize_with_key)
 op.output(
     "out2",
-    stream,
+    serialized,
     KafkaSink(
         brokers=["localhost:9092"],
         topic="output_topic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dev = [
     "vermin==1.5.2",
 ]
 kafka = [
+    "requests>=2.0",
+    "fastavro>=1.8",
     "confluent-kafka<=2.0.2",  # Update this to a broader bound once we fix CI.
 ]
 test = [

--- a/pysrc/bytewax/connectors/kafka/__init__.py
+++ b/pysrc/bytewax/connectors/kafka/__init__.py
@@ -34,14 +34,15 @@ Or the custom operators:
 
 """
 from . import operators, registry, serde
-from .message import KafkaMessage
+from .message import KafkaSinkMessage, KafkaSourceMessage
 from .sink import KafkaSink
 from .source import KafkaSource
 
 __all__ = [
     "KafkaSource",
     "KafkaSink",
-    "KafkaMessage",
+    "KafkaSinkMessage",
+    "KafkaSourceMessage",
     "operators",
     "registry",
     "serde",

--- a/pysrc/bytewax/connectors/kafka/__init__.py
+++ b/pysrc/bytewax/connectors/kafka/__init__.py
@@ -1,0 +1,48 @@
+"""Connectors for [Kafka](https://kafka.apache.org).
+
+Importing this module requires the
+[`confluent-kafka`](https://github.com/confluentinc/confluent-kafka-python)
+package to be installed.
+
+The input source returns a stream of `KafkaMessage`.
+See the docstring for its use.
+
+You can use `KafkaSource` and `KafkaSink` directly:
+
+>>> from bytewax.connectors.kafka import KafkaSource, KafkaSink
+>>> from bytewax import operators as op
+>>> from bytewax.dataflow import Dataflow
+>>>
+>>> brokers = ["localhost:1909"]
+>>> flow = Dataflow("example")
+>>> kinp = op.input("kafka-in", flow, KafkaSource(["localhost:1909"], ["in-topic"]))
+>>> processed = op.map("map", kinp, lambda x: (x.key, x.value))
+>>> op.output("kafka-out", processed, KafkaSink(brokers, "out-topic"))
+
+Or the custom operators:
+
+>>> from bytewax.connectors.kafka import operators as kop
+>>> from bytewax import operators as op
+>>> from bytewax.dataflow import Dataflow
+>>>
+>>> brokers = ["localhost:1909"]
+>>> flow = Dataflow("example")
+>>> kinp = kop.input("kafka-in", flow, brokers=brokers, topics=["in-topic"])
+>>> errs = op.inspect("errors", kinp.errs).then(op.raises, "crash-on-err")
+>>> processed = op.map("map", kinp.oks, lambda x: (x.key, x.value))
+>>> kop.output("kafka-out", processed, brokers=brokers, topic="out-topic")
+
+"""
+from . import operators, registry, serde
+from .message import KafkaMessage
+from .sink import KafkaSink
+from .source import KafkaSource
+
+__all__ = [
+    "KafkaSource",
+    "KafkaSink",
+    "KafkaMessage",
+    "operators",
+    "registry",
+    "serde",
+]

--- a/pysrc/bytewax/connectors/kafka/_types.py
+++ b/pysrc/bytewax/connectors/kafka/_types.py
@@ -1,0 +1,7 @@
+from typing import Optional, TypeVar, Union
+
+K = TypeVar("K")  # Key
+V = TypeVar("V")  # Value
+K2 = TypeVar("K2")  # Modified Key
+V2 = TypeVar("V2")  # Modified Value
+MaybeStrBytes = Optional[Union[str, bytes]]

--- a/pysrc/bytewax/connectors/kafka/error.py
+++ b/pysrc/bytewax/connectors/kafka/error.py
@@ -1,0 +1,17 @@
+"""Error handling related stuff."""
+
+from dataclasses import dataclass
+from typing import Generic
+
+from confluent_kafka import KafkaError as ConfluentKafkaError
+
+from ._types import K, V
+from .message import KafkaSourceMessage
+
+
+@dataclass(frozen=True)
+class KafkaError(Generic[K, V]):
+    """Custom KafkaErorr class that holds both the exception and the message itself."""
+
+    err: ConfluentKafkaError
+    msg: KafkaSourceMessage[K, V]

--- a/pysrc/bytewax/connectors/kafka/message.py
+++ b/pysrc/bytewax/connectors/kafka/message.py
@@ -1,12 +1,12 @@
 """KafkaMessage definition."""
 
 from dataclasses import dataclass, field
-from typing import Generic, List, Optional, Tuple, cast
+from typing import Generic, List, Optional, Tuple
 
 from ._types import K2, V2, K, V
 
 
-@dataclass
+@dataclass(frozen=True)
 class KafkaSourceMessage(Generic[K, V]):
     """Class that holds a message from kafka with metadata.
 
@@ -34,29 +34,48 @@ class KafkaSourceMessage(Generic[K, V]):
         return KafkaSinkMessage(key=self.key, value=self.value, headers=self.headers)
 
     def _with_key(self, key: K2) -> "KafkaSourceMessage[K2, V]":
-        """Modifies the key in place and returns the instance."""
+        """Returns a new instance with the specified key."""
         # Can't use `dataclasses.replace` directly since it requires
         # the fields you change to be the same type.
-        # But we can modify the message in place and return it
-        this = cast(KafkaSourceMessage[K2, V], self)
-        this.key = key
-        return this
+        return KafkaSourceMessage(
+            key=key,
+            value=self.value,
+            topic=self.topic,
+            headers=self.headers,
+            latency=self.latency,
+            offset=self.offset,
+            partition=self.partition,
+            timestamp=self.timestamp,
+        )
 
     def _with_value(self, value: V2) -> "KafkaSourceMessage[K, V2]":
-        """Modifies the value in place and returns the instance."""
-        this = cast(KafkaSourceMessage[K, V2], self)
-        this.value = value
-        return this
+        """Returns a new instance with the specified value."""
+        return KafkaSourceMessage(
+            key=self.key,
+            value=value,
+            topic=self.topic,
+            headers=self.headers,
+            latency=self.latency,
+            offset=self.offset,
+            partition=self.partition,
+            timestamp=self.timestamp,
+        )
 
     def _with_key_and_value(self, key: K2, value: V2) -> "KafkaSourceMessage[K2, V2]":
-        """Modifies both key and value in place and returns the instance."""
-        this = cast(KafkaSourceMessage[K2, V2], self)
-        this.key = key
-        this.value = value
-        return this
+        """Returns a new instance with the specified key and value."""
+        return KafkaSourceMessage(
+            key=key,
+            value=value,
+            topic=self.topic,
+            headers=self.headers,
+            latency=self.latency,
+            offset=self.offset,
+            partition=self.partition,
+            timestamp=self.timestamp,
+        )
 
 
-@dataclass
+@dataclass(frozen=True)
 class KafkaSinkMessage(Generic[K, V]):
     """Class that holds a message from kafka with metadata.
 
@@ -69,29 +88,42 @@ class KafkaSinkMessage(Generic[K, V]):
     key: K
     value: V
 
-    topic: Optional[str] = field(default=None)
+    topic: Optional[str] = None
     headers: List[Tuple[str, bytes]] = field(default_factory=list)
-    partition: Optional[int] = field(default=None)
-    timestamp: Optional[Tuple[int, int]] = field(default=None)
+    partition: Optional[int] = None
+    timestamp: int = 0
 
     def _with_key(self, key: K2) -> "KafkaSinkMessage[K2, V]":
-        """Modifies the key in place and returns the instance."""
+        """Returns a new instance with the specified key."""
         # Can't use `dataclasses.replace` directly since it requires
         # the fields you change to be the same type.
-        # But we can modify the message in place and return it
-        this = cast(KafkaSinkMessage[K2, V], self)
-        this.key = key
-        return this
+        return KafkaSinkMessage(
+            key=key,
+            value=self.value,
+            topic=self.topic,
+            headers=self.headers,
+            partition=self.partition,
+            timestamp=self.timestamp,
+        )
 
     def _with_value(self, value: V2) -> "KafkaSinkMessage[K, V2]":
-        """Modifies the value in place and returns the instance."""
-        this = cast(KafkaSinkMessage[K, V2], self)
-        this.value = value
-        return this
+        """Returns a new instance with the specified value."""
+        return KafkaSinkMessage(
+            key=self.key,
+            value=value,
+            topic=self.topic,
+            headers=self.headers,
+            partition=self.partition,
+            timestamp=self.timestamp,
+        )
 
     def _with_key_and_value(self, key: K2, value: V2) -> "KafkaSinkMessage[K2, V2]":
-        """Modifies both key and value in place and returns the instance."""
-        this = cast(KafkaSinkMessage[K2, V2], self)
-        this.key = key
-        this.value = value
-        return this
+        """Returns a new instance with the specified key and value."""
+        return KafkaSinkMessage(
+            key=key,
+            value=value,
+            topic=self.topic,
+            headers=self.headers,
+            partition=self.partition,
+            timestamp=self.timestamp,
+        )

--- a/pysrc/bytewax/connectors/kafka/message.py
+++ b/pysrc/bytewax/connectors/kafka/message.py
@@ -10,7 +10,7 @@ from ._types import K2, V2, K, V
 class KafkaSourceMessage(Generic[K, V]):
     """Class that holds a message from kafka with metadata.
 
-    Use `KafkaSourceMessage.key` to get the key and `KafkaMessage.value` to get
+    Use `msg.key` to get the key and `msg.value` to get
     the value.
 
     Other fields: `topic`, `headers`, `latency` `offset`, `partition`, `timestamp`

--- a/pysrc/bytewax/connectors/kafka/message.py
+++ b/pysrc/bytewax/connectors/kafka/message.py
@@ -1,0 +1,64 @@
+"""KafkaMessage definition."""
+
+from dataclasses import dataclass, replace
+from typing import Generic, List, Optional, Tuple
+
+from confluent_kafka import KafkaError
+
+from ._types import K2, V2, K, V
+
+
+@dataclass(frozen=True)
+class KafkaMessage(Generic[K, V]):
+    """Class that holds a message from kafka with metadata.
+
+    Use `KafkaMessage.key` to get the key and `KafkaMessage.value` to get
+    the value.
+
+    Check `KafkaMessage.error` before using the message.
+
+    Other fields: `topic`, `headers`, `latency` `offset`, `partition`, `timestamp`
+    """
+
+    key: K
+    value: V
+
+    error: Optional[KafkaError]
+    topic: Optional[str]
+    headers: List[Tuple[str, bytes]]
+    latency: Optional[float]
+    offset: Optional[int]
+    partition: Optional[int]
+    timestamp: Tuple[int, int]
+
+    def with_error(self, error: KafkaError) -> "KafkaMessage[K, V]":
+        """Returns a new instance of the message with the specified error."""
+        return replace(self, error=error)
+
+    def with_key(self, key: K2) -> "KafkaMessage[K2, V]":
+        """Returns a new instance of the message with the specified key."""
+        return KafkaMessage(
+            key=key,
+            value=self.value,
+            error=self.error,
+            topic=self.topic,
+            headers=self.headers,
+            latency=self.latency,
+            offset=self.offset,
+            partition=self.partition,
+            timestamp=self.timestamp,
+        )
+
+    def with_value(self, value: V2) -> "KafkaMessage[K, V2]":
+        """Returns a new instance of the message with the specified value."""
+        return KafkaMessage(
+            key=self.key,
+            value=value,
+            error=self.error,
+            topic=self.topic,
+            headers=self.headers,
+            latency=self.latency,
+            offset=self.offset,
+            partition=self.partition,
+            timestamp=self.timestamp,
+        )

--- a/pysrc/bytewax/connectors/kafka/operators.py
+++ b/pysrc/bytewax/connectors/kafka/operators.py
@@ -1,0 +1,293 @@
+"""Operators for the kafka source and sink."""
+from dataclasses import dataclass
+from typing import Dict, Generic, List, Tuple, Union, cast
+
+from confluent_kafka import OFFSET_BEGINNING
+from confluent_kafka.error import KafkaError
+
+import bytewax.operators as op
+from bytewax.dataflow import Dataflow
+from bytewax.operators import Stream, operator
+
+from ._types import K2, V2, K, MaybeStrBytes, V
+from .message import KafkaMessage
+from .serde import SchemaDeserializer, SchemaSerializer
+from .sink import KafkaSink
+from .source import KafkaSource
+
+__all__ = [
+    "deserialize",
+    "deserialize_key",
+    "deserialize_value",
+    "serialize",
+    "serialize_key",
+    "serialize_value",
+    "input",
+    "output",
+]
+
+
+@dataclass(frozen=True)
+class KafkaStreams(Generic[K, V, K2, V2]):
+    """Contains two streams of KafkaMessages, oks and errors.
+
+    - KafkaStreams.oks:
+        A stream of `KafkaMessage`s where `KafkaMessage.error is None`
+    - KafkaStreams.errors:
+        A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
+    """
+
+    oks: Stream[KafkaMessage[K, V]]
+    errs: Stream[KafkaMessage[K2, V2]]
+
+
+@operator
+def _kafka_error_split(
+    step_id: str, up: Stream[Union[KafkaMessage[K, V], KafkaMessage[K2, V2]]]
+) -> KafkaStreams[K, V, K2, V2]:
+    """Split a stream of KafkaMessages in two."""
+
+    def predicate(msg: KafkaMessage) -> bool:
+        return msg.error is None
+
+    branch = op.branch("branch", up, predicate)
+    # Cast the streams to the proper expected types.
+    # This assumes that messages where error is None will be KafkaMessage[K, V]
+    # while messages where error is not None will be KafkaMessage[K2, V2]
+    oks = cast(Stream[KafkaMessage[K, V]], branch.trues)
+    errs = cast(Stream[KafkaMessage[K2, V2]], branch.falses)
+    return KafkaStreams(oks, errs)
+
+
+_default_add_config: Dict = {}
+
+
+@operator
+def input(  # noqa A001
+    step_id: str,
+    flow: Dataflow,
+    *,
+    brokers: List[str],
+    topics: List[str],
+    tail: bool = True,
+    starting_offset: int = OFFSET_BEGINNING,
+    # TODO: Use Optional
+    # add_config: Optional[Dict[str, str]] = None,
+    add_config: Dict[str, str] = _default_add_config,
+    batch_size: int = 1000,
+) -> KafkaStreams[MaybeStrBytes, MaybeStrBytes, MaybeStrBytes, MaybeStrBytes]:
+    """Use a set of Kafka topics as an input source.
+
+    Partitions are the unit of parallelism.
+    Can support exactly-once processing.
+
+    Messages are emitted into the dataflow
+    as `bytewax.connectors.kafka.KafkaMessage` objects.
+
+    Args:
+        step_id:
+            Unique name for this step
+        flow:
+            A Dataflow
+        brokers:
+            List of `host:port` strings of Kafka brokers.
+        topics:
+            List of topics to consume from.
+        tail:
+            Whether to wait for new data on this topic when the
+            end is initially reached.
+        starting_offset:
+            Can be either `confluent_kafka.OFFSET_BEGINNING` or
+            `confluent_kafka.OFFSET_END`. Defaults to beginning of
+            topic.
+        add_config:
+            Any additional configuration properties. See the `rdkafka`
+            [docs](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md)
+            for options.
+        batch_size:
+            How many messages to consume at most at each poll. Defaults to 1000.
+    """
+    return op.input(
+        "kafka_input",
+        flow,
+        KafkaSource(
+            brokers,
+            topics,
+            tail,
+            starting_offset,
+            add_config,
+            batch_size,
+            # Don't raise on errors, since we split
+            # the stream and let users handle that
+            raise_on_errors=False,
+        ),
+    ).then(_kafka_error_split, "split_err")
+
+
+@operator
+def output(
+    step_id: str,
+    up: Stream[Tuple[bytes, bytes]],
+    *,
+    brokers: List[str],
+    topic: str,
+    # TODO: Use Optional
+    # add_config: Optional[Dict[str, str]] = None,
+    add_config: Dict[str, str] = _default_add_config,
+) -> None:
+    """Use a single Kafka topic as an output sink.
+
+    Items consumed from the dataflow must look like two-tuples of
+    `(key_bytes, value_bytes)`. Default partition routing is used.
+
+    Workers are the unit of parallelism.
+
+    Can support at-least-once processing. Messages from the resume
+    epoch will be duplicated right after resume.
+
+    Args:
+        step_id:
+            Unique name for this step
+        up:
+            A stream of `(key_bytes, value_bytes)` 2-tuples
+        brokers:
+            List of `host:port` strings of Kafka brokers.
+        topic:
+            Topic to produce to.
+        add_config:
+            Any additional configuration properties. See the `rdkafka`
+            [docs](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md)
+            for options.
+    """
+    return op.output("kafka_output", up, KafkaSink(brokers, topic, add_config))
+
+
+@operator
+def deserialize_key(
+    step_id: str,
+    up: Stream[KafkaMessage[K, V]],
+    deserializer: SchemaDeserializer[K, K2],
+) -> KafkaStreams[K2, V, K, V]:
+    """Deserialize the key of a KafkaMessage using the provided SchemaDeserializer.
+
+    Returns an object with two attributes:
+        - .oks: A stream of `KafkaMessage`s where `KafkaMessage.error is None`
+        - .errors: A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
+    """
+
+    # Make sure the first KafkaMessage in the return type's Union represents
+    # the `oks` stream and the second one the `errs` stream for the
+    # `_kafka_error_split` operator.
+    def shim_mapper(
+        msg: KafkaMessage[K, V]
+    ) -> Union[KafkaMessage[K2, V], KafkaMessage[K, V]]:
+        try:
+            key = deserializer.de(msg.key)
+            return msg.with_key(key)
+        except Exception as e:
+            return msg.with_error(KafkaError(KafkaError._KEY_DESERIALIZATION, f"{e}"))
+
+    return op.map("map", up, shim_mapper).then(_kafka_error_split, "split")
+
+
+@operator
+def deserialize_value(
+    step_id: str,
+    up: Stream[KafkaMessage[K, V]],
+    deserializer: SchemaDeserializer[V, V2],
+) -> KafkaStreams[K, V2, K, V]:
+    """Deserialize the value of a KafkaMessage using the provided SchemaDeserializer.
+
+    Returns an object with two attributes:
+        - .oks: A stream of `KafkaMessage`s where `KafkaMessage.error is None`
+        - .errors: A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
+    """
+
+    # Make sure the first KafkaMessage in the return type's Union represents
+    # the `oks` stream and the second one the `errs` stream for the
+    # `_kafka_error_split` operator.
+    def shim_mapper(
+        msg: KafkaMessage[K, V]
+    ) -> Union[KafkaMessage[K, V2], KafkaMessage[K, V]]:
+        try:
+            value = deserializer.de(msg.value)
+            return msg.with_value(value)
+        except Exception as e:
+            return msg.with_error(KafkaError(KafkaError._VALUE_DESERIALIZATION, f"{e}"))
+
+    return op.map("map", up, shim_mapper).then(_kafka_error_split, "split_err")
+
+
+@operator
+def deserialize(
+    step_id: str,
+    up: Stream[KafkaMessage[K, V]],
+    *,
+    key_deserializer: SchemaDeserializer[K, K2],
+    val_deserializer: SchemaDeserializer[V, V2],
+) -> KafkaStreams[K2, V2, Union[K, K2], Union[V, V2]]:
+    """Serialize both keys and values with the given serializers.
+
+    Returns an object with two attributes:
+        - .oks: A stream of `KafkaMessage`s where `KafkaMessage.error is None`
+        - .errors: A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
+    A message will be put in .errors even if only one of the deserializers fail.
+    """
+    keys = deserialize_key("de-key", up, key_deserializer)
+    values = deserialize_value("de-val", keys.oks, val_deserializer)
+    errors = cast(
+        # Either of key and value deserialization might have failed in the
+        # errors stream. Since we don't know better, just Union the possible
+        # output types
+        Stream[KafkaMessage[Union[K, K2], Union[V, V2]]],
+        op.merge("merg-errors", keys.errs, values.errs),
+    )
+    return KafkaStreams(values.oks, errors)
+
+
+@operator
+def serialize_key(
+    step_id: str, up: Stream[Tuple[K, V]], serializer: SchemaSerializer[K, K2]
+) -> Stream[Tuple[K2, V]]:
+    """Serialize the key of a KafkaMessage using the provided SchemaSerializer.
+
+    Crash if any error occurs.
+    """
+
+    def shim_mapper(key_msg: Tuple[K, V]) -> Tuple[K2, V]:
+        key, value = key_msg
+        return (serializer.ser(key), value)
+
+    return op.map("map", up, shim_mapper)
+
+
+@operator
+def serialize_value(
+    step_id: str, up: Stream[Tuple[K, V]], serializer: SchemaSerializer[V, V2]
+) -> Stream[Tuple[K, V2]]:
+    """Serialize the value of a KafkaMessage using the provided SchemaSerializer.
+
+    Crash if any error occurs.
+    """
+
+    def shim_mapper(key_msg: Tuple[K, V]) -> Tuple[K, V2]:
+        key, value = key_msg
+        return (key, serializer.ser(value))
+
+    return op.map("map", up, shim_mapper)
+
+
+@operator
+def serialize(
+    step_id: str,
+    up: Stream[Tuple[K, V]],
+    *,
+    key_serializer: SchemaSerializer[K, K2],
+    val_serializer: SchemaSerializer[V, V2],
+) -> Stream[Tuple[K2, V2]]:
+    """Serialize both keys and values with the given serializers.
+
+    Crash if any error occurs.
+    """
+    ser_keys = serialize_key("ser-key", up, key_serializer)
+    return serialize_value("val-ser", ser_keys, val_serializer)

--- a/pysrc/bytewax/connectors/kafka/operators.py
+++ b/pysrc/bytewax/connectors/kafka/operators.py
@@ -1,16 +1,17 @@
 """Operators for the kafka source and sink."""
 from dataclasses import dataclass
-from typing import Dict, Generic, List, Optional, Tuple, Union, cast
+from typing import Dict, Generic, List, Optional, Union, cast
 
 from confluent_kafka import OFFSET_BEGINNING
-from confluent_kafka.error import KafkaError
+from confluent_kafka import KafkaError as ConfluentKafkaError
 
 import bytewax.operators as op
 from bytewax.dataflow import Dataflow
 from bytewax.operators import Stream, operator
 
 from ._types import K2, V2, K, MaybeStrBytes, V
-from .message import KafkaMessage
+from .error import KafkaError
+from .message import KafkaSinkMessage, KafkaSourceMessage
 from .serde import SchemaDeserializer, SchemaSerializer
 from .sink import KafkaSink
 from .source import KafkaSource
@@ -28,7 +29,7 @@ __all__ = [
 
 
 @dataclass(frozen=True)
-class KafkaStreams(Generic[K, V, K2, V2]):
+class KafkaSourceOut(Generic[K, V, K2, V2]):
     """Contains two streams of KafkaMessages, oks and errors.
 
     - KafkaStreams.oks:
@@ -37,29 +38,37 @@ class KafkaStreams(Generic[K, V, K2, V2]):
         A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
     """
 
-    oks: Stream[KafkaMessage[K, V]]
-    errs: Stream[KafkaMessage[K2, V2]]
+    oks: Stream[KafkaSourceMessage[K, V]]
+    errs: Stream[KafkaError[K2, V2]]
 
 
 @operator
 def _kafka_error_split(
-    step_id: str, up: Stream[Union[KafkaMessage[K, V], KafkaMessage[K2, V2]]]
-) -> KafkaStreams[K, V, K2, V2]:
+    step_id: str, up: Stream[Union[KafkaSourceMessage[K2, V2], KafkaError[K, V]]]
+) -> KafkaSourceOut[K2, V2, K, V]:
     """Split a stream of KafkaMessages in two."""
-
-    def predicate(msg: KafkaMessage) -> bool:
-        return msg.error is None
-
-    branch = op.branch("branch", up, predicate)
+    branch = op.branch("branch", up, lambda msg: isinstance(msg, KafkaSourceMessage))
     # Cast the streams to the proper expected types.
-    # This assumes that messages where error is None will be KafkaMessage[K, V]
-    # while messages where error is not None will be KafkaMessage[K2, V2]
-    oks = cast(Stream[KafkaMessage[K, V]], branch.trues)
-    errs = cast(Stream[KafkaMessage[K2, V2]], branch.falses)
-    return KafkaStreams(oks, errs)
+    oks = cast(Stream[KafkaSourceMessage[K2, V2]], branch.trues)
+    errs = cast(Stream[KafkaError[K, V]], branch.falses)
+    return KafkaSourceOut(oks, errs)
 
 
-_default_add_config: Dict = {}
+@operator
+def _to_sink(
+    step_id: str, up: Stream[Union[KafkaSourceMessage[K, V], KafkaSinkMessage[K, V]]]
+) -> Stream[KafkaSinkMessage[K, V]]:
+    """Automatically convert a KafkaSourceMessage to KafkaSinkMessage."""
+
+    def shim_mapper(
+        msg: Union[KafkaSourceMessage[K, V], KafkaSinkMessage[K, V]]
+    ) -> KafkaSinkMessage[K, V]:
+        if isinstance(msg, KafkaSourceMessage):
+            return msg.to_sink()
+        else:
+            return msg
+
+    return op.map("map", up, shim_mapper)
 
 
 @operator
@@ -73,7 +82,7 @@ def input(  # noqa A001
     starting_offset: int = OFFSET_BEGINNING,
     add_config: Optional[Dict[str, str]] = None,
     batch_size: int = 1000,
-) -> KafkaStreams[MaybeStrBytes, MaybeStrBytes, MaybeStrBytes, MaybeStrBytes]:
+) -> KafkaSourceOut[MaybeStrBytes, MaybeStrBytes, MaybeStrBytes, MaybeStrBytes]:
     """Use a set of Kafka topics as an input source.
 
     Partitions are the unit of parallelism.
@@ -125,7 +134,7 @@ def input(  # noqa A001
 @operator
 def output(
     step_id: str,
-    up: Stream[Tuple[bytes, bytes]],
+    up: Stream[Union[KafkaSourceMessage, KafkaSinkMessage]],
     *,
     brokers: List[str],
     topic: str,
@@ -155,15 +164,17 @@ def output(
             [docs](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md)
             for options.
     """
-    return op.output("kafka_output", up, KafkaSink(brokers, topic, add_config))
+    return _to_sink("to_sink", up).then(
+        op.output, "kafka_output", KafkaSink(brokers, topic, add_config)
+    )
 
 
 @operator
 def deserialize_key(
     step_id: str,
-    up: Stream[KafkaMessage[K, V]],
+    up: Stream[KafkaSourceMessage[K, V]],
     deserializer: SchemaDeserializer[K, K2],
-) -> KafkaStreams[K2, V, K, V]:
+) -> KafkaSourceOut[K2, V, K, V]:
     """Deserialize the key of a KafkaMessage using the provided SchemaDeserializer.
 
     Returns an object with two attributes:
@@ -175,13 +186,14 @@ def deserialize_key(
     # the `oks` stream and the second one the `errs` stream for the
     # `_kafka_error_split` operator.
     def shim_mapper(
-        msg: KafkaMessage[K, V]
-    ) -> Union[KafkaMessage[K2, V], KafkaMessage[K, V]]:
+        msg: KafkaSourceMessage[K, V]
+    ) -> Union[KafkaSourceMessage[K2, V], KafkaError[K, V]]:
         try:
             key = deserializer.de(msg.key)
-            return msg.with_key(key)
+            return msg._with_key(key)
         except Exception as e:
-            return msg.with_error(KafkaError(KafkaError._KEY_DESERIALIZATION, f"{e}"))
+            err = ConfluentKafkaError(ConfluentKafkaError._KEY_DESERIALIZATION, f"{e}")
+            return KafkaError(err, msg)
 
     return op.map("map", up, shim_mapper).then(_kafka_error_split, "split")
 
@@ -189,9 +201,9 @@ def deserialize_key(
 @operator
 def deserialize_value(
     step_id: str,
-    up: Stream[KafkaMessage[K, V]],
+    up: Stream[KafkaSourceMessage[K, V]],
     deserializer: SchemaDeserializer[V, V2],
-) -> KafkaStreams[K, V2, K, V]:
+) -> KafkaSourceOut[K, V2, K, V]:
     """Deserialize the value of a KafkaMessage using the provided SchemaDeserializer.
 
     Returns an object with two attributes:
@@ -199,17 +211,17 @@ def deserialize_value(
         - .errors: A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
     """
 
-    # Make sure the first KafkaMessage in the return type's Union represents
-    # the `oks` stream and the second one the `errs` stream for the
-    # `_kafka_error_split` operator.
     def shim_mapper(
-        msg: KafkaMessage[K, V]
-    ) -> Union[KafkaMessage[K, V2], KafkaMessage[K, V]]:
+        msg: KafkaSourceMessage[K, V]
+    ) -> Union[KafkaSourceMessage[K, V2], KafkaError[K, V]]:
         try:
             value = deserializer.de(msg.value)
-            return msg.with_value(value)
+            return msg._with_value(value)
         except Exception as e:
-            return msg.with_error(KafkaError(KafkaError._VALUE_DESERIALIZATION, f"{e}"))
+            err = ConfluentKafkaError(
+                ConfluentKafkaError._VALUE_DESERIALIZATION, f"{e}"
+            )
+            return KafkaError(err, msg)
 
     return op.map("map", up, shim_mapper).then(_kafka_error_split, "split_err")
 
@@ -217,11 +229,11 @@ def deserialize_value(
 @operator
 def deserialize(
     step_id: str,
-    up: Stream[KafkaMessage[K, V]],
+    up: Stream[KafkaSourceMessage[K, V]],
     *,
     key_deserializer: SchemaDeserializer[K, K2],
     val_deserializer: SchemaDeserializer[V, V2],
-) -> KafkaStreams[K2, V2, Union[K, K2], Union[V, V2]]:
+) -> KafkaSourceOut[K2, V2, K, V]:
     """Serialize both keys and values with the given serializers.
 
     Returns an object with two attributes:
@@ -229,61 +241,84 @@ def deserialize(
         - .errors: A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
     A message will be put in .errors even if only one of the deserializers fail.
     """
-    keys = deserialize_key("de-key", up, key_deserializer)
-    values = deserialize_value("de-val", keys.oks, val_deserializer)
-    errors = cast(
-        # Either of key and value deserialization might have failed in the
-        # errors stream. Since we don't know better, just Union the possible
-        # output types
-        Stream[KafkaMessage[Union[K, K2], Union[V, V2]]],
-        op.merge("merg-errors", keys.errs, values.errs),
-    )
-    return KafkaStreams(values.oks, errors)
+
+    # Use a single map step rather than concatenating
+    # deserialize_key and deserialize_value so we can
+    # return the original message if any of the 2 fail.
+    def shim_mapper(
+        msg: KafkaSourceMessage[K, V]
+    ) -> Union[KafkaSourceMessage[K2, V2], KafkaError[K, V]]:
+        try:
+            key = key_deserializer.de(msg.key)
+        except Exception as e:
+            err = ConfluentKafkaError(ConfluentKafkaError._KEY_DESERIALIZATION, f"{e}")
+            return KafkaError(err, msg)
+
+        try:
+            value = val_deserializer.de(msg.value)
+        except Exception as e:
+            err = ConfluentKafkaError(
+                ConfluentKafkaError._VALUE_DESERIALIZATION, f"{e}"
+            )
+            return KafkaError(err, msg)
+
+        return msg._with_key_and_value(key, value)
+
+    return op.map("map", up, shim_mapper).then(_kafka_error_split, "split_err")
 
 
 @operator
 def serialize_key(
-    step_id: str, up: Stream[Tuple[K, V]], serializer: SchemaSerializer[K, K2]
-) -> Stream[Tuple[K2, V]]:
+    step_id: str,
+    up: Stream[Union[KafkaSourceMessage[K, V], KafkaSinkMessage[K, V]]],
+    serializer: SchemaSerializer[K, K2],
+) -> Stream[KafkaSinkMessage[K2, V]]:
     """Serialize the key of a KafkaMessage using the provided SchemaSerializer.
 
     Crash if any error occurs.
     """
 
-    def shim_mapper(key_msg: Tuple[K, V]) -> Tuple[K2, V]:
-        key, value = key_msg
-        return (serializer.ser(key), value)
+    def shim_mapper(msg: KafkaSinkMessage[K, V]) -> KafkaSinkMessage[K2, V]:
+        key = serializer.ser(msg.key)
+        return msg._with_key(key)
 
-    return op.map("map", up, shim_mapper)
+    return _to_sink("to_sink", up).then(op.map, "map", shim_mapper)
 
 
 @operator
 def serialize_value(
-    step_id: str, up: Stream[Tuple[K, V]], serializer: SchemaSerializer[V, V2]
-) -> Stream[Tuple[K, V2]]:
+    step_id: str,
+    up: Stream[Union[KafkaSourceMessage[K, V], KafkaSinkMessage[K, V]]],
+    serializer: SchemaSerializer[V, V2],
+) -> Stream[KafkaSinkMessage[K, V2]]:
     """Serialize the value of a KafkaMessage using the provided SchemaSerializer.
 
     Crash if any error occurs.
     """
 
-    def shim_mapper(key_msg: Tuple[K, V]) -> Tuple[K, V2]:
-        key, value = key_msg
-        return (key, serializer.ser(value))
+    def shim_mapper(msg: KafkaSinkMessage[K, V]) -> KafkaSinkMessage[K, V2]:
+        value = serializer.ser(msg.value)
+        return msg._with_value(value)
 
-    return op.map("map", up, shim_mapper)
+    return _to_sink("to_sink", up).then(op.map, "map", shim_mapper)
 
 
 @operator
 def serialize(
     step_id: str,
-    up: Stream[Tuple[K, V]],
+    up: Stream[Union[KafkaSourceMessage[K, V], KafkaSinkMessage[K, V]]],
     *,
     key_serializer: SchemaSerializer[K, K2],
     val_serializer: SchemaSerializer[V, V2],
-) -> Stream[Tuple[K2, V2]]:
+) -> Stream[KafkaSinkMessage[K2, V2]]:
     """Serialize both keys and values with the given serializers.
 
     Crash if any error occurs.
     """
-    ser_keys = serialize_key("ser-key", up, key_serializer)
-    return serialize_value("val-ser", ser_keys, val_serializer)
+
+    def shim_mapper(msg: KafkaSinkMessage[K, V]) -> KafkaSinkMessage[K2, V2]:
+        key = key_serializer.ser(msg.key)
+        value = val_serializer.ser(msg.value)
+        return msg._with_key_and_value(key, value)
+
+    return _to_sink("to_sink", up).then(op.map, "map", shim_mapper)

--- a/pysrc/bytewax/connectors/kafka/operators.py
+++ b/pysrc/bytewax/connectors/kafka/operators.py
@@ -61,7 +61,7 @@ def _to_sink(
     """Automatically convert a KafkaSourceMessage to KafkaSinkMessage."""
 
     def shim_mapper(
-        msg: Union[KafkaSourceMessage[K, V], KafkaSinkMessage[K, V]]
+        msg: Union[KafkaSourceMessage[K, V], KafkaSinkMessage[K, V]],
     ) -> KafkaSinkMessage[K, V]:
         if isinstance(msg, KafkaSourceMessage):
             return msg.to_sink()
@@ -186,7 +186,7 @@ def deserialize_key(
     # the `oks` stream and the second one the `errs` stream for the
     # `_kafka_error_split` operator.
     def shim_mapper(
-        msg: KafkaSourceMessage[K, V]
+        msg: KafkaSourceMessage[K, V],
     ) -> Union[KafkaSourceMessage[K2, V], KafkaError[K, V]]:
         try:
             key = deserializer.de(msg.key)
@@ -212,7 +212,7 @@ def deserialize_value(
     """
 
     def shim_mapper(
-        msg: KafkaSourceMessage[K, V]
+        msg: KafkaSourceMessage[K, V],
     ) -> Union[KafkaSourceMessage[K, V2], KafkaError[K, V]]:
         try:
             value = deserializer.de(msg.value)
@@ -246,7 +246,7 @@ def deserialize(
     # deserialize_key and deserialize_value so we can
     # return the original message if any of the 2 fail.
     def shim_mapper(
-        msg: KafkaSourceMessage[K, V]
+        msg: KafkaSourceMessage[K, V],
     ) -> Union[KafkaSourceMessage[K2, V2], KafkaError[K, V]]:
         try:
             key = key_deserializer.de(msg.key)

--- a/pysrc/bytewax/connectors/kafka/operators.py
+++ b/pysrc/bytewax/connectors/kafka/operators.py
@@ -1,6 +1,6 @@
 """Operators for the kafka source and sink."""
 from dataclasses import dataclass
-from typing import Dict, Generic, List, Tuple, Union, cast
+from typing import Dict, Generic, List, Optional, Tuple, Union, cast
 
 from confluent_kafka import OFFSET_BEGINNING
 from confluent_kafka.error import KafkaError
@@ -71,9 +71,7 @@ def input(  # noqa A001
     topics: List[str],
     tail: bool = True,
     starting_offset: int = OFFSET_BEGINNING,
-    # TODO: Use Optional
-    # add_config: Optional[Dict[str, str]] = None,
-    add_config: Dict[str, str] = _default_add_config,
+    add_config: Optional[Dict[str, str]] = None,
     batch_size: int = 1000,
 ) -> KafkaStreams[MaybeStrBytes, MaybeStrBytes, MaybeStrBytes, MaybeStrBytes]:
     """Use a set of Kafka topics as an input source.
@@ -131,9 +129,7 @@ def output(
     *,
     brokers: List[str],
     topic: str,
-    # TODO: Use Optional
-    # add_config: Optional[Dict[str, str]] = None,
-    add_config: Dict[str, str] = _default_add_config,
+    add_config: Optional[Dict[str, str]] = None,
 ) -> None:
     """Use a single Kafka topic as an output sink.
 

--- a/pysrc/bytewax/connectors/kafka/registry.py
+++ b/pysrc/bytewax/connectors/kafka/registry.py
@@ -12,6 +12,7 @@ from typing import Dict, Optional, Union
 
 import requests
 from confluent_kafka.schema_registry import SchemaRegistryClient
+from fastavro.types import AvroMessage
 
 from ._types import MaybeStrBytes
 from .serde import (
@@ -84,7 +85,7 @@ class ConfluentSchemaRegistry:
         schema = self._get_schema(schema_ref)
         return _ConfluentAvroSerializer(self.client, schema)
 
-    def deserializer(self) -> SchemaDeserializer[MaybeStrBytes, Dict]:
+    def deserializer(self) -> SchemaDeserializer[MaybeStrBytes, AvroMessage]:
         """Confluent avro deserializer.
 
         `schema_ref` is not needed since Confluent cloud adds the schema_id
@@ -135,7 +136,7 @@ class RedpandaSchemaRegistry:
 
     def deserializer(
         self, schema_ref: Union[int, SchemaRef]
-    ) -> SchemaDeserializer[MaybeStrBytes, Dict]:
+    ) -> SchemaDeserializer[MaybeStrBytes, AvroMessage]:
         """Fastavro deserializer.
 
         Specify either the `schema_id` or a `SchemaRef` instance.

--- a/pysrc/bytewax/connectors/kafka/registry.py
+++ b/pysrc/bytewax/connectors/kafka/registry.py
@@ -1,0 +1,142 @@
+"""Schema registries connection.
+
+This module offers two preconfigured schema registries:
+- ConfluentSchemaRegistry
+- RedpandaSchemaRegistry
+
+Subclass "SchemaRegistry" to implement support for your any registry.
+"""
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+
+import requests
+from confluent_kafka.schema_registry import SchemaRegistryClient
+
+from ._types import MaybeStrBytes
+from .serde import (
+    SchemaDeserializer,
+    SchemaSerializer,
+    _AvroDeserializer,
+    _AvroSerializer,
+    _ConfluentAvroDeserializer,
+    _ConfluentAvroSerializer,
+)
+
+__all__ = [
+    "SchemaRef",
+    "ConfluentSchemaRegistry",
+    "RedpandaSchemaRegistry",
+]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SchemaRef:
+    """Info used to retrieve a schema from a schema registry.
+
+    Specify the `subject` and optionally `version`.
+    If no `version` is specified, it defaults to the latest schema.
+    """
+
+    # TODO: Only `avro` supported for now, but we might want
+    #       to add `protobuf` and others too
+    # format: str = "avro"
+    subject: str
+    version: Optional[int] = None
+
+
+class ConfluentSchemaRegistry:
+    """Confluent's schema registry for Kafka's input and output connectors."""
+
+    def __init__(self, client: SchemaRegistryClient):
+        """Init.
+
+        Args:
+            client:
+                Configured `confluent_kafka.schema_registry.SchemaRegistryClient`
+        """
+        self.client = client
+
+    def _get_schema(self, schema_ref: Union[int, SchemaRef]) -> str:
+        # Schema can bew retrieved by `schema_id`, or by
+        # specifying a `subject` and a `version`, which
+        # defaults to `latest`.
+        if isinstance(schema_ref, int):
+            schema = self.client.get_schema(schema_ref)
+        else:
+            subject = schema_ref.subject
+            version = schema_ref.version
+            if version is None:
+                schema = self.client.get_latest_version(subject).schema
+            else:
+                schema = self.client.get_version(subject, version).schema
+        return schema.schema_str
+
+    def serializer(
+        self, schema_ref: Union[int, SchemaRef]
+    ) -> SchemaSerializer[Dict, bytes]:
+        """Confluent avro serializer.
+
+        Specify either the `schema_id` or a `SchemaRef` instance.
+        """
+        schema = self._get_schema(schema_ref)
+        return _ConfluentAvroSerializer(self.client, schema)
+
+    def deserializer(self) -> SchemaDeserializer[MaybeStrBytes, Dict]:
+        """Confluent avro deserializer.
+
+        `schema_ref` is not needed since Confluent cloud adds the schema_id
+        as metadata in each message.
+        The client will automatically fetch and cache the schemas needed.
+        """
+        return _ConfluentAvroDeserializer(self.client)
+
+
+class RedpandaSchemaRegistry:
+    """Redpanda's schema registry client."""
+
+    def __init__(self, base_url: str = "http://localhost:8081"):
+        """Init.
+
+        Args:
+            base_url:
+                Base url of redpanda's schema registry instance
+        """
+        self._base_url = base_url
+
+    def _get_schema(self, schema_ref: Union[int, SchemaRef]) -> bytes:
+        # Schema can bew retrieved by `schema_id`, or by
+        # specifying a `subject` and a `version`, which
+        # defaults to `latest`.
+        if isinstance(schema_ref, int):
+            url = f"{self._base_url}/schemas/{schema_ref}/schema"
+        else:
+            version = schema_ref.version or "latest"
+            url = (
+                f"{self._base_url}/subjects/"
+                f"{schema_ref.subject}/versions/"
+                f"{version}/schema"
+            )
+        return requests.get(url).content
+
+    def serializer(
+        self, schema_ref: Union[int, SchemaRef]
+    ) -> SchemaSerializer[Dict, bytes]:
+        """Fastavro serializer.
+
+        Specify either the `schema_id` or a `SchemaRef` instance.
+        """
+        schema = self._get_schema(schema_ref)
+        return _AvroSerializer(schema)
+
+    def deserializer(
+        self, schema_ref: Union[int, SchemaRef]
+    ) -> SchemaDeserializer[MaybeStrBytes, Dict]:
+        """Fastavro deserializer.
+
+        Specify either the `schema_id` or a `SchemaRef` instance.
+        """
+        schema = self._get_schema(schema_ref)
+        return _AvroDeserializer(schema)

--- a/pysrc/bytewax/connectors/kafka/registry.py
+++ b/pysrc/bytewax/connectors/kafka/registry.py
@@ -119,7 +119,9 @@ class RedpandaSchemaRegistry:
                 f"{schema_ref.subject}/versions/"
                 f"{version}/schema"
             )
-        return requests.get(url).content
+        resp = requests.get(url)
+        resp.raise_for_status()
+        return resp.content
 
     def serializer(
         self, schema_ref: Union[int, SchemaRef]

--- a/pysrc/bytewax/connectors/kafka/serde.py
+++ b/pysrc/bytewax/connectors/kafka/serde.py
@@ -1,0 +1,90 @@
+"""Serializers and deserializers for kafka messages."""
+import io
+import json
+import logging
+from abc import ABC, abstractmethod
+from typing import Dict, Generic, TypeVar
+
+from confluent_kafka.schema_registry import record_subject_name_strategy
+from confluent_kafka.schema_registry.avro import AvroDeserializer, AvroSerializer
+from fastavro import parse_schema, schemaless_reader, schemaless_writer
+
+from ._types import MaybeStrBytes
+
+logger = logging.getLogger(__name__)
+
+SerdeOut = TypeVar("SerdeOut")
+SerdeIn = TypeVar("SerdeIn")
+
+
+class SchemaSerializer(ABC, Generic[SerdeIn, SerdeOut]):
+    """A serializer for a specific schema."""
+
+    @abstractmethod
+    def ser(self, obj: SerdeIn) -> SerdeOut:
+        """Serialize an object."""
+        ...
+
+
+class SchemaDeserializer(ABC, Generic[SerdeIn, SerdeOut]):
+    """A deserializer for a specific schema."""
+
+    @abstractmethod
+    def de(self, data: SerdeIn) -> SerdeOut:
+        """Deserialize data."""
+        ...
+
+
+class _ConfluentAvroSerializer(SchemaSerializer[Dict, bytes]):
+    def __init__(self, client, schema_str):
+        # Use a different "subject.name.strategy" than the default. See:
+        # https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#subject-name-strategy
+        self.serializer = AvroSerializer(
+            client,
+            schema_str,
+            conf={"subject.name.strategy": record_subject_name_strategy},
+        )
+
+    def ser(self, obj: Dict) -> bytes:
+        return self.serializer(obj, ctx=None)
+
+
+class _ConfluentAvroDeserializer(SchemaDeserializer[MaybeStrBytes, Dict]):
+    def __init__(self, client):
+        self.deserializer = AvroDeserializer(client)
+
+    def de(self, data: MaybeStrBytes) -> Dict:
+        if data is None:
+            msg = "Can't deserialize None data"
+            raise ValueError(msg)
+        if isinstance(data, str):
+            data = data.encode()
+        # Here the ctx is only used if a custom `from_dict`
+        # function is passed to the deserializer, but we
+        # initialize it ourselves and don't pass that,
+        # so we can set `ctx` to None
+        return self.deserializer(data, ctx=None)
+
+
+class _AvroSerializer(SchemaSerializer[Dict, bytes]):
+    def __init__(self, schema):
+        self.schema = parse_schema(json.loads(schema))
+
+    def ser(self, obj: Dict) -> bytes:
+        bytes_writer = io.BytesIO()
+        schemaless_writer(bytes_writer, self.schema, obj)
+        return bytes_writer.getvalue()
+
+
+class _AvroDeserializer(SchemaDeserializer[MaybeStrBytes, Dict]):
+    def __init__(self, schema):
+        self.schema = parse_schema(json.loads(schema))
+
+    def de(self, data: MaybeStrBytes) -> Dict:
+        if data is None:
+            msg = "Can't deserialize None data"
+            raise ValueError(msg)
+        if isinstance(data, str):
+            data = data.encode()
+        payload = io.BytesIO(data)
+        return schemaless_reader(payload, self.schema)

--- a/pysrc/bytewax/connectors/kafka/serde.py
+++ b/pysrc/bytewax/connectors/kafka/serde.py
@@ -3,7 +3,7 @@ import io
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, Generic, TypeVar
+from typing import Dict, Generic, TypeVar, cast
 
 from confluent_kafka.schema_registry import record_subject_name_strategy
 from confluent_kafka.schema_registry.avro import AvroDeserializer, AvroSerializer
@@ -87,4 +87,6 @@ class _AvroDeserializer(SchemaDeserializer[MaybeStrBytes, Dict]):
         if isinstance(data, str):
             data = data.encode()
         payload = io.BytesIO(data)
-        return schemaless_reader(payload, self.schema)
+        # Since we are passing a schema to the reader,
+        # the result should always be a dict
+        return cast(Dict, schemaless_reader(payload, self.schema, None))

--- a/pysrc/bytewax/connectors/kafka/sink.py
+++ b/pysrc/bytewax/connectors/kafka/sink.py
@@ -1,22 +1,36 @@
 """KafkaSink."""
 
-from typing import Dict, Iterable, List, Optional, Tuple
+import time
+from typing import Dict, Iterable, List, Optional
 
 from confluent_kafka import Producer
 
 from bytewax.outputs import DynamicSink, StatelessSinkPartition
 
-from ._types import MaybeStrBytes
+from .message import KafkaSinkMessage
 
 
-class _KafkaSinkPartition(StatelessSinkPartition[Tuple[MaybeStrBytes, MaybeStrBytes]]):
+class _KafkaSinkPartition(StatelessSinkPartition[KafkaSinkMessage]):
     def __init__(self, producer, topic):
         self._producer = producer
         self._topic = topic
 
-    def write_batch(self, items: List[Tuple[MaybeStrBytes, MaybeStrBytes]]) -> None:
-        for key, value in items:
-            self._producer.produce(self._topic, value, key)
+    def write_batch(self, items: List[KafkaSinkMessage]) -> None:
+        for msg in items:
+            topic = self._topic if msg.topic is None else msg.topic
+            if topic is None:
+                err = f"No topic to produce to for {msg}"
+                raise RuntimeError(err)
+
+            ts = int(time.time() * 1000) if msg.timestamp is None else msg.timestamp
+
+            self._producer.produce(
+                value=msg.value,
+                key=msg.key,
+                headers=msg.headers,
+                topic=topic,
+                timestamp=ts,
+            )
             self._producer.poll(0)
         self._producer.flush()
 
@@ -24,7 +38,7 @@ class _KafkaSinkPartition(StatelessSinkPartition[Tuple[MaybeStrBytes, MaybeStrBy
         self._producer.flush()
 
 
-class KafkaSink(DynamicSink[Tuple[MaybeStrBytes, MaybeStrBytes]]):
+class KafkaSink(DynamicSink[KafkaSinkMessage]):
     """Use a single Kafka topic as an output sink.
 
     Items consumed from the dataflow must look like two-tuples of
@@ -39,7 +53,9 @@ class KafkaSink(DynamicSink[Tuple[MaybeStrBytes, MaybeStrBytes]]):
     def __init__(
         self,
         brokers: Iterable[str],
-        topic: str,
+        # Optional with no defaults, so you have to explicitely pass
+        # `topic=None` if you want to use the topic from the messages
+        topic: Optional[str],
         add_config: Optional[Dict[str, str]] = None,
     ):
         """Init.
@@ -48,7 +64,8 @@ class KafkaSink(DynamicSink[Tuple[MaybeStrBytes, MaybeStrBytes]]):
             brokers:
                 List of `host:port` strings of Kafka brokers.
             topic:
-                Topic to produce to.
+                Topic to produce to. If it's `None`, the topic
+                to produce to will be read in each KafkaMessage.
             add_config:
                 Any additional configuration properties. See [the
                 `rdkafka`

--- a/pysrc/bytewax/connectors/kafka/sink.py
+++ b/pysrc/bytewax/connectors/kafka/sink.py
@@ -31,7 +31,7 @@ class _KafkaSinkPartition(
                 key=msg.key,
                 headers=msg.headers,
                 topic=topic,
-                timestamp=0 if msg.timestamp is None else msg.timestamp,
+                timestamp=msg.timestamp,
             )
             self._producer.poll(0)
         self._producer.flush()

--- a/pysrc/bytewax/connectors/kafka/sink.py
+++ b/pysrc/bytewax/connectors/kafka/sink.py
@@ -1,0 +1,70 @@
+"""KafkaSink."""
+
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from confluent_kafka import Producer
+
+from bytewax.outputs import DynamicSink, StatelessSinkPartition
+
+from ._types import MaybeStrBytes
+
+
+class _KafkaSinkPartition(StatelessSinkPartition[Tuple[MaybeStrBytes, MaybeStrBytes]]):
+    def __init__(self, producer, topic):
+        self._producer = producer
+        self._topic = topic
+
+    def write_batch(self, items: List[Tuple[MaybeStrBytes, MaybeStrBytes]]) -> None:
+        for key, value in items:
+            self._producer.produce(self._topic, value, key)
+            self._producer.poll(0)
+        self._producer.flush()
+
+    def close(self) -> None:
+        self._producer.flush()
+
+
+class KafkaSink(DynamicSink[Tuple[MaybeStrBytes, MaybeStrBytes]]):
+    """Use a single Kafka topic as an output sink.
+
+    Items consumed from the dataflow must look like two-tuples of
+    `(key_bytes, value_bytes)`. Default partition routing is used.
+
+    Workers are the unit of parallelism.
+
+    Can support at-least-once processing. Messages from the resume
+    epoch will be duplicated right after resume.
+    """
+
+    def __init__(
+        self,
+        brokers: Iterable[str],
+        topic: str,
+        add_config: Optional[Dict[str, str]] = None,
+    ):
+        """Init.
+
+        Args:
+            brokers:
+                List of `host:port` strings of Kafka brokers.
+            topic:
+                Topic to produce to.
+            add_config:
+                Any additional configuration properties. See [the
+                `rdkafka`
+                documentation](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md)
+                for options.
+        """
+        self._brokers = brokers
+        self._topic = topic
+        self._add_config = {} if add_config is None else add_config
+
+    def build(self, worker_index: int, worker_count: int) -> _KafkaSinkPartition:
+        """See ABC docstring."""
+        config = {
+            "bootstrap.servers": ",".join(self._brokers),
+        }
+        config.update(self._add_config)
+        producer = Producer(config)
+
+        return _KafkaSinkPartition(producer, self._topic)

--- a/pysrc/bytewax/connectors/kafka/source.py
+++ b/pysrc/bytewax/connectors/kafka/source.py
@@ -1,7 +1,7 @@
 """KafkaSource."""
 
 from datetime import datetime
-from typing import Dict, Iterable, List, Optional, TypeAlias, Union
+from typing import Dict, Iterable, List, Optional, Union
 
 from confluent_kafka import OFFSET_BEGINNING, Consumer, TopicPartition
 from confluent_kafka import KafkaError as ConfluentKafkaError
@@ -14,9 +14,9 @@ from .error import KafkaError
 from .message import KafkaSourceMessage
 
 # Some type aliases
-_KafkaMessage: TypeAlias = KafkaSourceMessage[MaybeStrBytes, MaybeStrBytes]
-_KafkaError: TypeAlias = KafkaError[MaybeStrBytes, MaybeStrBytes]
-_KafkaItem: TypeAlias = Union[_KafkaMessage, _KafkaError]
+_KafkaMessage = KafkaSourceMessage[MaybeStrBytes, MaybeStrBytes]
+_KafkaError = KafkaError[MaybeStrBytes, MaybeStrBytes]
+_KafkaItem = Union[_KafkaMessage, _KafkaError]
 
 
 def _list_parts(client: AdminClient, topics: Iterable[str]) -> Iterable[str]:


### PR DESCRIPTION
This PR supersedes #312 

It started as a PR to support schema registries, but ended up a revamp of the whole connector, in preparation for when we'll move this to its own repository.

### Module structure
I split the `bytewax.connectors.kafka` module into different files:
- `__init__.py`: now only exposes the public api
- `message.py`: Definition of KafkaMessage
- `operators.py`: custom kafka specific operators
- `registry.py`: Registry related stuff
- `serde.py`: Kafka's own (de)serialization interface
- `sink.py`: KafkaSink definition
- `source.py`: KafkaSource definition
- `_types.py`: Typing stuff, private, for internal use


### `KafkaSource` changes
`KafkaSource` now returns a stream of `KafkaMessage` rather than a stream of `(key, value)` tuples.
Users can decide to still key the stream on `KafkaMessage.key`, but they can also do anything else.
`KafkaMessage` includes all the metadata we get from each message, including an optional `KafkaMessage.error` field to hold error info.
`KafkaSource` now accepts a `raise_on_error` parameter (`True` by default). If set to `False`, errors while receiving kafka messages won't crash the dataflow, and the error itself will be set into `KafkaMessage.error`

Other than that, `KafkaSource` and `KafkaSink` are the same.

### Schema registry support
The connector offers a `SchemaRegistry` abstract class that can be subclassed to implement support for a specific schema registry.

Two implementations are offered:
- `ConfluentSchemaRegistry`
- `RedpandaSchemaRegistry`

You instantiate the schema registry object you want, then use `SchemaRegistry.serializer` and `SchemaRegistry.deserializer` functions to instantiate a specific (de)serializer.
You can specify a schema either by its `schema_id`, or using the `SchemaRef` object, specifying the `subject` and optionally the `version` of the schema:

```python
registry = RedpandaSchemaRegistry(redpanda_url)
key_deserializer = registry.deserializer(SchemaRef("key-schema"))
```

### Custom operators
This PR introduces some new custom operators.
`kafka_in` and `deserialize*` operators return an object with two named streams: `oks` and `errors`. Users can ignore errors, log them, or still crash the dataflow by using the `raises` operator.


#### `kafka_in`
Wraps a `KafkaSource`, forcing `raise_on_errors` to `False` to return a stream of ok messages and another of error messages:
```python
from bytewax.connectors.kafka import operators as kop
# ...
flow = Dataflow("schema_registry")
kinp = kop.kafka_in("kafka-in", flow, brokers=KAFKA_BROKERS, topics=IN_TOPICS)
op.inspect("inspect-msgs", kinp.oks)
op.inspect("inspect-errors", kinp.errors).then(op.raises, "raise-on-error")
```

#### `deserialize_key`
```python
# ...
key_de = registry.deserializer(SchemaRef("sensor-key"))
msgs = kop.deserialize_key("key_de", kinp.oks, key_de)
```
#### `deserialize_value`
```python
# ...
key_de = registry.deserializer(SchemaRef("sensor-value"))
msgs = kop.deserialize_value("value_de", kinp.oks, value_de)
```
#### `deserialize`
This chains `deserialize_key` and `deserialize_value`:
```python
# ...
key_de = registry.deserializer(SchemaRef("sensor-key"))
val_de = registry.deserializer(SchemaRef("sensor-value"))
msgs = kop.deserialize("de", kinp.oks, key_deserializer=key_de, val_deserializer=val_de)
```
#### `serialize_key`
```python
# ...
key_ser = registry.serializer(SchemaRef("sensor-key"))
serialized = kop.serialize_key("key_ser", msgs, key_ser)
```
#### `serialize_value`
```python
# ...
val_ser = registry.serializer(SchemaRef("aggregated-value"))
serialized = kop.serialize_value("val-ser", msgs, val_ser)
```
#### `serialize`
```python
# ...
key_ser = registry.serializer(SchemaRef("sensor-key"))
val_ser = registry.serializer(SchemaRef("aggregated-value"))
serialized = kop.serialize("ser", msgs, key_serializer=key_ser, val_serializer=val_ser)
```

#### `kafka_out`
```python
# ...
kop.kafka_out("kafka-out", serialized, brokers=KAFKA_BROKERS, topic=OUT_TOPIC)
```