### PR TITLE
More type annotation fixups

### DIFF
--- a/pysrc/bytewax/operators/__init__.py
+++ b/pysrc/bytewax/operators/__init__.py
@@ -1626,7 +1626,7 @@ def join(
     step_id: str,
     *sides: KeyedStream[V],
     running: bool = ...,
-) -> KeyedStream[Iterable[V]]: ...
+) -> KeyedStream[Tuple[V, ...]]: ...
 
 
 @overload
@@ -1634,7 +1634,7 @@ def join(
     step_id: str,
     *sides: KeyedStream[Any],
     running: bool = ...,
-) -> KeyedStream[Iterable[Any]]: ...
+) -> KeyedStream[Tuple]: ...
 
 
 @operator

--- a/pysrc/bytewax/operators/windowing.py
+++ b/pysrc/bytewax/operators/windowing.py
@@ -1593,7 +1593,7 @@ def join_window(
     windower: Windower[Any],
     *sides: KeyedStream[V],
     product: bool = ...,
-) -> WindowOut[V, Iterable[V]]: ...
+) -> WindowOut[V, Tuple[V, ...]]: ...
 
 
 @overload
@@ -1603,7 +1603,7 @@ def join_window(
     windower: Windower[Any],
     *sides: KeyedStream[Any],
     product: bool = ...,
-) -> WindowOut[Any, Iterable[Any]]: ...
+) -> WindowOut[Any, Tuple]: ...
 
 
 @operator


### PR DESCRIPTION
- **Better typing on `merge`**
- **Add proper fallback overloads on `join`, `join_name`, and `merge`**
- **Adds generics on `Clock` and `Windower` arguments properly**
- **Add edge case overloads to `join_window` and `collect_window`**
