### PR TITLE
fix backup interval of zero raising an exception

### DIFF
--- a/pysrc/bytewax/run.py
+++ b/pysrc/bytewax/run.py
@@ -311,7 +311,7 @@ def _parse_args():
     # If recovery is configured, make sure that the snapshot_interval and
     # backup_interval are set.
     if args.recovery_directory is not None and (
-        not args.snapshot_interval or not args.backup_interval
+        not args.snapshot_interval or args.backup_interval is None
     ):
         arg_parser.error(
             "when running with recovery, the `-s/--snapshot_interval` and "

--- a/pytests/test_parse.py
+++ b/pytests/test_parse.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import os
 import sys
 from unittest.mock import patch
@@ -42,3 +43,32 @@ def test_parse_args_environ(tmpdir):
             parsed = _parse_args()
             assert parsed.process_id == 0
             assert parsed.addresses == "localhost:1234;localhost:5678"
+
+def test_parse_backup_interval():
+    testargs = [
+        "fake_command",
+        "examples/basic.py:flow",
+        "--backup-interval",
+        "60"
+    ]
+    # Mock sys.argv to test that the parsing phase works well
+    with patch.object(sys, "argv", testargs):
+        parsed = _parse_args()
+        # Test the custom handling of the import_str
+        assert parsed.backup_interval == timedelta(minutes=1)
+        
+def test_parse_backup_interval_zero():
+    testargs = [
+        "fake_command",
+        "examples/basic.py:flow",
+        "--recovery-directory",
+        "/fake/directory",
+        "--snapshot-interval",
+        "30",
+        "--backup-interval",
+        "0"
+    ]
+    # Mock sys.argv to test that the parsing phase works well
+    with patch.object(sys, "argv", testargs):
+        parsed = _parse_args()
+        assert parsed.backup_interval == timedelta(seconds=0)


### PR DESCRIPTION
fixes #392

This PR fixes the `bytewax.run` script disallowing a `backup-interval` of 0 seconds
