### PR TITLE
Adds a simple Mermaid diagram encoder

### DIFF
--- a/pysrc/bytewax/_encoder.py
+++ b/pysrc/bytewax/_encoder.py
@@ -126,7 +126,7 @@ def json_for(obj) -> Any:
     """Hook to extend the JSON serialization.
 
     Register new types via `@json_for.register`. See
-    {py:obj}`singledispatch` for more info.
+    {py:obj}`functools.singledispatch` for more info.
 
     If this contains nested un-serializeable types, this will be
     re-called with them later by {py:obj}`json.dumps`; you don't have


### PR DESCRIPTION
Adds a simple Mermaid diagram encoder that only shows top level operators and ignores debugging information like ports and stream IDs.

It might be useful to expose this publicly at some point?

Use it in the same way as all the other renderers:

```python
from bytewax._encoder import to_mermaid

print(to_mermaid(flow))
```

Here's an example of the output on the `examples/basic.py` dataflow:

```mermaid
flowchart TD
subgraph "basic (Dataflow)"
basic.inp["inp (input)"]
basic.e_o["e_o (branch)"]
basic.inp -- "down → up" --> basic.e_o
basic.halve["halve (map)"]
basic.e_o -- "trues → up" --> basic.halve
basic.double["double (map)"]
basic.e_o -- "falses → up" --> basic.double
basic.merge["merge (merge)"]
basic.halve -- "down → ups" --> basic.merge
basic.double -- "down → ups" --> basic.merge
basic.minus_one["minus_one (map)"]
basic.merge -- "down → up" --> basic.minus_one
basic.stringy["stringy (map)"]
basic.minus_one -- "down → up" --> basic.stringy
basic.out["out (output)"]
basic.stringy -- "down → up" --> basic.out
end
```