### PR TITLE
Refactor operators

### DIFF
--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -56,7 +56,7 @@ where
     ) -> PyResult<(Stream<S, TdPyAny>, Stream<S, TdPyAny>)> {
         let mut op_builder = OperatorBuilder::new(format!("{step_id}.branch"), self.scope());
 
-        let mut input = op_builder.new_input(self, Pipeline);
+        let mut self_handle = op_builder.new_input(self, Pipeline);
         let (mut output1, falses) = op_builder.new_output();
         let (mut output2, trues) = op_builder.new_output();
 

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -378,7 +378,7 @@ where
         op_builder.build(move |_| {
             let mut inbuf = Vec::new();
             move |_frontiers| {
-                let mut output_handle = output.activate();
+                let mut downstream_handle = downstream_output.activate();
 
                 input.for_each(|time, data| {
                     data.swap(&mut vector);

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -73,6 +73,7 @@ where
                     unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
                         let pred = predicate.as_ref(py);
                         for item in vector.drain(..) {
+                            let item = PyObject::from(item);
                             let res = pred
                                 .call1((item.clone_ref(py),))
                                 .reraise_with(|| {

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -61,7 +61,7 @@ where
         let (mut output2, trues) = op_builder.new_output();
 
         op_builder.build(move |_| {
-            let mut vector = Vec::new();
+            let mut inbuf = Vec::new();
             move |_frontiers| {
                 let mut output1_handle = output1.activate();
                 let mut output2_handle = output2.activate();

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -385,6 +385,7 @@ where
                     let mut out1 = output_handle.session(&time);
                     unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
                         for item in vector.drain(..) {
+                            let item = PyObject::from(item);
                             let (key, value) = item
                                 .extract::<(&PyAny, PyObject)>(py)
                                 .raise_with::<PyTypeError>(|| {

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -382,7 +382,7 @@ where
 
                 input.for_each(|time, data| {
                     data.swap(&mut vector);
-                    let mut out1 = output_handle.session(&time);
+                    let mut downstream_session = downstream_handle.session(&time);
                     unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
                         for item in vector.drain(..) {
                             let item = PyObject::from(item);

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -369,7 +369,7 @@ where
     S: Scope,
 {
     fn extract_key(&self, for_step_id: StepId) -> Stream<S, (StateKey, TdPyAny)> {
-        let mut op_builder = OperatorBuilder::new("extract_key".to_string(), self.scope());
+        let mut op_builder = OperatorBuilder::new(format!("{for_step_id}.extract_key"), self.scope());
         let mut input = op_builder.new_input(self, Pipeline);
 
         let (mut output, keyed_stream) = op_builder.new_output();

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -370,9 +370,9 @@ where
 {
     fn extract_key(&self, for_step_id: StepId) -> Stream<S, (StateKey, TdPyAny)> {
         let mut op_builder = OperatorBuilder::new(format!("{for_step_id}.extract_key"), self.scope());
-        let mut input = op_builder.new_input(self, Pipeline);
+        let mut self_handle = op_builder.new_input(self, Pipeline);
 
-        let (mut output, keyed_stream) = op_builder.new_output();
+        let (mut downstream_output, downstream) = op_builder.new_output();
 
         op_builder.build(move |_| {
             let mut vector = Vec::new();

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -375,7 +375,7 @@ where
         let (mut downstream_output, downstream) = op_builder.new_output();
 
         op_builder.build(move |_| {
-            let mut vector = Vec::new();
+            let mut inbuf = Vec::new();
             move |_frontiers| {
                 let mut output_handle = output.activate();
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -322,7 +322,7 @@ where
                             .get_upstream(py, &step, "up")
                             .reraise("core operator `branch` missing port")?;
 
-                        let (trues, falses) = up.branch(py, step_id, predicate)?;
+                        let (trues, falses) = up.branch(step_id, predicate)?;
 
                         streams
                             .insert_downstream(py, &step, "trues", trues)


### PR DESCRIPTION
This PR refactors the `branch` and `extract_key` operators to use Timely's `OperatorBuilder` and avoid taking the GIL in a tight loop.