### PR TITLE
Run Vermin twice, once for lib code 3.8- and once for dev code 3.12-

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,7 +63,8 @@ fmt-md *files: _assert-venv
 
 # Lint the code in the repo; runs in CI
 lint: _assert-venv
-    vermin pysrc/ pytests/ docs/ examples/ *.py
+    vermin --config-file vermin-lib.ini pysrc/ pytests/ examples/
+    vermin --config-file vermin-dev.ini docs/ *.py
     ruff check pysrc/ pytests/ docs/ examples/ *.py
     # TODO: Add `examples/` to mypy checking. Will require a lot of
     # fixup?

--- a/stubgen.py
+++ b/stubgen.py
@@ -18,7 +18,7 @@ import importlib
 import inspect
 import itertools
 from argparse import ArgumentParser
-from ast import unparse  # novermin
+from ast import unparse
 from dataclasses import dataclass
 from inspect import Parameter, Signature
 from types import (
@@ -32,7 +32,7 @@ from types import (
 )
 from typing import List, Mapping, Optional, Tuple, Union
 
-import graphlib  # novermin
+import graphlib
 from typing_extensions import Self, TypeVar
 
 _N = TypeVar("_N")

--- a/vermin-dev.ini
+++ b/vermin-dev.ini
@@ -1,6 +1,6 @@
 [vermin]
 show_tips = no
 eval_annotations = yes
-parse_comments = yes
+parse_comments = no
 only_show_violations = yes
-targets = 3.8-
+targets = 3.12-

--- a/vermin-lib.ini
+++ b/vermin-lib.ini
@@ -1,0 +1,6 @@
+[vermin]
+show_tips = no
+eval_annotations = yes
+parse_comments = no
+only_show_violations = yes
+targets = 3.8-


### PR DESCRIPTION
Since the dev env is now pinned to Python 3.12, let's make it a little
easier on ourselves and only assert that the acutal library code
supports 3.8. Runs `vermin` twice as part of `just lint` to do that.
