### PR TITLE
[Docs]: Fix path to Slack icon

### DIFF
--- a/docs/_templates/slack-footer.html
+++ b/docs/_templates/slack-footer.html
@@ -1,6 +1,6 @@
 <div class="bd-slack">
   <figure class="bd-slack-icon">
-    <img src="/_static/img/slack.svg" class="bd-slack-img" alt="Join our community Slack channel" />
+    <img src="{{ pathto('_static/img/slack.svg', 1) }}" class="bd-slack-img" alt="Join our community Slack channel" />
   </figure>
   <div class="bd-slack-content">
     <h4 class="bd-slack-title">Need some help? Join <strong>our community!</strong></h4>


### PR DESCRIPTION
Fixes Slack icon img path in the Sphinx docs.
Preview: https://bytewax--402.org.readthedocs.build/402/articles/index.html