### PR TITLE
Add an overload to `branch` operator so if it gets a `TypeGuard`, the output streams are typed correctly

### DIFF
--- a/pytests/operators/test_branch.py
+++ b/pytests/operators/test_branch.py
@@ -1,9 +1,11 @@
 import re
+from typing import List, Union
 
 import bytewax.operators as op
 from bytewax.dataflow import Dataflow
 from bytewax.testing import TestingSink, TestingSource, run_main
 from pytest import raises
+from typing_extensions import TypeGuard
 
 
 def test_branch():
@@ -11,7 +13,7 @@ def test_branch():
     out_odds = []
     out_evens = []
 
-    def is_odd(x):
+    def is_odd(x: int) -> bool:
         return x % 2 != 0
 
     flow = Dataflow("test_df")
@@ -26,6 +28,28 @@ def test_branch():
 
     assert out_odds == [1, 3]
     assert out_evens == [2]
+
+
+def test_branch_type():
+    inp: List[Union[int, str]] = [1, "a", 2, "b"]
+    out_ints = []
+    out_strs = []
+
+    def is_int(x: Union[int, str]) -> TypeGuard[int]:
+        return isinstance(x, int)
+
+    flow = Dataflow("test_df")
+    s = op.input("inp", flow, TestingSource(inp))
+    b_out = op.branch("branch", s, is_int)
+    ints = b_out.trues
+    strs = b_out.falses
+    op.output("out_ints", ints, TestingSink(out_ints))
+    op.output("out_strs", strs, TestingSink(out_strs))
+
+    run_main(flow)
+
+    assert out_ints == [1, 2]
+    assert out_strs == ["a", "b"]
 
 
 def test_branch_raises_on_non_bool_key():


### PR DESCRIPTION
This is a little convenience thing that increases the specificity of
the downstreams returned by the `branch` operator. If you use
`typing{,_extensions}.TypeGuard[X]` as the return value of a function
that returns a `bool`, you're asserting to the type checker that the
argument is actually the narrower type `X`.

This will help out when you're splitting out error types from mixed
streams.

Hopefully https://peps.python.org/pep-0724/ is accepted, and then this
will make this even more powerful automatically: it will help better
type the `falses` stream to specifically the type that is left if
possible.
