### PR TITLE
Fix an issue with session windows

### DIFF
--- a/src/window/clock/system_clock.rs
+++ b/src/window/clock/system_clock.rs
@@ -44,7 +44,7 @@ pub(crate) struct SystemClock {
 }
 
 impl<V> Clock<V> for SystemClock {
-    fn watermark(&mut self, next_value: &Poll<Option<DateTime<Utc>>>) -> DateTime<Utc> {
+    fn watermark(&mut self, _py: Python, next_value: &Poll<Option<V>>) -> DateTime<Utc> {
         if let Poll::Ready(None) = next_value {
             self.eof = true;
         }


### PR DESCRIPTION
This PR reverts part of #414, which introduced the bug described here #427

The ordering of calls in the previous code when using the `SystemClock` was causing the calculated watermark to come after the time for the item in the dataflow under Linux, and intermittently after the watermark time on aarch64, since https://doc.rust-lang.org/std/time/struct.SystemTime.html is represented with less precision on that platform.

PR #414 was introduced to avoid calling `time_for` twice, which has a performance penalty, but after the changes that moved the taking of the GIL in #418, the performance difference in my local benchmarks for reverting this change wasn't significant.