### PR TITLE
Make KafkaSinkMessage types covariant

### DIFF
--- a/pysrc/bytewax/connectors/kafka/_types.py
+++ b/pysrc/bytewax/connectors/kafka/_types.py
@@ -1,7 +1,9 @@
 from typing import Optional, TypeVar, Union
 
 K = TypeVar("K")  # Key
+K_co = TypeVar("K_co", covariant=True)
 V = TypeVar("V")  # Value
+V_co = TypeVar("V_co", covariant=True)
 K2 = TypeVar("K2")  # Modified Key
 V2 = TypeVar("V2")  # Modified Value
 MaybeStrBytes = Optional[Union[str, bytes]]

--- a/pysrc/bytewax/connectors/kafka/message.py
+++ b/pysrc/bytewax/connectors/kafka/message.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from typing import Generic, List, Optional, Tuple
 
-from ._types import K2, V2, K, V, K_co, V_co
+from ._types import K2, V2, K, K_co, V, V_co
 
 
 @dataclass(frozen=True)

--- a/pysrc/bytewax/connectors/kafka/message.py
+++ b/pysrc/bytewax/connectors/kafka/message.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from typing import Generic, List, Optional, Tuple
 
-from ._types import K2, V2, K, V
+from ._types import K2, V2, K, V, K_co, V_co
 
 
 @dataclass(frozen=True)
@@ -76,7 +76,7 @@ class KafkaSourceMessage(Generic[K, V]):
 
 
 @dataclass(frozen=True)
-class KafkaSinkMessage(Generic[K, V]):
+class KafkaSinkMessage(Generic[K_co, V_co]):
     """Class that holds a message from kafka with metadata.
 
     Use `KafkaMessage.key` to get the key and `KafkaMessage.value` to get
@@ -85,15 +85,15 @@ class KafkaSinkMessage(Generic[K, V]):
     Other fields: `topic`, `headers`, `partition`, `timestamp`
     """
 
-    key: K
-    value: V
+    key: K_co
+    value: V_co
 
     topic: Optional[str] = None
     headers: List[Tuple[str, bytes]] = field(default_factory=list)
     partition: Optional[int] = None
     timestamp: int = 0
 
-    def _with_key(self, key: K2) -> "KafkaSinkMessage[K2, V]":
+    def _with_key(self, key: K2) -> "KafkaSinkMessage[K2, V_co]":
         """Returns a new instance with the specified key."""
         # Can't use `dataclasses.replace` directly since it requires
         # the fields you change to be the same type.
@@ -106,7 +106,7 @@ class KafkaSinkMessage(Generic[K, V]):
             timestamp=self.timestamp,
         )
 
-    def _with_value(self, value: V2) -> "KafkaSinkMessage[K, V2]":
+    def _with_value(self, value: V2) -> "KafkaSinkMessage[K_co, V2]":
         """Returns a new instance with the specified value."""
         return KafkaSinkMessage(
             key=self.key,

--- a/pysrc/bytewax/connectors/kafka/operators.py
+++ b/pysrc/bytewax/connectors/kafka/operators.py
@@ -134,7 +134,12 @@ def input(  # noqa A001
 @operator
 def output(
     step_id: str,
-    up: Stream[Union[KafkaSourceMessage, KafkaSinkMessage]],
+    up: Stream[
+        Union[
+            KafkaSourceMessage[MaybeStrBytes, MaybeStrBytes],
+            KafkaSinkMessage[MaybeStrBytes, MaybeStrBytes],
+        ]
+    ],
     *,
     brokers: List[str],
     topic: str,

--- a/pysrc/bytewax/connectors/kafka/operators.py
+++ b/pysrc/bytewax/connectors/kafka/operators.py
@@ -34,7 +34,7 @@ class KafkaSourceOut(Generic[K, V, K2, V2]):
 
     - KafkaStreams.oks:
         A stream of `KafkaMessage`s where `KafkaMessage.error is None`
-    - KafkaStreams.errors:
+    - KafkaStreams.errs:
         A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
     """
 
@@ -184,7 +184,7 @@ def deserialize_key(
 
     Returns an object with two attributes:
         - .oks: A stream of `KafkaMessage`s where `KafkaMessage.error is None`
-        - .errors: A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
+        - .errs: A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
     """
 
     # Make sure the first KafkaMessage in the return type's Union represents
@@ -213,7 +213,7 @@ def deserialize_value(
 
     Returns an object with two attributes:
         - .oks: A stream of `KafkaMessage`s where `KafkaMessage.error is None`
-        - .errors: A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
+        - .errs: A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
     """
 
     def shim_mapper(
@@ -243,8 +243,8 @@ def deserialize(
 
     Returns an object with two attributes:
         - .oks: A stream of `KafkaMessage`s where `KafkaMessage.error is None`
-        - .errors: A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
-    A message will be put in .errors even if only one of the deserializers fail.
+        - .errs: A stream of `KafkaMessage`s where `KafkaMessage.error is not None`
+    A message will be put in .errs even if only one of the deserializers fail.
     """
 
     # Use a single map step rather than concatenating

--- a/pysrc/bytewax/connectors/kafka/serde.py
+++ b/pysrc/bytewax/connectors/kafka/serde.py
@@ -17,7 +17,6 @@ __all__ = [
     "SerdeOut",
     "SchemaSerializer",
     "SchemaDeserializer",
-    # Reexport AvroMessage too
     "AvroMessage",
 ]
 

--- a/pysrc/bytewax/connectors/kafka/sink.py
+++ b/pysrc/bytewax/connectors/kafka/sink.py
@@ -43,8 +43,8 @@ class _KafkaSinkPartition(
 class KafkaSink(DynamicSink[KafkaSinkMessage[MaybeStrBytes, MaybeStrBytes]]):
     """Use a single Kafka topic as an output sink.
 
-    Items consumed from the dataflow must look like two-tuples of
-    `(key_bytes, value_bytes)`. Default partition routing is used.
+    Items consumed from the dataflow must be `KafkaSinkMessage` with
+    both key and value represented as `str | bytes | None`.
 
     Workers are the unit of parallelism.
 


### PR DESCRIPTION
This allows us to specify the proper expected types in the `output` operator in kafka connector, as suggested by @davidselassie [here](https://github.com/bytewax/bytewax/pull/332#discussion_r1431819308)