### PR TITLE
Fix recovery store garbage collection

### DIFF
--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -442,20 +442,20 @@ fn get_migrations(py: Python) -> &Migrations<'static> {
     MIGRATIONS.get_or_init(py, || {
         Migrations::new(vec![
             M::up(
-                "CREATE TABLE parts ( \
-                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                 part_index INTEGER PRIMARY KEY NOT NULL CHECK (part_index >= 0), \
-                 part_count INTEGER NOT NULL CHECK (part_count > 0), \
-                 CHECK (part_index < part_count) \
+                "CREATE TABLE parts (
+                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                 part_index INTEGER PRIMARY KEY NOT NULL CHECK (part_index >= 0),
+                 part_count INTEGER NOT NULL CHECK (part_count > 0),
+                 CHECK (part_index < part_count)
                  ) STRICT",
             ),
             // This is a sharded table.
             M::up(
-                "CREATE TABLE exs ( \
-                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                 ex_num INTEGER NOT NULL PRIMARY KEY, \
-                 worker_count INTEGER NOT NULL CHECK (worker_count > 0), \
-                 resume_epoch INTEGER NOT NULL \
+                "CREATE TABLE exs (
+                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                 ex_num INTEGER NOT NULL PRIMARY KEY,
+                 worker_count INTEGER NOT NULL CHECK (worker_count > 0),
+                 resume_epoch INTEGER NOT NULL
                  ) STRICT",
             ),
             // This is a sharded table.
@@ -464,12 +464,12 @@ fn get_migrations(py: Python) -> &Migrations<'static> {
             // know what partition the row in `ex` will be in; we'd
             // need a "sharded foreign key" kinda thing.
             M::up(
-                "CREATE TABLE fronts ( \
-                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                 ex_num INTEGER NOT NULL, \
-                 worker_index INTEGER NOT NULL CHECK (worker_index >= 0), \
-                 worker_frontier INTEGER NOT NULL, \
-                 PRIMARY KEY (ex_num, worker_index) \
+                "CREATE TABLE fronts (
+                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                 ex_num INTEGER NOT NULL,
+                 worker_index INTEGER NOT NULL CHECK (worker_index >= 0),
+                 worker_frontier INTEGER NOT NULL,
+                 PRIMARY KEY (ex_num, worker_index)
                  ) STRICT",
             ),
             // This is _not_ a sharded table. Commits affect a whole
@@ -477,21 +477,21 @@ fn get_migrations(py: Python) -> &Migrations<'static> {
             // shard as partition definitions. We don't use a foreign
             // key here, though so we don't have to deal with flow_id.
             M::up(
-                "CREATE TABLE commits ( \
-                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                 part_index INTEGER PRIMARY KEY NOT NULL, \
-                 commit_epoch INTEGER NOT NULL \
+                "CREATE TABLE commits (
+                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                 part_index INTEGER PRIMARY KEY NOT NULL,
+                 commit_epoch INTEGER NOT NULL
                  ) STRICT",
             ),
             // This is a sharded table.
             M::up(
-                "CREATE TABLE snaps ( \
-                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                 step_id TEXT NOT NULL, \
-                 state_key TEXT NOT NULL, \
-                 snap_epoch INTEGER NOT NULL, \
-                 ser_change TEXT, \
-                 PRIMARY KEY (step_id, state_key, snap_epoch) \
+                "CREATE TABLE snaps (
+                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                 step_id TEXT NOT NULL,
+                 state_key TEXT NOT NULL,
+                 snap_epoch INTEGER NOT NULL,
+                 ser_change TEXT,
+                 PRIMARY KEY (step_id, state_key, snap_epoch)
                  ) STRICT",
             ),
         ])
@@ -530,7 +530,7 @@ impl Writer for PartitionMetaWriter {
             tracing::trace!("Writing {part:?}");
             let PartitionMeta(part_index, part_count) = part;
             txn.execute(
-                "INSERT INTO parts (part_index, part_count) \
+                "INSERT INTO parts (part_index, part_count)
                  VALUES (?1, ?2)",
                 (part_index.0, part_count.0),
             )
@@ -556,7 +556,7 @@ impl Writer for ExecutionMetaWriter {
             // Do not upsert because we should never see an execution
             // twice.
             txn.execute(
-                "INSERT INTO exs (ex_num, worker_count, resume_epoch) \
+                "INSERT INTO exs (ex_num, worker_count, resume_epoch)
                  VALUES (?1, ?2, ?3)",
                 (ex_num.0, worker_count.0, resume_epoch.0),
             )
@@ -580,9 +580,9 @@ impl Writer for FrontierWriter {
             tracing::trace!("Writing {front:?}");
             let FrontierMeta(ex, worker_count, wf) = front;
             txn.execute(
-                "INSERT INTO fronts (ex_num, worker_index, worker_frontier) \
-                 VALUES (?1, ?2, ?3) \
-                 ON CONFLICT (ex_num, worker_index) DO UPDATE \
+                "INSERT INTO fronts (ex_num, worker_index, worker_frontier)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT (ex_num, worker_index) DO UPDATE
                  SET worker_frontier = EXCLUDED.worker_frontier",
                 (ex.0, worker_count.0, wf.0),
             )
@@ -606,9 +606,9 @@ impl Writer for SerializedSnapshotWriter {
             tracing::trace!("Writing {snap:?}");
             let SerializedSnapshot(step_id, state_key, snap_epoch, ser_change) = snap;
             txn.execute(
-                "INSERT INTO snaps (step_id, state_key, snap_epoch, ser_change) \
-                 VALUES (?1, ?2, ?3, ?4) \
-                 ON CONFLICT (step_id, state_key, snap_epoch) DO UPDATE \
+                "INSERT INTO snaps (step_id, state_key, snap_epoch, ser_change)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT (step_id, state_key, snap_epoch) DO UPDATE
                  SET ser_change = EXCLUDED.ser_change",
                 (step_id.0, state_key.0, snap_epoch.0, ser_change),
             )
@@ -632,7 +632,7 @@ impl Writer for CommitWriter {
             tracing::trace!("Writing {commit:?}");
             let CommitMeta(part_idx, commit_epoch) = commit;
             txn.execute(
-                "INSERT INTO commits (part_index, commit_epoch) \
+                "INSERT INTO commits (part_index, commit_epoch)
                  VALUES (?1, ?2)",
                 (part_idx.0, commit_epoch),
             )
@@ -662,7 +662,7 @@ impl BatchIterator for PartitionMetaLoader {
                 .conn
                 .borrow_mut()
                 .prepare(
-                    "SELECT part_index, part_count \
+                    "SELECT part_index, part_count
                      FROM parts",
                 )
                 .unwrap()
@@ -708,7 +708,7 @@ impl BatchIterator for ExecutionMetaLoader {
                 .conn
                 .borrow_mut()
                 .prepare(
-                    "SELECT ex_num, worker_count, resume_epoch \
+                    "SELECT ex_num, worker_count, resume_epoch
                      FROM exs",
                 )
                 .unwrap()
@@ -750,7 +750,7 @@ impl BatchIterator for FrontierLoader {
                 .conn
                 .borrow()
                 .prepare(
-                    "SELECT ex_num, worker_index, worker_frontier \
+                    "SELECT ex_num, worker_index, worker_frontier
                      FROM fronts",
                 )
                 .unwrap()
@@ -817,17 +817,17 @@ impl SerializedSnapshotLoader {
             // results by that, and since there is only one row per
             // (step_id, state_key), the LIMIT clause causes it to batch.
             .prepare(
-                "WITH max_epoch_snaps AS ( \
-                 SELECT step_id, state_key, MAX(snap_epoch) AS snap_epoch \
-                 FROM snaps \
-                 WHERE snap_epoch < ?1 \
-                 GROUP BY step_id, state_key \
-                 ) \
-                 SELECT step_id, state_key, snap_epoch, ser_change \
-                 FROM snaps \
-                 JOIN max_epoch_snaps USING (step_id, state_key, snap_epoch) \
-                 WHERE ?2 IS NULL OR ?3 IS NULL OR (step_id, state_key) > (?2, ?3) \
-                 ORDER BY step_id, state_key \
+                "WITH max_epoch_snaps AS (
+                 SELECT step_id, state_key, MAX(snap_epoch) AS snap_epoch
+                 FROM snaps
+                 WHERE snap_epoch < ?1
+                 GROUP BY step_id, state_key
+                 )
+                 SELECT step_id, state_key, snap_epoch, ser_change
+                 FROM snaps
+                 JOIN max_epoch_snaps USING (step_id, state_key, snap_epoch)
+                 WHERE ?2 IS NULL OR ?3 IS NULL OR (step_id, state_key) > (?2, ?3)
+                 ORDER BY step_id, state_key
                  LIMIT ?4",
             )
             .unwrap()
@@ -908,7 +908,7 @@ impl BatchIterator for CommitLoader {
                 .conn
                 .borrow()
                 .prepare(
-                    "SELECT part_index, commit_epoch \
+                    "SELECT part_index, commit_epoch
                      FROM commits",
                 )
                 .unwrap()
@@ -939,9 +939,9 @@ impl Committer<u64> for RecoveryCommitter {
         let mut conn = self.conn.borrow_mut();
         let txn = conn.transaction().unwrap();
         txn.execute(
-            "INSERT INTO commits (part_index, commit_epoch) \
-             VALUES (?1, ?2) \
-             ON CONFLICT (part_index) DO UPDATE \
+            "INSERT INTO commits (part_index, commit_epoch)
+             VALUES (?1, ?2)
+             ON CONFLICT (part_index) DO UPDATE
              SET commit_epoch = EXCLUDED.commit_epoch",
             (self.part_key.0, epoch),
         )
@@ -953,19 +953,19 @@ impl Committer<u64> for RecoveryCommitter {
         // the most recent snapshot is not deleted it's ok for this to
         // be `<=`.
         txn.execute(
-            "WITH max_epoch_snapshots AS ( \
-             SELECT step_id, state_key, MAX(snap_epoch) AS snap_epoch \
-             FROM snaps \
-             WHERE snap_epoch < ?1 \
-             GROUP BY step_id, state_key \
-             ), \
-             garbage_snapshots AS ( \
-             SELECT step_id, state_key, snaps.snap_epoch \
-             FROM snaps \
-             JOIN max_epoch_snapshots USING (step_id, state_key) \
-             WHERE snaps.snap_epoch < max_epoch_snapshots.snap_epoch \
-             ) \
-             DELETE FROM snaps \
+            "WITH max_epoch_snapshots AS (
+             SELECT step_id, state_key, MAX(snap_epoch) AS snap_epoch
+             FROM snaps
+             WHERE snap_epoch <= ?1
+             GROUP BY step_id, state_key
+             ),
+             garbage_snapshots AS (
+             SELECT step_id, state_key, snaps.snap_epoch
+             FROM snaps
+             JOIN max_epoch_snapshots USING (step_id, state_key)
+             WHERE snaps.snap_epoch < max_epoch_snapshots.snap_epoch
+             )
+             DELETE FROM snaps
              WHERE (step_id, state_key, snap_epoch) IN garbage_snapshots",
             (epoch,),
         )
@@ -1201,27 +1201,27 @@ impl RecoveryPart {
 
         let resume_from = txn
             .query_row(
-                "WITH max_ex AS ( \
-                 SELECT ex_num, worker_count, resume_epoch \
-                 FROM exs \
-                 WHERE ex_num = (SELECT MAX(ex_num) FROM exs) \
-                 ), \
-                 default_progress AS ( \
-                 SELECT ex_num, value AS worker_index, resume_epoch AS worker_frontier \
-                 FROM generate_series(0, (SELECT worker_count - 1 FROM max_ex)) \
-                 CROSS JOIN max_ex \
-                 ), \
-                 explicit_progress AS ( \
-                 SELECT ex_num, worker_index, worker_frontier \
-                 FROM fronts \
-                 WHERE ex_num = (SELECT MAX(ex_num) FROM exs) \
-                 ), \
-                 max_progress AS ( \
-                 SELECT ex_num, worker_index, MAX(worker_frontier) AS worker_frontier \
-                 FROM (SELECT * FROM explicit_progress UNION SELECT * FROM default_progress) \
-                 GROUP BY ex_num, worker_index \
-                 ) \
-                 SELECT ex_num + 1, MIN(worker_frontier) \
+                "WITH max_ex AS (
+                 SELECT ex_num, worker_count, resume_epoch
+                 FROM exs
+                 WHERE ex_num = (SELECT MAX(ex_num) FROM exs)
+                 ),
+                 default_progress AS (
+                 SELECT ex_num, value AS worker_index, resume_epoch AS worker_frontier
+                 FROM generate_series(0, (SELECT worker_count - 1 FROM max_ex))
+                 CROSS JOIN max_ex
+                 ),
+                 explicit_progress AS (
+                 SELECT ex_num, worker_index, worker_frontier
+                 FROM fronts
+                 WHERE ex_num = (SELECT MAX(ex_num) FROM exs)
+                 ),
+                 max_progress AS (
+                 SELECT ex_num, worker_index, MAX(worker_frontier) AS worker_frontier
+                 FROM (SELECT * FROM explicit_progress UNION SELECT * FROM default_progress)
+                 GROUP BY ex_num, worker_index
+                 )
+                 SELECT ex_num + 1, MIN(worker_frontier)
                  FROM max_progress",
                 (),
                 // `MIN(worker_frontier)` always returns a


### PR DESCRIPTION
Something was wrong with the delete part of the query. Fixes to build
up CTEs that represent the to-be-deleted data and then do the delete.

Adds a test which confirms that only the latest snapshot is retained.
