### PR TITLE
refactor orderbook example to remove ordereddict

### DIFF
--- a/examples/orderbook.py
+++ b/examples/orderbook.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Dict, List, Optional
 
-
 import websockets
 from bytewax import operators as op
 from bytewax.connectors.stdio import StdOutSink
@@ -85,7 +84,8 @@ class OrderBookState:
 
             target_dict = self.asks if side == "sell" else self.bids
 
-            # If size is zero, remove the price level; otherwise, update/add the price level
+            # If size is zero, remove the price level; otherwise,
+            # update/add the price level
             if size == 0.0:
                 target_dict.pop(price, None)
             else:
@@ -96,7 +96,6 @@ class OrderBookState:
                 self.ask_price = min(self.asks.keys(), default=None)
             else:
                 self.bid_price = max(self.bids.keys(), default=None)
-
 
     def spread(self) -> float:
         return self.ask_price - self.bid_price  # type: ignore

--- a/examples/orderbook.py
+++ b/examples/orderbook.py
@@ -1,10 +1,9 @@
 import json
-from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import List, Optional
+from typing import Dict, List, Optional
 
-# pip install websockets
+
 import websockets
 from bytewax import operators as op
 from bytewax.connectors.stdio import StdOutSink
@@ -36,7 +35,7 @@ class CoinbasePartition(StatefulSourcePartition):
         agen = _ws_agen(product_id)
         self._batcher = batch_async(agen, timedelta(seconds=0.5), 100)
 
-    def next_batch(self, _sched):
+    def next_batch(self):
         return next(self._batcher)
 
     def snapshot(self):
@@ -65,69 +64,39 @@ class OrderBookSummary:
 
 @dataclass
 class OrderBookState:
-    bids: OrderedDict = field(default_factory=OrderedDict)
-    asks: OrderedDict = field(default_factory=OrderedDict)
+    bids: Dict[float, float] = field(default_factory=dict)
+    asks: Dict[float, float] = field(default_factory=dict)
     bid_price: Optional[float] = None
     ask_price: Optional[float] = None
 
     def update(self, data):
-        if len(self.bids) <= 0:
-            self.bids = OrderedDict(
-                (float(price), float(size)) for price, size in data["bids"]
-            )
-        # The bid_price is the highest priced buy limit order.
-        # since the bids are in order, the first item of our newly constructed bids
-        # will have our bid price, so we can track the best bid
-        if self.bid_price is None:
-            self.bid_price = next(iter(self.bids))
-        if len(self.asks) <= 0:
-            self.asks = OrderedDict(
-                (float(price), float(size)) for price, size in data["asks"]
-            )
-        # The ask price is the lowest priced sell limit order.
-        # since the asks are in order, the first item of our newly constructed
-        # asks will be our ask price, so we can track the best ask
-        if self.ask_price is None:
-            self.ask_price = next(iter(self.asks))
+        # Initialize bids and asks if they're empty
+        if not self.bids:
+            self.bids = {float(price): float(size) for price, size in data["bids"]}
+            self.bid_price = max(self.bids.keys(), default=None)
+        if not self.asks:
+            self.asks = {float(price): float(size) for price, size in data["asks"]}
+            self.ask_price = min(self.asks.keys(), default=None)
 
-        # We receive a list of lists here, normally it is only one change,
-        # but could be more than one.
-        if "changes" in data:
-            for update in data["changes"]:
-                price = float(update[1])
-                size = float(update[2])
-            if update[0] == "sell":
-                # first check if the size is zero and needs to be removed
-                if size == 0.0:
-                    try:
-                        del self.asks[price]
-                        # if it was the ask price removed,
-                        # update with new ask price
-                        if price <= self.ask_price:
-                            self.ask_price = min(self.asks.keys())
-                    except KeyError:
-                        # don't need to add price with size zero
-                        pass
-                else:
-                    self.asks[price] = size
-                    if price < self.ask_price:
-                        self.ask_price = price
-            if update[0] == "buy":
-                # first check if the size is zero and needs to be removed
-                if size == 0.0:
-                    try:
-                        del self.bids[price]
-                        # if it was the bid price removed,
-                        # update with new bid price
-                        if price >= self.bid_price:
-                            self.bid_price = max(self.bids.keys())
-                    except KeyError:
-                        # don't need to add price with size zero
-                        pass
-                else:
-                    self.bids[price] = size
-                    if price > self.bid_price:
-                        self.bid_price = price
+        # Process updates from the "changes" field in the data
+        for change in data.get("changes", []):
+            side, price_str, size_str = change
+            price, size = float(price_str), float(size_str)
+
+            target_dict = self.asks if side == "sell" else self.bids
+
+            # If size is zero, remove the price level; otherwise, update/add the price level
+            if size == 0.0:
+                target_dict.pop(price, None)
+            else:
+                target_dict[price] = size
+
+            # After update, recalculate the best bid and ask prices
+            if side == "sell":
+                self.ask_price = min(self.asks.keys(), default=None)
+            else:
+                self.bid_price = max(self.bids.keys(), default=None)
+
 
     def spread(self) -> float:
         return self.ask_price - self.bid_price  # type: ignore
@@ -162,11 +131,11 @@ def mapper(state, value):
     return (state, state.summarize())
 
 
-stats = op.stateful_map("order_book", inp, mapper)
+stats = op.stateful_map("orderbook", inp, mapper)
 # ('BTC-USD', (36905.39, 0.00334873, 36905.4, 1.6e-05, 0.010000000002037268))
 
 
-# filter on 0.1% spread as a per
+# # filter on 0.1% spread as a per
 def just_large_spread(prod_summary):
     product, summary = prod_summary
     return summary.spread / summary.ask_price > 0.0001


### PR DESCRIPTION
Last week I modified the orderbook guide to match the 0.19 version changes

Within the discussion the topic of refactoring code to remove ordered dictionaries came up (ordered by default Python >3.7). Proposed a change, change was approved. Bringing changes under the examples/orderbook.py file

[Discussion](https://github.com/bytewax/crypto-orderbook-app/pull/2#discussion_r1532760038)
