### PR TITLE
Refactors window boundary calculation to avoid overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ For help with updating to new Bytewax versions, please see the
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Fixes bug where items would be incorrectly marked as late in sliding
+  and tumbling windows in cases where the timestamps are very far from
+  the `align_to` parameter of the windower.
+
 - Adds `stateful_flat_map` operator.
 
 - *Breaking change* Removes `builder` argument from `stateful_map`.


### PR DESCRIPTION
Fixes https://github.com/bytewax/bytewax/issues/413

Use some slightly different number twiddling to calculate window boundaries so that there isn't an overflow when using item times that are very far from the `align_to` time. Instead of finding the window index and then multiplying by the offset to get the start time of each window, use the remainder from the index calculation to find the start of a nearby window and then adjust.