### PR TITLE
Removes `now` and `sched` arguments in input partitions and unary logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,26 @@ notes on GitHub when we make a new release.__
 
 - *Breaking change* Removes `builder` argument from `stateful_map`.
   Instead, the initial state value is always `None` and you can call
-  your previous builder by hand.
+  your previous builder by hand in the `mapper`.
+
+- *Breaking change* Improves performance by removing the `now:
+  datetime` argument from `FixedPartitionedSource.build_part`,
+  `DynamicSource.build`, and `UnaryLogic.on_item`. If you need the
+  current time, use:
+
+```python
+from datetime import datetime, timezone
+
+now = datetime.now(timezone.utc)
+```
+
+- *Breaking change* Improves performance by removing the `sched:
+  datetime` argument from `StatefulSourcePartition.next_batch`,
+  `StatelessSourcePartition.next_batch`, `UnaryLogic.on_notify`. You
+  should already have the scheduled next awake time in whatever
+  instance variable you returned in
+  `{Stateful,Stateless}SourcePartition.next_awake` or
+  `UnaryLogic.notify_at`.
 
 ## v0.18.1
 

--- a/pysrc/bytewax/connectors/files.py
+++ b/pysrc/bytewax/connectors/files.py
@@ -1,7 +1,6 @@
 """Connectors for local text files."""
 import os
 from csv import DictReader
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 from zlib import adler32
@@ -44,7 +43,7 @@ class _FileSourcePartition(StatefulSourcePartition[str, int]):
         self._batcher = batch(it, batch_size)
 
     @override
-    def next_batch(self, sched: Optional[datetime]) -> List[str]:
+    def next_batch(self) -> List[str]:
         return next(self._batcher)
 
     @override
@@ -127,7 +126,7 @@ class DirSource(FixedPartitionedSource[str, int]):
 
     @override
     def build_part(
-        self, now: datetime, for_part: str, resume_state: Optional[int]
+        self, for_part: str, resume_state: Optional[int]
     ) -> _FileSourcePartition:
         _fs_id, for_path = for_part.split("::", 1)
         path = self._dir_path / for_path
@@ -191,7 +190,7 @@ class FileSource(FixedPartitionedSource[str, int]):
 
     @override
     def build_part(
-        self, now: datetime, for_part: str, resume_state: Optional[int]
+        self, for_part: str, resume_state: Optional[int]
     ) -> _FileSourcePartition:
         _fs_id, path = for_part.split("::", 1)
         # TODO: Warn and return None. Then we could support
@@ -217,7 +216,7 @@ class _CSVPartition(StatefulSourcePartition[Dict[str, str], int]):
         self._batcher = batch(reader, batch_size)
 
     @override
-    def next_batch(self, sched: Optional[datetime]) -> List[Dict[str, str]]:
+    def next_batch(self) -> List[Dict[str, str]]:
         return next(self._batcher)
 
     @override
@@ -310,7 +309,7 @@ class CSVSource(FixedPartitionedSource[Dict[str, str], int]):
         return self._file_source.list_parts()
 
     @override
-    def build_part(self, now: datetime, for_part: str, resume_state: Optional[Any]):
+    def build_part(self, for_part: str, resume_state: Optional[Any]):
         _fs_id, path = for_part.split("::", 1)
         assert path == str(
             self._file_source._path

--- a/pysrc/bytewax/connectors/kafka/__init__.py
+++ b/pysrc/bytewax/connectors/kafka/__init__.py
@@ -40,7 +40,6 @@ Or the custom operators:
 
 """
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import Dict, Generic, Iterable, List, Optional, Tuple, TypeVar, Union
 
 from confluent_kafka import OFFSET_BEGINNING, Consumer, Producer, TopicPartition
@@ -209,9 +208,7 @@ class _KafkaSourcePartition(
         self._eof = False
         self._raise_on_errors = raise_on_errors
 
-    def next_batch(
-        self, sched: Optional[datetime]
-    ) -> List[SerializedKafkaSourceResult]:
+    def next_batch(self) -> List[SerializedKafkaSourceResult]:
         if self._eof:
             raise StopIteration()
 
@@ -341,7 +338,7 @@ class KafkaSource(FixedPartitionedSource[SerializedKafkaSourceResult, Optional[i
         return list(_list_parts(client, self._topics))
 
     def build_part(
-        self, now: datetime, for_part: str, resume_state: Optional[int]
+        self, for_part: str, resume_state: Optional[int]
     ) -> _KafkaSourcePartition:
         """See ABC docstring."""
         idx, topic = for_part.split("-", 1)

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -65,7 +65,7 @@ class _IterSourcePartition(StatefulSourcePartition[X, int]):
         self._raise: Optional[Exception] = None
 
     @override
-    def next_batch(self, sched: Optional[datetime]) -> List[X]:
+    def next_batch(self) -> List[X]:
         if self._raise is not None:
             raise self._raise
 
@@ -173,7 +173,7 @@ class TestingSource(FixedPartitionedSource[X, int]):
 
     @override
     def build_part(
-        self, now: datetime, for_part: str, resume_state: Optional[int]
+        self, for_part: str, resume_state: Optional[int]
     ) -> _IterSourcePartition[X]:
         return _IterSourcePartition(self._ib, self._batch_size, resume_state)
 

--- a/pytests/connectors/test_files.py
+++ b/pytests/connectors/test_files.py
@@ -95,26 +95,26 @@ def test_file_input_supports_blank_lines():
     ]
 
 
-def test_file_input_resume_state(now):
+def test_file_input_resume_state():
     file_path = Path("pytests/fixtures/dir_input/partition-1.txt")
     inp = FileSource(file_path, batch_size=1, get_fs_id=lambda _dir: "SHARED")
-    part = inp.build_part(now, f"SHARED::{file_path}", None)
-    assert part.next_batch(now) == ["one1"]
-    assert part.next_batch(now) == ["one2"]
+    part = inp.build_part(f"SHARED::{file_path}", None)
+    assert part.next_batch() == ["one1"]
+    assert part.next_batch() == ["one2"]
     resume_state = part.snapshot()
-    assert part.next_batch(now) == ["one3"]
-    assert part.next_batch(now) == ["one4"]
+    assert part.next_batch() == ["one3"]
+    assert part.next_batch() == ["one4"]
     part.close()
 
     inp = FileSource(file_path, batch_size=1, get_fs_id=lambda _dir: "SHARED")
-    part = inp.build_part(now, f"SHARED::{file_path}", resume_state)
+    part = inp.build_part(f"SHARED::{file_path}", resume_state)
     assert part.snapshot() == resume_state
-    assert part.next_batch(now) == ["one3"]
-    assert part.next_batch(now) == ["one4"]
-    assert part.next_batch(now) == ["one5"]
-    assert part.next_batch(now) == ["one6"]
+    assert part.next_batch() == ["one3"]
+    assert part.next_batch() == ["one4"]
+    assert part.next_batch() == ["one5"]
+    assert part.next_batch() == ["one6"]
     with raises(StopIteration):
-        part.next_batch(now)
+        part.next_batch()
     part.close()
 
 

--- a/pytests/operators/test_collect.py
+++ b/pytests/operators/test_collect.py
@@ -6,12 +6,12 @@ from bytewax.operators import _CollectLogic, _CollectState
 from bytewax.testing import TestingSink, TestingSource, run_main
 
 
-def test_collect_logic_snapshot(now):
+def test_collect_logic_snapshot():
     now = datetime(2023, 1, 1, tzinfo=timezone.utc)
     timeout = timedelta(seconds=10)
-    logic = _CollectLogic("test_step", timeout, 3, _CollectState())
+    logic = _CollectLogic("test_step", lambda: now, timeout, 3, _CollectState())
 
-    logic.on_item(now, 1)
+    logic.on_item(1)
 
     assert logic.snapshot() == _CollectState([1], now + timeout)
 

--- a/pytests/operators/test_fold_final.py
+++ b/pytests/operators/test_fold_final.py
@@ -4,13 +4,13 @@ from bytewax.operators import _FoldFinalLogic
 from bytewax.testing import TestingSink, TestingSource, run_main
 
 
-def test_fold_final_logic_snapshot(now):
+def test_fold_final_logic_snapshot():
     def folder(old_state, value):
         return "new_state"
 
     logic = _FoldFinalLogic("test_step", folder, "old_state")
 
-    logic.on_item(now, 5)
+    logic.on_item(5)
 
     assert logic.snapshot() == "new_state"
 

--- a/pytests/operators/test_join.py
+++ b/pytests/operators/test_join.py
@@ -4,11 +4,11 @@ from bytewax.operators import _JoinLogic, _JoinState
 from bytewax.testing import TestingSink, TestingSource, run_main
 
 
-def test_join_logic_snapshot(now):
+def test_join_logic_snapshot():
     logic = _JoinLogic("test_step", False, _JoinState.for_names(["a", "b", "c"]))
 
-    logic.on_item(now, ("a", 1))
-    logic.on_item(now, ("b", 2))
+    logic.on_item(("a", 1))
+    logic.on_item(("b", 2))
 
     expect = _JoinState({"a": [1], "b": [2], "c": []})
     assert logic.snapshot() == expect

--- a/pytests/operators/test_stateful_flat_map.py
+++ b/pytests/operators/test_stateful_flat_map.py
@@ -4,24 +4,24 @@ from bytewax.operators import UnaryLogic, _StatefulFlatMapLogic
 from bytewax.testing import TestingSink, TestingSource, run_main
 
 
-def test_stateful_map_logic_discard_on_none(now):
+def test_stateful_map_logic_discard_on_none():
     def mapper(old_state, value):
         assert old_state is None
         return None, None
 
     logic = _StatefulFlatMapLogic("test_step", mapper, None)
-    (out, discard) = logic.on_item(now, 1)
+    (out, discard) = logic.on_item(1)
 
     assert discard == UnaryLogic.DISCARD
 
 
-def test_stateful_map_logic_snapshot(now):
+def test_stateful_map_logic_snapshot():
     def mapper(old_state, value):
         assert old_state is None
         return "new_state", None
 
     logic = _StatefulFlatMapLogic("test_step", mapper, None)
-    logic.on_item(now, 1)
+    logic.on_item(1)
 
     assert logic.snapshot() == "new_state"
 

--- a/pytests/test_testing.py
+++ b/pytests/test_testing.py
@@ -18,59 +18,59 @@ def test_ffwd_iter():
         next(it)
 
 
-def test_testing_source(now):
+def test_testing_source():
     inp = TestingSource(range(3))
-    part = inp.build_part(now, "iterable", None)
-    assert part.next_batch(now) == [0]
-    assert part.next_batch(now) == [1]
-    assert part.next_batch(now) == [2]
+    part = inp.build_part("iterable", None)
+    assert part.next_batch() == [0]
+    assert part.next_batch() == [1]
+    assert part.next_batch() == [2]
     with raises(StopIteration):
-        part.next_batch(now)
+        part.next_batch()
     part.close()
 
 
-def test_testing_source_resume_state(now):
+def test_testing_source_resume_state():
     inp = TestingSource(range(3))
-    part = inp.build_part(now, "iterable", None)
-    assert part.next_batch(now) == [0]
-    assert part.next_batch(now) == [1]
+    part = inp.build_part("iterable", None)
+    assert part.next_batch() == [0]
+    assert part.next_batch() == [1]
     resume_state = part.snapshot()
     assert resume_state == 2
-    assert part.next_batch(now) == [2]
+    assert part.next_batch() == [2]
     part.close()
 
     inp = TestingSource(range(3))
-    part = inp.build_part(now, "iterable", resume_state)
+    part = inp.build_part("iterable", resume_state)
     assert part.snapshot() == resume_state
-    assert part.next_batch(now) == [2]
+    assert part.next_batch() == [2]
     with raises(StopIteration):
-        part.next_batch(now)
+        part.next_batch()
     part.close()
 
 
-def test_testing_source_batch_size(now):
+def test_testing_source_batch_size():
     inp = TestingSource(range(5), batch_size=2)
-    part = inp.build_part(now, "iterable", None)
-    assert part.next_batch(now) == [0, 1]
-    assert part.next_batch(now) == [2, 3]
-    assert part.next_batch(now) == [4]
+    part = inp.build_part("iterable", None)
+    assert part.next_batch() == [0, 1]
+    assert part.next_batch() == [2, 3]
+    assert part.next_batch() == [4]
     part.close()
 
 
-def test_testing_source_eof(now):
+def test_testing_source_eof():
     inp = TestingSource([0, 1, 2, TestingSource.EOF(), 3, 4], batch_size=2)
-    part = inp.build_part(now, "iterable", None)
-    assert part.next_batch(now) == [0, 1]
-    assert part.next_batch(now) == [2]
+    part = inp.build_part("iterable", None)
+    assert part.next_batch() == [0, 1]
+    assert part.next_batch() == [2]
     with raises(StopIteration):
-        part.next_batch(now)
+        part.next_batch()
     part.close()
 
     resume_state = part.snapshot()
-    part = inp.build_part(now, "iterable", resume_state)
-    assert part.next_batch(now) == [3, 4]
+    part = inp.build_part("iterable", resume_state)
+    assert part.next_batch() == [3, 4]
     with raises(StopIteration):
-        part.next_batch(now)
+        part.next_batch()
     part.close()
 
 
@@ -90,20 +90,20 @@ def test_testing_source_eof_run(recovery_config):
     assert out == [3, 4]
 
 
-def test_testing_source_abort(now):
+def test_testing_source_abort():
     inp = TestingSource([0, 1, 2, TestingSource.ABORT(), 3, 4], batch_size=2)
-    part = inp.build_part(now, "iterable", None)
-    assert part.next_batch(now) == [0, 1]
+    part = inp.build_part("iterable", None)
+    assert part.next_batch() == [0, 1]
     resume_state = part.snapshot()
-    assert part.next_batch(now) == [2]
+    assert part.next_batch() == [2]
     with raises(AbortExecution):
-        part.next_batch(now)
+        part.next_batch()
 
-    part = inp.build_part(now, "iterable", resume_state)
-    assert part.next_batch(now) == [2, 3]
-    assert part.next_batch(now) == [4]
+    part = inp.build_part("iterable", resume_state)
+    assert part.next_batch() == [2, 3]
+    assert part.next_batch() == [4]
     with raises(StopIteration):
-        part.next_batch(now)
+        part.next_batch()
     part.close()
 
 


### PR DESCRIPTION
I feel bad about this since it's breaking API churn, but I came back
upon this when I was doing the "bigger then memory state" prototyping.

I don't think we should include the `datetime` arguments to
`next_batch` and `on_item` in input partitions and stateful operators
for performance reasons.

From my benchmarking of stateful dataflows, a ton of the time is spent
converting these timestamps between Rust and Python, which is fine if
you use them, but it means that every input and stateful operator has
to pay the penalty even if they are not used.

By having to explicitly request the current time, you pay the penalty
if you need it, but all other operators are sped back up.

It also turns out that the scheduled times are really redundant since
you'll always have that time stored in the partition / logic already
because you needed to return it from `next_awake` or `notify_at`, so
you don't lose any functionality.
