### PR TITLE
Don't call `time_for` twice

### DIFF
--- a/src/window/clock/event_time_clock.rs
+++ b/src/window/clock/event_time_clock.rs
@@ -164,23 +164,16 @@ where
         watermark.unwrap_or(DateTime::<Utc>::MIN_UTC)
     }
 
-    fn time_for(&mut self, event: &Poll<Option<TdPyAny>>) -> Poll<Option<DateTime<Utc>>> {
-        match event {
-            Poll::Ready(Some(event)) => {
-                let event_time = Python::with_gil(|py| {
-                    self.dt_getter
-                        // Call the event time getter function with the event as parameter
-                        .call1(py, (event.clone_ref(py),))
-                        .unwrap()
-                        // Convert to DateTime<Utc>
-                        .extract(py)
-                        .unwrap()
-                });
-                Poll::Ready(Some(event_time))
-            }
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
-        }
+    fn time_for(&mut self, event: &TdPyAny) -> DateTime<Utc> {
+        Python::with_gil(|py| {
+            self.dt_getter
+                // Call the event time getter function with the event as parameter
+                .call1(py, (event.clone_ref(py),))
+                .unwrap()
+                // Convert to DateTime<Utc>
+                .extract(py)
+                .unwrap()
+        })
     }
 
     fn snapshot(&self) -> TdPyAny {

--- a/src/window/clock/event_time_clock.rs
+++ b/src/window/clock/event_time_clock.rs
@@ -115,12 +115,12 @@ impl<S> Clock<TdPyAny> for EventClock<S>
 where
     S: TimeSource,
 {
-    fn watermark(&mut self, next_value: &Poll<Option<TdPyAny>>) -> DateTime<Utc> {
+    fn watermark(&mut self, next_value: &Poll<Option<DateTime<Utc>>>) -> DateTime<Utc> {
         let now = self.source.now();
 
         // Incoming event time and system time it was ingested.
         let next_event_time_system_time = match next_value {
-            Poll::Ready(Some(event)) => Some((self.time_for(event), now)),
+            Poll::Ready(Some(event_time)) => Some((*event_time, now)),
             Poll::Ready(None) => Some((DateTime::<Utc>::MAX_UTC, now)),
             Poll::Pending => None,
         };
@@ -164,16 +164,23 @@ where
         watermark.unwrap_or(DateTime::<Utc>::MIN_UTC)
     }
 
-    fn time_for(&mut self, event: &TdPyAny) -> DateTime<Utc> {
-        Python::with_gil(|py| {
-            self.dt_getter
-                // Call the event time getter function with the event as parameter
-                .call1(py, (event.clone_ref(py),))
-                .unwrap()
-                // Convert to DateTime<Utc>
-                .extract(py)
-                .unwrap()
-        })
+    fn time_for(&mut self, event: &Poll<Option<TdPyAny>>) -> Poll<Option<DateTime<Utc>>> {
+        match event {
+            Poll::Ready(Some(event)) => {
+                let event_time = Python::with_gil(|py| {
+                    self.dt_getter
+                        // Call the event time getter function with the event as parameter
+                        .call1(py, (event.clone_ref(py),))
+                        .unwrap()
+                        // Convert to DateTime<Utc>
+                        .extract(py)
+                        .unwrap()
+                });
+                Poll::Ready(Some(event_time))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
     }
 
     fn snapshot(&self) -> TdPyAny {
@@ -213,13 +220,8 @@ mod tests {
             "watermark should start at the beginning of time before any items"
         );
 
-        let item1 = Python::with_gil(|py| {
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 0)
-                .unwrap()
-                .into_py(py)
-                .into()
-        });
-        let found = clock.watermark(&Poll::Ready(Some(item1)));
+        let time1 = Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 0).unwrap();
+        let found = clock.watermark(&Poll::Ready(Some(time1)));
         assert_eq!(
             found,
             Utc.with_ymd_and_hms(2023, 3, 16, 8, 59, 50).unwrap(),
@@ -235,13 +237,8 @@ mod tests {
         );
 
         clock.source.now = Utc.with_ymd_and_hms(2023, 5, 10, 9, 0, 4).unwrap();
-        let item2 = Python::with_gil(|py| {
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 1, 0)
-                .unwrap()
-                .into_py(py)
-                .into()
-        });
-        let found = clock.watermark(&Poll::Ready(Some(item2)));
+        let time2 = Utc.with_ymd_and_hms(2023, 3, 16, 9, 1, 0).unwrap();
+        let found = clock.watermark(&Poll::Ready(Some(time2)));
         assert_eq!(
             found,
             Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 50).unwrap(),
@@ -249,13 +246,8 @@ mod tests {
         );
 
         clock.source.now = Utc.with_ymd_and_hms(2023, 5, 10, 9, 0, 6).unwrap();
-        let item3 = Python::with_gil(|py| {
-            Utc.with_ymd_and_hms(2023, 3, 16, 9, 1, 1)
-                .unwrap()
-                .into_py(py)
-                .into()
-        });
-        let found = clock.watermark(&Poll::Ready(Some(item3)));
+        let time3 = Utc.with_ymd_and_hms(2023, 3, 16, 9, 1, 1).unwrap();
+        let found = clock.watermark(&Poll::Ready(Some(time3)));
         assert_eq!(
             found,
             Utc.with_ymd_and_hms(2023, 3, 16, 9, 0, 52).unwrap(),

--- a/src/window/clock/system_clock.rs
+++ b/src/window/clock/system_clock.rs
@@ -44,7 +44,7 @@ pub(crate) struct SystemClock {
 }
 
 impl<V> Clock<V> for SystemClock {
-    fn watermark(&mut self, next_value: &Poll<Option<V>>) -> DateTime<Utc> {
+    fn watermark(&mut self, next_value: &Poll<Option<DateTime<Utc>>>) -> DateTime<Utc> {
         if let Poll::Ready(None) = next_value {
             self.eof = true;
         }
@@ -56,8 +56,8 @@ impl<V> Clock<V> for SystemClock {
         }
     }
 
-    fn time_for(&mut self, _item: &V) -> DateTime<Utc> {
-        Utc::now()
+    fn time_for(&mut self, _item: &Poll<std::option::Option<V>>) -> Poll<Option<DateTime<Utc>>> {
+        Poll::Ready(Some(Utc::now()))
     }
 
     fn snapshot(&self) -> TdPyAny {

--- a/src/window/clock/system_clock.rs
+++ b/src/window/clock/system_clock.rs
@@ -56,8 +56,8 @@ impl<V> Clock<V> for SystemClock {
         }
     }
 
-    fn time_for(&mut self, _item: &Poll<std::option::Option<V>>) -> Poll<Option<DateTime<Utc>>> {
-        Poll::Ready(Some(Utc::now()))
+    fn time_for(&mut self, _item: &V) -> DateTime<Utc> {
+        Utc::now()
     }
 
     fn snapshot(&self) -> TdPyAny {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -124,13 +124,13 @@ pub(crate) trait Clock<V> {
     ///
     /// This can mutate the [`ClockState`] on every call to ensure
     /// future calls are accurate.
-    fn watermark(&mut self, next_value: &Poll<Option<V>>) -> DateTime<Utc>;
+    fn watermark(&mut self, next_value: &Poll<Option<DateTime<Utc>>>) -> DateTime<Utc>;
 
     /// Get the time for an item.
     ///
     /// This can mutate the [`ClockState`] if noting that an item has
     /// arrived should advance the clock or something.
-    fn time_for(&mut self, value: &V) -> DateTime<Utc>;
+    fn time_for(&mut self, value: &Poll<Option<V>>) -> Poll<Option<DateTime<Utc>>>;
 
     /// Snapshot the internal state of this clock.
     ///
@@ -420,13 +420,13 @@ where
     ) -> Vec<Result<(WindowMetadata, R), WindowError<V>>> {
         let mut output = Vec::new();
 
-        let watermark = self.clock.watermark(&next_value);
+        let item_time = self.clock.time_for(&next_value);
+        let watermark = self.clock.watermark(&item_time);
+
         tracing::trace!("Watermark at {watermark:?}");
 
-        if let Poll::Ready(Some(value)) = next_value {
-            let item_time = self.clock.time_for(&value);
+        if let (Poll::Ready(Some(value)), Poll::Ready(Some(item_time))) = (next_value, item_time) {
             tracing::trace!("{value:?} has time {item_time:?}");
-
             for window_result in self.windower.insert(&watermark, &item_time) {
                 let value = value.clone();
                 match window_result {


### PR DESCRIPTION
This PR attempts to remove duplicate calls to `Clock.time_for`, and is related to, but not the ultimate fix for the performance issue demonstrated in this dataflow:

https://gist.github.com/damiondoesthings/b5d16d22d18f37675a8a76e318c1bc8c

The following is a benchmark between this branch and `main` using the dataflow in that gist as a benchmark.

```shell
❯ hyperfine \
                 --parameter-list branch_name main,deduplicate_time_for \
                 --setup "git checkout {branch_name}; maturin develop --release" \
                 "python -m bytewax.run examples.slow_wax"
Benchmark 1: python -m bytewax.run examples.slow_wax (branch_name = main)
  Time (mean ± σ):     13.964 s ±  1.383 s    [User: 5.072 s, System: 12.765 s]
  Range (min … max):   12.492 s … 16.433 s    10 runs

Benchmark 2: python -m bytewax.run examples.slow_wax (branch_name = deduplicate_time_for)
  Time (mean ± σ):      9.895 s ±  0.724 s    [User: 3.945 s, System: 8.302 s]
  Range (min … max):    8.485 s … 11.191 s    10 runs

Summary
  python -m bytewax.run examples.slow_wax (branch_name = deduplicate_time_for) ran
    1.41 ± 0.17 times faster than python -m bytewax.run examples.slow_wax (branch_name = main)
```