### PR TITLE
Update the readme with changes from 0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ op.output("pg-out", PsqlOutput())
 
 #### Execution
 
-Bytewax dataflows can be executed on a single host with multiple Python processes, or on multiple hosts. When processing data in a distributed fashion, Bytewax will ensure that all items with the same key are routed to the same host.
+Bytewax dataflows can be executed in a single Python process, or on multiple processes on multiple hosts with multiple worker threads. When processing data in a distributed fashion, Bytewax uses routing keys to ensure your state is updated in a correct way automatically.
 
 ```sh
 # a single worker locally

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ op.inspect("debug", merged_stream)
 
 ##### Joining Streams
 
-Joining streams is different than merging because it uses logic to join the records in the streams together. The joins in Bytewax can be running or not. A regular join in streaming is more closely related to an inner join in SQL in that the stream will progress when the records match on the key.
+Joining streams is different than merging because it uses logic to join the records in the streams together. The joins in Bytewax can be running or not. A regular join in streaming is more closely related to an inner join in SQL in that the dataflow will emit data downstream from a join when all of the sides of the join have matched on the key.
 
 ```python
 from bytewax import operators as op

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ def remove_bytewax(user_id__event_data):
     user_id, event_data = user_id__event_data
     return "bytewax" not in event_data["email"]
 
+
 flow = Dataflow("kafka_in_out")
 stream = kop.input("inp", flow, brokers=BROKERS, topics=IN_TOPICS)
 # we can inspect the stream coming from the kafka topic

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Bytewax is a Python framework that simplifies event and stream processing. Becau
 
 Bytewax is a Python framework and Rust distributed processing engine that uses a dataflow computational model to provide parallelizable stream processing and event processing capabilities similar to Flink, Spark, and Kafka Streams. You can use Bytewax for a variety of workloads from moving data à la Kafka Connect style all the way to advanced online machine learning workloads. Bytewax is not limited to streaming applications but excels anywhere that data can be distributed at the input and output.
 
-Bytewax has an accompanying command line interface, [waxctl](https://bytewax.io/docs/deployment/waxctl/), which supports the deployment of dataflows on cloud vms or kuberentes. You can download it [here](https://bytewax.io/downloads/).
+Bytewax has an accompanying command line interface, [waxctl](https://bytewax.io/docs/deployment/waxctl/), which supports the deployment of dataflows on cloud servers or kuberentes. You can download it [here](https://bytewax.io/downloads/).
 
 _____________
 
@@ -35,17 +35,21 @@ pip install bytewax
 A Bytewax dataflow is Python code that will represent an input, a series of processing steps, and an output. The inputs could range from a Kafka stream to a WebSocket and the outputs could vary from a data lake to a key-value store.
 
 ```python
+from bytewax import operators as op
+from bytewax.connectors.kafka import operators as kop
 from bytewax.dataflow import Dataflow
-from bytewax.connectors.kafka import KafkaInput
 
 # Bytewax has input and output helpers for common input and output data sources
-# but you can also create your own with the ManualOutputConfig.
+# but you can also create your own with the [Sink and Source API](https://github.com/bytewax/bytewax/blob/main/docs/articles/advanced-concepts/custom-io-connectors.md).
 ```
 
 At a high-level, the dataflow compute model is one in which a program execution is conceptualized as data flowing through a series of operator-based steps. Operators like `map` and `filter` are the processing primitives of Bytewax. Each of them gives you a “shape” of data transformation, and you give them regular Python functions to customize them to a specific task you need. See the documentation for a list of the [available operators](https://bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow)
 
 ```python
-import json
+BROKERS = ["localhost:19092"]
+IN_TOPICS = ["in_topic"]
+OUT_TOPIC = "out_topic"
+ERR_TOPIC = "errors"
 
 
 def deserialize(key_bytes__payload_bytes):
@@ -64,48 +68,67 @@ def remove_bytewax(user_id__event_data):
     user_id, event_data = user_id__event_data
     return "bytewax" not in event_data["email"]
 
-
-flow = Dataflow()
-flow.input("inp", KafkaInput(brokers=["localhost:9092"], topic="web_events"))
-flow.map(deserialize)
-flow.map(anonymize_email)
-flow.filter(remove_bytewax)
+flow = Dataflow("kafka_in_out")
+stream = kop.input("inp", flow, brokers=BROKERS, topics=IN_TOPICS)
+# we can inspect the stream coming from the kafka topic
+op.inspect("inspect-errors", stream.errs)
+op.inspect("inspect-oks", stream.oks, brokers=BROKERS, topic=ERR_TOPIC)
+# and output errors to be handled as needed
+kop.output("out_errs", stream.errs)
+stream = op.map("deserialize", stream.oks, deserialize)
+stream = op.map("anon", stream, anonymize_email)
+stream = op.filter("filter_employees", stream, remove_bytewax)
+# and finally output the cleaned data to a new topic
+kop.output("out1", stream, brokers=BROKERS, topic=OUT_TOPIC)
 ```
 
 Bytewax is a stateful stream processing framework, which means that some operations remember information across multiple events.  Windows and aggregations are also stateful, and can be reconstructed in the event of failure. Bytewax can be configured with different [state recovery mechanisms](https://bytewax.io/apidocs/bytewax.recovery) to durably persist state in order to recover from failure.
 
-There are multiple stateful operators available like `reduce`, `stateful_map` and `fold_window`. The complete list can be found in the [API documentation for all operators](https://bytewax.io/apidocs/bytewax.dataflow). Below we use the `fold_window` operator with a tumbling window based on system time to gather events and calculate the number of times events have occurred on a per-user basis.
+There are multiple stateful operators available like `reduce`, `stateful_map` and `fold_window`. The complete list can be found in the [API documentation for all operators](https://www.bytewax.io/apidocs/bytewax.operators/index). Below we use the `fold_window` operator with a tumbling window based on system time to gather events and calculate the number of times events have occurred on a per-user basis.
 
 ```python
 from datetime import datetime, timedelta, timezone
-from collections import defaultdict
 
-from bytewax.window import TumblingWindow, SystemClockConfig
-
-
-def build():
-    return defaultdict(lambda: 0)
+from bytewax.dataflow import Dataflow
+from bytewax.operators import window as window_op
+from bytewax.operators.window import EventClockConfig, TumblingWindow
 
 
-def count_events(results, event):
-    results[event["type"]] += 1
-    return results
+# This is the accumulator function, and outputs a list of 2-tuples,
+# containing the event's "value" and it's "time" (used later to print info)
+def acc_values(acc, event):
+    acc.append((event["value"], event["time"]))
+    return acc
 
 
-cc = SystemClockConfig()
+# This function instructs the event clock on how to retrieve the
+# event's datetime from the input.
+# Note that the datetime MUST be UTC. If the datetime is using a different
+# representation, we would have to convert it here.
+def get_event_time(event):
+    return datetime.fromisoformat(event["time"])
+
+
+# Configure the `fold_window` operator to use the event time.
+cc = EventClockConfig(get_event_time, wait_for_system_duration=timedelta(seconds=10))
+
+# And a 5 seconds tumbling window
 align_to = datetime(2023, 1, 1, tzinfo=timezone.utc)
-wc = TumblingWindow(length=timedelta(seconds=5), align_to=align_to)
+wc = TumblingWindow(align_to=align_to, length=timedelta(seconds=5))
 
-flow.fold_window("session_state_recovery", cc, wc, build, count_events)
+running_avg_stream = window_op.fold_window(
+    "running_average", keyed_stream, cc, wc, list, acc_values
+)
 ```
 
-Output mechanisms in Bytewax are managed in the [output operator](https://bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow.output). There are a number of helpers that allow you to easily connect and write to other systems ([output docs](https://docs.bytewax.io/apidocs/bytewax.outputs)). If there isn’t a helper built, it is easy to build a custom version, which we will do below. Similar the input, Bytewax output can be parallelized and the client connection will occur on the worker.
+Output in Bytewax is described as a sink and these are grouped into [connectors](https://www.bytewax.io/apidocs/bytewax.connectors/index). There are a number of basic connectors in the bytewax repo to help you during development. In addition to the built-in connectors, it is possible to use the input and output API to build a custom sink and source. There is also a hub for connectors built by the community, partners and Bytewax. Below is an example of a custom connector for Postgres using the psycopg2 library.
 
 ```python
 import json
 
 import psycopg2
 
+from bytewax import operators as op
 from bytewax.outputs import PartitionedOutput, StatefulSink
 
 
@@ -145,13 +168,24 @@ class PsqlOutput(PartitionedOutput):
         return PsqlSink()
 
 
-flow.output("out", PsqlOutput())
+op.output("pg-out", PsqlOutput())
 ```
 
 Bytewax dataflows can be executed on a single host with multiple Python processes, or on multiple hosts. When processing data in a distributed fashion, Bytewax will ensure that all items with the same key are routed to the same host.
 
 ```sh
+# a single worker locally
 python -m bytewax.run my_dataflow:flow
+
+# multiple workers in a single process
+python -m bytewax.run my_dataflow:flow -w 2
+
+# multiple workers in more than one process
+# first we start the first process running in cluster_one port 2101
+python -m bytewax.run my_dataflow:flow -w 2 -i0 -a "cluster_one:2101;cluster_two:2101"
+
+# then the second in cluster_two
+python -m bytewax.run simple -w 3 -i1 -a "cluster_one:2101;cluster_two:2101"
 ```
 
 It can also be run in a Docker container as described further in the [documentation](https://bytewax.io/docs/deployment/container).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Bytewax is a Python framework that simplifies event and stream processing. Becau
 
 Bytewax is a Python framework and Rust distributed processing engine that uses a dataflow computational model to provide parallelizable stream processing and event processing capabilities similar to Flink, Spark, and Kafka Streams. You can use Bytewax for a variety of workloads from moving data à la Kafka Connect style all the way to advanced online machine learning workloads. Bytewax is not limited to streaming applications but excels anywhere that data can be distributed at the input and output.
 
-Bytewax has an accompanying command line interface, [waxctl](https://bytewax.io/docs/deployment/waxctl/), which supports the deployment of dataflows on cloud servers or kuberentes. You can download it [here](https://bytewax.io/downloads/).
+Bytewax has an accompanying command line interface, [waxctl](https://bytewax.io/docs/deployment/waxctl/), which supports the deployment of dataflows on cloud servers or Kubernetes. You can download it [here](https://bytewax.io/downloads/).
 
 _____________
 

--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ Bytewax dataflows can be executed in a single Python process, or on multiple pro
 # a single worker locally
 python -m bytewax.run my_dataflow:flow
 
-# multiple workers in a single process
-python -m bytewax.run my_dataflow:flow -w 2
+# Start two worker threads in a single process.
+python -m bytewax.run my_dataflow -w 2
 
 # Start a process on two separate machines to form a Bytewax cluster.
 # Start the first process with two worker threads on `machine_one`.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ from bytewax.dataflow import Dataflow
 # but you can also create your own with the [Sink and Source API](https://github.com/bytewax/bytewax/blob/main/docs/articles/advanced-concepts/custom-io-connectors.md).
 ```
 
-At a high-level, the dataflow compute model is one in which a program execution is conceptualized as data flowing through a series of operator-based steps. Operators like `map` and `filter` are the processing primitives of Bytewax. Each of them gives you a “shape” of data transformation, and you give them regular Python functions to customize them to a specific task you need. See the documentation for a list of the [available operators](https://bytewax.io/apidocs/bytewax.dataflow#bytewax.dataflow.Dataflow)
+At a high-level, the dataflow compute model is one in which a program execution is conceptualized as data flowing through a series of operator-based steps. Operators like `map` and `filter` are the processing primitives of Bytewax. Each of them gives you a “shape” of data transformation, and you give them regular Python functions to customize them to a specific task you need. See the documentation for a list of the [available operators](https://bytewax.io/apidocs/bytewax.operators/index)
 
 ```python
 BROKERS = ["localhost:19092"]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ def remove_bytewax(user_id__event_data):
 
 flow = Dataflow("kafka_in_out")
 stream = kop.input("inp", flow, brokers=BROKERS, topics=IN_TOPICS)
-# we can inspect the stream coming from the kafka topic
+# we can inspect the stream coming from the kafka topic to view the items within on std out for debugging
 op.inspect("inspect-errors", stream.errs)
 op.inspect("inspect-oks", stream.oks, brokers=BROKERS, topic=ERR_TOPIC)
 # and output errors to be handled as needed

--- a/README.md
+++ b/README.md
@@ -250,12 +250,12 @@ python -m bytewax.run my_dataflow:flow
 # multiple workers in a single process
 python -m bytewax.run my_dataflow:flow -w 2
 
-# multiple workers in more than one process
-# first we start the first process running in cluster_one port 2101
-python -m bytewax.run my_dataflow:flow -w 2 -i0 -a "cluster_one:2101;cluster_two:2101"
+# Start a process on two separate machines to form a Bytewax cluster.
+# Start the first process with two worker threads on `machine_one`.
+machine_one$ python -m bytewax.run my_dataflow -w 2 -i0 -a "machine_one:2101;machine_two:2101"
 
-# then the second in cluster_two
-python -m bytewax.run simple -w 3 -i1 -a "cluster_one:2101;cluster_two:2101"
+# Then start the second process with three worker threads on `machine_two`.
+machine_two$ python -m bytewax.run my_dataflow -w 3 -i1 -a "machine_one:2101;machine_two:2101"
 ```
 
 It can also be run in a Docker container as described further in the [documentation](https://bytewax.io/docs/deployment/container).

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ op.inspect("inspect-errors", stream.errs)
 op.inspect("inspect-oks", stream.oks, brokers=BROKERS, topic=ERR_TOPIC)
 # and output errors to be handled as needed
 kop.output("out_errs", stream.errs)
-stream = op.map("deserialize", stream.oks, deserialize)
-stream = op.map("anon", stream, anonymize_email)
-stream = op.filter("filter_employees", stream, remove_bytewax)
+deser_msgs = op.map("deserialize", stream.oks, deserialize)
+keyed_msgs = op.key_on("key_on_user", deser_msgs, lambda msg: msg["user_id"])
+anon_msgs = op.map_value("anon", keyed_msgs, anonymize_email)
+filtered_msgs = op.filter_value("filter_employees", anon_msgs, remove_bytewax)
 # and finally output the cleaned data to a new topic
 kop.output("out1", stream, brokers=BROKERS, topic=OUT_TOPIC)
 ```

--- a/examples/event_time_processing.py
+++ b/examples/event_time_processing.py
@@ -70,15 +70,15 @@ def get_event_time(event):
     return datetime.fromisoformat(event["time"])
 
 
-# Configure the `fold_window` operator to use the event time.
+# Configure the `collect_window` operator to use the event time.
 cc = EventClockConfig(get_event_time, wait_for_system_duration=timedelta(seconds=10))
 
 # And a 5 seconds tumbling window
 align_to = datetime(2023, 1, 1, tzinfo=timezone.utc)
 wc = TumblingWindow(align_to=align_to, length=timedelta(seconds=5))
 
-running_avg_stream = window_op.fold_window(
-    "running_average", keyed_stream, cc, wc, list, acc_values
+windowed_stream = window_op.collect_window(
+    "window", keyed_stream, cc, wc, acc_values
 )
 
 
@@ -96,5 +96,5 @@ def format_event(event):
     )
 
 
-formatted_stream = op.map("format_event", running_avg_stream, format_event)
+formatted_stream = op.map("format_event", windowed_stream, format_event)
 op.output("out", formatted_stream, StdOutSink())

--- a/examples/event_time_processing.py
+++ b/examples/event_time_processing.py
@@ -77,9 +77,7 @@ cc = EventClockConfig(get_event_time, wait_for_system_duration=timedelta(seconds
 align_to = datetime(2023, 1, 1, tzinfo=timezone.utc)
 wc = TumblingWindow(align_to=align_to, length=timedelta(seconds=5))
 
-windowed_stream = window_op.collect_window(
-    "window", keyed_stream, cc, wc, acc_values
-)
+windowed_stream = window_op.collect_window("window", keyed_stream, cc, wc, acc_values)
 
 
 # Calculate the average of the values for each window, and


### PR DESCRIPTION
Brings the readme up to date with the current syntax and adds joins.

I think this is still missing a good way to describe running vs non-running joins.