### PR TITLE
Allow jsonpickle to serialize numpy/pandas

### DIFF
--- a/pysrc/bytewax/serde.py
+++ b/pysrc/bytewax/serde.py
@@ -4,7 +4,12 @@ from abc import ABC, abstractmethod
 from typing import Any, cast
 
 import jsonpickle
+import jsonpickle.ext.numpy as jsonpickle_numpy
+import jsonpickle.ext.pandas as jsonpickle_pandas
 from typing_extensions import override
+
+jsonpickle_numpy.register_handlers()
+jsonpickle_pandas.register_handlers()
 
 
 class Serde(ABC):

--- a/pysrc/bytewax/serde.py
+++ b/pysrc/bytewax/serde.py
@@ -1,23 +1,26 @@
 """Serialization for recovery and transport."""
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, cast
 
 import jsonpickle
 from typing_extensions import override
 
+logger = logging.getLogger(__name__)
+
 try:
     import jsonpickle.ext.numpy as jsonpickle_numpy
 
     jsonpickle_numpy.register_handlers()
 except ImportError:
-    pass
+    logger.debug("Unable to register jsonpickle numpy extensions")
 try:
     import jsonpickle.ext.pandas as jsonpickle_pandas
 
     jsonpickle_pandas.register_handlers()
 except ImportError:
-    pass
+    logger.debug("Unable to register jsonpickle pandas handlers")
 
 
 class Serde(ABC):

--- a/pysrc/bytewax/serde.py
+++ b/pysrc/bytewax/serde.py
@@ -4,12 +4,20 @@ from abc import ABC, abstractmethod
 from typing import Any, cast
 
 import jsonpickle
-import jsonpickle.ext.numpy as jsonpickle_numpy
-import jsonpickle.ext.pandas as jsonpickle_pandas
 from typing_extensions import override
 
-jsonpickle_numpy.register_handlers()
-jsonpickle_pandas.register_handlers()
+try:
+    import jsonpickle.ext.numpy as jsonpickle_numpy
+
+    jsonpickle_numpy.register_handlers()
+except ImportError:
+    pass
+try:
+    import jsonpickle.ext.pandas as jsonpickle_pandas
+
+    jsonpickle_pandas.register_handlers()
+except ImportError:
+    pass
 
 
 class Serde(ABC):


### PR DESCRIPTION
This PR fixes an issue where `jsonpickle` will trigger a  `SIGSEGV (Address boundary error)` when deserializing from the recovery store if the state contains a Pandas Dataframe.

I was going to add a test for this case, but it would mean adding pandas as a dependency for our test suite.