### PR TITLE
Resample operator

### DIFF
--- a/examples/resampler.py
+++ b/examples/resampler.py
@@ -16,12 +16,10 @@ merged = op.merge("sources", s1, s2, s3)
 def sampler(prev_sample: Optional[float], batch: List[float]) -> Optional[float]:
     if batch:
         return sum(batch) / len(batch)
-    elif prev_sample:
-        # If no items in this batch, return the previous
-        # sampled value, if any
-        return prev_sample
     else:
-        return None
+        # If no items in this batch, return the previous
+        # sampled value, which might still be `None`
+        return prev_sample
 
 
 resampled = op.resample("resample", merged, timedelta(seconds=0.5), sampler)

--- a/examples/resampler.py
+++ b/examples/resampler.py
@@ -1,0 +1,24 @@
+from datetime import timedelta
+from typing import List, Optional
+
+from bytewax import operators as op
+from bytewax.connectors.demo import RandomMetricSource
+from bytewax.dataflow import Dataflow
+
+flow = Dataflow("resampler")
+
+s1 = op.input("source1", flow, RandomMetricSource("tmp1", timedelta(seconds=0.001)))
+s2 = op.input("source2", flow, RandomMetricSource("tmp2", timedelta(seconds=0.04)))
+s3 = op.input("source3", flow, RandomMetricSource("tmp3", timedelta(seconds=1.005)))
+merged = op.merge("sources", s1, s2, s3)
+
+
+def sampler(batch: List[float]) -> Optional[float]:
+    if batch:
+        return sum(batch) / len(batch)
+    else:
+        return None
+
+
+resampled = op.resample("resample", merged, timedelta(seconds=0.5), sampler)
+op.inspect("resmapled", resampled)

--- a/examples/resampler.py
+++ b/examples/resampler.py
@@ -13,9 +13,13 @@ s3 = op.input("source3", flow, RandomMetricSource("tmp3", timedelta(seconds=1.00
 merged = op.merge("sources", s1, s2, s3)
 
 
-def sampler(batch: List[float]) -> Optional[float]:
+def sampler(prev_sample: Optional[float], batch: List[float]) -> Optional[float]:
     if batch:
         return sum(batch) / len(batch)
+    elif prev_sample:
+        # If no items in this batch, return the previous
+        # sampled value, if any
+        return prev_sample
     else:
         return None
 

--- a/pysrc/bytewax/operators/__init__.py
+++ b/pysrc/bytewax/operators/__init__.py
@@ -1573,7 +1573,9 @@ def resample(
     >>> s2 = op.input("s2", flow, RandomMetricSource("2", timedelta(seconds=0.2), 4))
     >>> s3 = op.input("s3", flow, RandomMetricSource("3", timedelta(seconds=0.1), 1))
     >>> merged = op.merge("sources", s1, s2, s3)
-    >>> resampled = op.resample("res", merged, timedelta(seconds=1.0), lambda t: len(t))
+    >>> def sampler(prev_sample, batch):
+    ...     return len(batch)
+    >>> resampled = op.resample("res", merged, timedelta(seconds=1.0), sampler)
     >>> res = op.inspect("resampled", resampled)
     >>> run_main(flow)
     resample.resampled: ('1', 5)

--- a/pytests/operators/test_resample.py
+++ b/pytests/operators/test_resample.py
@@ -1,0 +1,19 @@
+from datetime import timedelta
+
+import bytewax.operators as op
+from bytewax.connectors.demo import RandomMetricSource
+from bytewax.dataflow import Dataflow
+from bytewax.testing import TestingSink, run_main
+
+
+def test_resample():
+    out = []
+    flow = Dataflow("resample")
+    s1 = op.input("s1", flow, RandomMetricSource("1", timedelta(seconds=0.1), 5))
+    s2 = op.input("s2", flow, RandomMetricSource("2", timedelta(seconds=0.2), 4))
+    s3 = op.input("s3", flow, RandomMetricSource("3", timedelta(seconds=0.5), 1))
+    merged = op.merge("sources", s1, s2, s3)
+    resampled = op.resample("res", merged, timedelta(seconds=1.0), lambda t: len(t))
+    op.output("out", resampled, TestingSink(out))
+    run_main(flow)
+    assert out == [("1", 5), ("2", 4), ("3", 1)]

--- a/pytests/operators/test_resample.py
+++ b/pytests/operators/test_resample.py
@@ -13,7 +13,9 @@ def test_resample():
     s2 = op.input("s2", flow, RandomMetricSource("2", timedelta(seconds=0.2), 4))
     s3 = op.input("s3", flow, RandomMetricSource("3", timedelta(seconds=0.5), 1))
     merged = op.merge("sources", s1, s2, s3)
-    resampled = op.resample("res", merged, timedelta(seconds=1.0), lambda t: len(t))
+    resampled = op.resample(
+        "res", merged, timedelta(seconds=1.0), lambda p, batch: len(batch)
+    )
     op.output("out", resampled, TestingSink(out))
     run_main(flow)
     assert out == [("1", 5), ("2", 4), ("3", 1)]


### PR DESCRIPTION
Following the discussion during the office hours, this PR introduces the `resample` operator. It's a stateful operator that accumulate items for a fixed period of time, and passes the previous sample (if any) and the current batch (which might be empty) to a user provided `sampler` function.

Given a stream of floats, it can be used like this:

```python
def sampler(prev_sample: Optional[float], batch: List[float]) -> Optional[float]:
    if batch:
        return sum(batch) / len(batch)
    # prev_sample could be `None`, you might want to
    # set a default value here
    return prev_sample

resampled = op.resample("resample", stream, timedelta(seconds=0.5), sampler)
```

This will emit either the average of received values or the previously recorded average (which might be `None`) for each key at 2Hz, regardless of the input's frequency.

_edit_: A warning I should add here is that if the key space grows indefinitely, so does the state and the number of items emitted, since the keys are only discarded on EOF.