### PR TITLE
Advanced recovery - part one

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,7 +1,14 @@
+from datetime import timedelta
+from typing import Tuple
+
 import bytewax.operators as op
 from bytewax.connectors.stdio import StdOutSink
 from bytewax.dataflow import Dataflow
 from bytewax.testing import TestingSource
+
+# from bytewax.tracing import setup_tracing
+
+# setup_tracing(log_level="TRACE")
 
 
 def double(x: int) -> int:
@@ -16,8 +23,8 @@ def minus_one(x: int) -> int:
     return x - 1
 
 
-def stringy(x: int) -> str:
-    return f"<dance>{x}</dance>"
+def stringy(x: int) -> Tuple[str, str]:
+    return "all", f"<dance>{x}</dance>"
 
 
 flow = Dataflow("basic")
@@ -29,4 +36,5 @@ odds = op.map("double", branch.falses, double)
 combo = op.merge("merge", evens, odds)
 combo = op.map("minus_one", combo, minus_one)
 string_output = op.map("stringy", combo, stringy)
-op.output("out", string_output, StdOutSink())
+out = op.collect("collect", string_output, timedelta(seconds=10), 3)
+op.output("out", out, StdOutSink())

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,14 +1,7 @@
-from datetime import timedelta
-from typing import Tuple
-
 import bytewax.operators as op
 from bytewax.connectors.stdio import StdOutSink
 from bytewax.dataflow import Dataflow
 from bytewax.testing import TestingSource
-
-# from bytewax.tracing import setup_tracing
-
-# setup_tracing(log_level="TRACE")
 
 
 def double(x: int) -> int:
@@ -23,8 +16,8 @@ def minus_one(x: int) -> int:
     return x - 1
 
 
-def stringy(x: int) -> Tuple[str, str]:
-    return "all", f"<dance>{x}</dance>"
+def stringy(x: int) -> str:
+    return f"<dance>{x}</dance>"
 
 
 flow = Dataflow("basic")
@@ -36,5 +29,4 @@ odds = op.map("double", branch.falses, double)
 combo = op.merge("merge", evens, odds)
 combo = op.map("minus_one", combo, minus_one)
 string_output = op.map("stringy", combo, stringy)
-out = op.collect("collect", string_output, timedelta(seconds=10), 3)
-op.output("out", out, StdOutSink())
+op.output("out", string_output, StdOutSink())

--- a/pysrc/bytewax/_bytewax.pyi
+++ b/pysrc/bytewax/_bytewax.pyi
@@ -29,12 +29,6 @@ class RecoveryConfig:
 
     :type db_dir: pathlib.Path
 
-    :arg snapshot_serde: Format to use when encoding state snapshot
-        objects in the recovery partitions. Defaults to
-        {py:obj}`~bytewax.serde.JsonPickleSerde`.
-
-    :type snapshot_serde: typing.Optional[bytewax.serde.Serde]
-
     :arg backup: Class to use to save recovery files to a durable
         storage like amazon's S3.
 
@@ -49,7 +43,7 @@ class RecoveryConfig:
     """
     ...
 
-    def __init__(self, db_dir, snapshot_serde=None, backup=None, batch_backup=None):
+    def __init__(self, db_dir, backup=None, batch_backup=None):
         ...
 
     def __new__(cls, *args, **kwargs):
@@ -66,10 +60,6 @@ class RecoveryConfig:
 
     @property
     def db_dir(self):
-        ...
-
-    @property
-    def snapshot_serde(self):
         ...
 
 class TracingConfig:
@@ -100,18 +90,23 @@ def cluster_main(flow, addresses, proc_id, *, epoch_interval=None, recovery_conf
 
     Blocks until execution is complete.
 
-    ```python
-    >>> from bytewax.dataflow import Dataflow
-    >>> import bytewax.operators as op
-    >>> from bytewax.testing import TestingSource, cluster_main
-    >>> from bytewax.connectors.stdio import StdOutSink
-    >>> flow = Dataflow("my_df")
-    >>> s = op.input("inp", flow, TestingSource(range(3)))
-    >>> op.output("out", s, StdOutSink())
-    >>> # In a real example, use "host:port" of all other workers.
-    >>> addresses = []
-    >>> proc_id = 0
-    >>> cluster_main(flow, addresses, proc_id)
+    ```{testcode}
+    from bytewax.dataflow import Dataflow
+    import bytewax.operators as op
+    from bytewax.testing import TestingSource, cluster_main
+    from bytewax.connectors.stdio import StdOutSink
+
+    flow = Dataflow("my_df")
+    s = op.input("inp", flow, TestingSource(range(3)))
+    op.output("out", s, StdOutSink())
+
+    # In a real example, use "host:port" of all other workers.
+    addresses = []
+    proc_id = 0
+    cluster_main(flow, addresses, proc_id)
+    ```
+
+    ```{testoutput}
     0
     1
     2
@@ -156,15 +151,19 @@ def run_main(flow, *, epoch_interval=None, recovery_config=None):
 
     This is only used for unit testing. See `bytewax.run`.
 
-    ```python
-    >>> from bytewax.dataflow import Dataflow
-    >>> import bytewax.operators as op
-    >>> from bytewax.testing import TestingSource, run_main
-    >>> from bytewax.connectors.stdio import StdOutSink
-    >>> flow = Dataflow("my_df")
-    >>> s = op.input("inp", flow, TestingSource(range(3)))
-    >>> op.output("out", s, StdOutSink())
-    >>> run_main(flow)
+    ```{testcode}
+    from bytewax.dataflow import Dataflow
+    import bytewax.operators as op
+    from bytewax.testing import TestingSource, run_main
+    from bytewax.connectors.stdio import StdOutSink
+    flow = Dataflow("my_df")
+    s = op.input("inp", flow, TestingSource(range(3)))
+    op.output("out", s, StdOutSink())
+
+    run_main(flow)
+    ```
+
+    ```{testoutput}
     0
     1
     2
@@ -197,7 +196,7 @@ def setup_tracing(tracing_config=None, log_level=None):
     Note: To make this work, you have to keep a reference of the
     returned object.
 
-    % skip: next
+    % Skip this doctest because it requires starting the webserver.
 
     ```python
     from bytewax.tracing import setup_tracing
@@ -213,16 +212,6 @@ def setup_tracing(tracing_config=None, log_level=None):
         `"ERROR"`.
 
     :type log_level: str
-
-    """
-    ...
-
-def test_cluster(flow, *, epoch_interval=None, recovery_config=None, processes=1, workers_per_process=1):
-    """Execute a Dataflow by spawning multiple Python processes.
-
-    Blocks until execution is complete.
-
-    This function should only be used for testing purposes.
 
     """
     ...

--- a/pysrc/bytewax/backup.py
+++ b/pysrc/bytewax/backup.py
@@ -3,8 +3,8 @@
 Subclass the `Backup` class to create an object that will be used by the dataflow
 to manage the files used by the recovery system.
 
-Assumptions about the behavior of this storage:
-- Some sort of blob storage.
+Bytewax makes some assumptions about the behavior of this storage:
+- It's some sort of blob storage.
 - Files are write once. They do not need to be modified in-place and can be immutable.
 - Files can be deleted.
 - Enables listing of files by name in something like a single directory or bucket.
@@ -14,9 +14,7 @@ Assumptions about the behavior of this storage:
 - Read-after-write consistency for listing.
 """
 
-import glob
 import logging
-import shutil
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List
@@ -27,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 class Backup(ABC):
-    """TODO."""
+    """Backup to durable storage interface."""
 
     @abstractmethod
     def list_keys(self) -> List[str]:
@@ -48,7 +46,7 @@ class Backup(ABC):
     def delete(self, key: str):
         """Delete the given key from durable storage.
 
-        This is used for garbace collection/compaction.
+        This is used for garbage collection/compaction.
         """
         ...
 
@@ -74,36 +72,3 @@ class NoopBackup(Backup):
     @override
     def delete(self, key: str):
         pass
-
-
-class TestingBackup(Backup):
-    """TODO."""
-
-    def __init__(self, path="/tmp/bytewax/durable/"):
-        """TODO."""
-        self.path = Path(path)
-        self.path.mkdir(exist_ok=True)
-
-    @override
-    def list_keys(self) -> List[str]:
-        return glob.glob(self.path / "*.sqlite3")
-
-    @override
-    def upload(self, from_local: Path, to_key: str):
-        from_local = Path(from_local)
-        (self.path / to_key).mkdir(exist_ok=True)
-        dest = self.path / to_key / from_local.name
-        shutil.move(from_local, dest)
-
-    @override
-    def download(self, from_key: str, to_local: Path):
-        pass
-
-    @override
-    def delete(self, key: str):
-        pass
-
-
-def testing_backup(path="/tmp/bytewax/durable"):
-    """Return an instanced TestingBackup object."""
-    return TestingBackup(path)

--- a/pysrc/bytewax/backup.py
+++ b/pysrc/bytewax/backup.py
@@ -1,0 +1,109 @@
+"""Backup to durable storage interface.
+
+Subclass the `Backup` class to create an object that will be used by the dataflow
+to manage the files used by the recovery system.
+
+Assumptions about the behavior of this storage:
+- Some sort of blob storage.
+- Files are write once. They do not need to be modified in-place and can be immutable.
+- Files can be deleted.
+- Enables listing of files by name in something like a single directory or bucket.
+  Sub-directories or any more hierarchy are not needed.
+- File upload and deletion are atomic r.e. listing. Files either appear in the
+  listing with full contents, or do not appear; no half-written files.
+- Read-after-write consistency for listing.
+"""
+
+import glob
+import logging
+import shutil
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import List
+
+from typing_extensions import override
+
+logger = logging.getLogger(__name__)
+
+
+class Backup(ABC):
+    """TODO."""
+
+    @abstractmethod
+    def list_keys(self) -> List[str]:
+        """List files in the storage."""
+        ...
+
+    @abstractmethod
+    def upload(self, from_local: Path, to_key: str):
+        """Upload the given file to durable storage under the name `to_key`."""
+        ...
+
+    @abstractmethod
+    def download(self, from_key: str, to_local: Path):
+        """Download the given key from the durable storage to a local path."""
+        ...
+
+    @abstractmethod
+    def delete(self, key: str):
+        """Delete the given key from durable storage.
+
+        This is used for garbace collection/compaction.
+        """
+        ...
+
+
+class NoopBackup(Backup):
+    """NoopBackup.
+
+    This class is here just to be used as a default.
+    """
+
+    @override
+    def list_keys(self) -> List[str]:
+        return []
+
+    @override
+    def upload(self, from_local: Path, to_key: str):
+        pass
+
+    @override
+    def download(self, from_key: str, to_local: Path):
+        pass
+
+    @override
+    def delete(self, key: str):
+        pass
+
+
+class TestingBackup(Backup):
+    """TODO."""
+
+    def __init__(self, path="/tmp/bytewax/durable/"):
+        """TODO."""
+        self.path = Path(path)
+        self.path.mkdir(exist_ok=True)
+
+    @override
+    def list_keys(self) -> List[str]:
+        return glob.glob(self.path / "*.sqlite3")
+
+    @override
+    def upload(self, from_local: Path, to_key: str):
+        from_local = Path(from_local)
+        (self.path / to_key).mkdir(exist_ok=True)
+        dest = self.path / to_key / from_local.name
+        shutil.move(from_local, dest)
+
+    @override
+    def download(self, from_key: str, to_local: Path):
+        pass
+
+    @override
+    def delete(self, key: str):
+        pass
+
+
+def testing_backup(path="/tmp/bytewax/durable"):
+    """Return an instanced TestingBackup object."""
+    return TestingBackup(path)

--- a/pysrc/bytewax/recovery.py
+++ b/pysrc/bytewax/recovery.py
@@ -3,20 +3,10 @@
 import argparse
 from pathlib import Path
 
-from bytewax._bytewax import (
-    InconsistentPartitionsError,
-    MissingPartitionsError,
-    NoPartitionsError,
-    RecoveryConfig,
-    init_db_dir,
-)
+from bytewax._bytewax import RecoveryConfig
 
 __all__ = [
-    "InconsistentPartitionsError",
-    "NoPartitionsError",
-    "MissingPartitionsError",
     "RecoveryConfig",
-    "init_db_dir",
 ]
 
 
@@ -42,4 +32,3 @@ def _parse_args():
 
 if __name__ == "__main__":
     args = _parse_args()
-    init_db_dir(args.db_dir, args.part_count)

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -251,12 +251,13 @@ class TestingBackup(Backup):
 
     def __init__(self, path: Union[str, Path]):
         """Init and check that the directory exists."""
-        self.path = Path(path)
+        if isinstance(path, str):
+            self.path = Path(path)
         assert self.path.exists(), f"Local backup directory {self.path} doesn't exists!"
 
     @override
     def list_keys(self) -> List[str]:
-        return glob.glob(self.path / "*.sqlite3")
+        return glob.glob(self.path / "*")
 
     @override
     def upload(self, from_local: Union[str, Path], to_key: str):
@@ -266,7 +267,7 @@ class TestingBackup(Backup):
         shutil.move(from_local, dest)
 
     @override
-    def download(self, from_key: str, to_local: Path):
+    def download(self, from_key: str, to_local: Union[str, Path]):
         source = self.path / from_key
         shutil.move(source, to_local)
 

--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -13,6 +13,8 @@ from bytewax._bytewax import (
     cluster_main,
     run_main,
 )
+from bytewax.backup import Backup
+from bytewax.dataflow import Dataflow
 from bytewax.inputs import (
     AbortExecution,
     FixedPartitionedSource,
@@ -23,6 +25,8 @@ from bytewax.outputs import DynamicSink, StatelessSinkPartition
 from bytewax.run import (
     _create_arg_parser,
     _EnvDefault,
+    _locate_subclass,
+    _prepare_import,
 )
 
 __all__ = [

--- a/pysrc/bytewax/visualize.py
+++ b/pysrc/bytewax/visualize.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Literal
 from typing_extensions import Self
 
 from bytewax.dataflow import Dataflow, Operator
-from bytewax.run import _locate_dataflow, _prepare_import
+from bytewax.run import _locate_subclass, _prepare_import
 
 
 @dataclass(frozen=True)
@@ -378,7 +378,7 @@ def _parse_args() -> argparse.Namespace:
 
 def _visualize_main(import_str: str, output_format: _Formats, recursive: bool) -> None:
     mod_str, attr_str = _prepare_import(import_str)
-    flow = _locate_dataflow(mod_str, attr_str)
+    flow = _locate_subclass(mod_str, attr_str, Dataflow)
 
     if output_format == "json":
         out = to_json(flow)

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -6,7 +6,7 @@ This sets up our fixtures and logging.
 
 from datetime import datetime, timezone
 
-from bytewax.recovery import RecoveryConfig, init_db_dir
+from bytewax.recovery import RecoveryConfig
 from bytewax.testing import cluster_main, run_main
 from bytewax.tracing import setup_tracing
 from pytest import fixture
@@ -59,8 +59,7 @@ def recovery_config(tmp_path):
     It will point to a single partition recovery store.
 
     """
-    init_db_dir(tmp_path, 1)
-    yield RecoveryConfig(str(tmp_path))
+    yield RecoveryConfig(str(tmp_path), batch_backup=True)
 
 
 @fixture

--- a/pytests/operators/test_stateful.py
+++ b/pytests/operators/test_stateful.py
@@ -297,9 +297,9 @@ def test_stateful_recovers_older_snapshots(recovery_config):
         ("a", "a1"),
         TestingSource.ABORT(),
         ("b", "b1"),
-        ("b", "DISCARD"),
         TestingSource.ABORT(),
         ("c", "c1"),
+        ("b", "DISCARD"),
         TestingSource.ABORT(),
         ("a", "a2"),
         ("b", "b2"),
@@ -321,6 +321,13 @@ def test_stateful_recovers_older_snapshots(recovery_config):
     run_main(flow, epoch_interval=ZERO_TD, recovery_config=recovery_config)
     assert out == [
         ("b", (None, "b1")),
+    ]
+
+    out.clear()
+    run_main(flow, epoch_interval=ZERO_TD, recovery_config=recovery_config)
+    assert out == [
+        ("b", ("b1", "b1")),
+        ("c", (None, "c1")),
         ("b", ("b1", "DISCARD")),
     ]
 
@@ -328,13 +335,6 @@ def test_stateful_recovers_older_snapshots(recovery_config):
     run_main(flow, epoch_interval=ZERO_TD, recovery_config=recovery_config)
     assert out == [
         ("b", (None, "DISCARD")),
-        ("c", (None, "c1")),
-    ]
-
-    out.clear()
-    run_main(flow, epoch_interval=ZERO_TD, recovery_config=recovery_config)
-    assert out == [
-        ("c", ("c1", "c1")),
         ("a", ("a1", "a2")),
         ("b", (None, "b2")),
         ("c", ("c1", "c2")),

--- a/pytests/operators/test_stateful.py
+++ b/pytests/operators/test_stateful.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Tuple
 import bytewax.operators as op
 from bytewax.dataflow import Dataflow
 from bytewax.operators import StatefulLogic
+from bytewax.recovery import RecoveryConfig
 from bytewax.testing import TestingSink, TestingSource, run_main
 from typing_extensions import override
 
@@ -288,4 +289,53 @@ def test_stateful_snapshots_discard_per_key(recovery_config):
     assert out == [
         ("a", (None, "a3")),
         ("b", ("b2", "b3")),
+    ]
+
+
+def test_stateful_recovers_older_snapshots(recovery_config):
+    inp = [
+        ("a", "a1"),
+        TestingSource.ABORT(),
+        ("b", "b1"),
+        ("b", "DISCARD"),
+        TestingSource.ABORT(),
+        ("c", "c1"),
+        TestingSource.ABORT(),
+        ("a", "a2"),
+        ("b", "b2"),
+        ("c", "c2"),
+    ]
+    out = []
+
+    flow = Dataflow("test_df")
+    s = op.input("inp", flow, TestingSource(inp))
+    s = op.stateful("stateful", s, KeepLastLogic)
+    op.output("out", s, TestingSink(out))
+
+    run_main(flow, epoch_interval=ZERO_TD, recovery_config=recovery_config)
+    assert out == [
+        ("a", (None, "a1")),
+    ]
+
+    out.clear()
+    run_main(flow, epoch_interval=ZERO_TD, recovery_config=recovery_config)
+    assert out == [
+        ("b", (None, "b1")),
+        ("b", ("b1", "DISCARD")),
+    ]
+
+    out.clear()
+    run_main(flow, epoch_interval=ZERO_TD, recovery_config=recovery_config)
+    assert out == [
+        ("b", (None, "DISCARD")),
+        ("c", (None, "c1")),
+    ]
+
+    out.clear()
+    run_main(flow, epoch_interval=ZERO_TD, recovery_config=recovery_config)
+    assert out == [
+        ("c", ("c1", "c1")),
+        ("a", ("a1", "a2")),
+        ("b", (None, "b2")),
+        ("c", ("c1", "c2")),
     ]

--- a/pytests/test_parse.py
+++ b/pytests/test_parse.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from datetime import timedelta
 from unittest.mock import patch
 
 from bytewax.run import _parse_args, _prepare_import
@@ -30,32 +29,6 @@ def test_parse_args_environ(tmpdir):
             parsed = _parse_args()
             assert parsed.process_id == 0
             assert parsed.addresses == "localhost:1234;localhost:5678"
-
-
-def test_parse_backup_interval():
-    testargs = ["fake_command", "examples/basic.py:flow", "--backup-interval", "60"]
-    # Mock sys.argv to test that the parsing phase works well
-    with patch.object(sys, "argv", testargs):
-        parsed = _parse_args()
-        # Test the custom handling of the import_str
-        assert parsed.backup_interval == timedelta(minutes=1)
-
-
-def test_parse_backup_interval_zero():
-    testargs = [
-        "fake_command",
-        "examples/basic.py:flow",
-        "--recovery-directory",
-        "/fake/directory",
-        "--snapshot-interval",
-        "30",
-        "--backup-interval",
-        "0",
-    ]
-    # Mock sys.argv to test that the parsing phase works well
-    with patch.object(sys, "argv", testargs):
-        parsed = _parse_args()
-        assert parsed.backup_interval == timedelta(seconds=0)
 
 
 def test_prepare_import_file():

--- a/pytests/test_recovery.py
+++ b/pytests/test_recovery.py
@@ -9,12 +9,6 @@ ZERO_TD = timedelta(seconds=0)
 FIVE_TD = timedelta(seconds=5)
 
 
-def test_input_recovery(tmp_path):
-    recovery_config = RecoveryConfig(str(tmp_path))
-    inp = [0, 1, 2, TestingSource.ABORT(), 3, 4]
-    out = []
-
-
 def test_abort_no_snapshots(tmp_path):
     inp = [0, 1, 2, TestingSource.ABORT(), 3, 4]
     out = []
@@ -43,7 +37,7 @@ def test_abort_with_snapshots(tmp_path):
     s = op.input("inp", flow, TestingSource(inp))
     op.output("out", s, TestingSink(out))
 
-    # Setting immediate mode snapshot means we will have a snapshot after each item.
+    # Setting batch_backup to False means we will have a snapshot after each item.
     recovery_config = RecoveryConfig(str(tmp_path), batch_backup=False)
     run_main(flow, recovery_config=recovery_config)
     assert out == [0, 1, 2]

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -36,6 +36,10 @@ impl Dataflow {
     pub(crate) fn substeps(&self, py: Python) -> PyResult<Vec<Operator>> {
         self.0.getattr(py, "substeps")?.extract(py)
     }
+
+    pub(crate) fn flow_id(&self, py: Python) -> PyResult<String> {
+        self.0.getattr(py, "flow_id")?.extract(py)
+    }
 }
 
 pub(crate) struct Operator(PyObject);

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -211,7 +211,6 @@ impl FixedPartitionedSource {
         epoch_interval: EpochInterval,
         probe: &ProbeHandle<u64>,
         abort: &Arc<AtomicBool>,
-        start_at: ResumeEpoch,
         mut state: InputState,
     ) -> PyResult<(Stream<S, TdPyAny>, Stream<S, SerializedSnapshot>)>
     where
@@ -219,6 +218,7 @@ impl FixedPartitionedSource {
     {
         let recovery_on = state.recovery_on();
         let immediate_snapshot = state.immediate_snapshot();
+        let start_at = state.start_at();
         let this_worker = scope.w_index();
 
         let local_parts = self.list_parts(py).reraise_with(|| {

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -185,7 +185,7 @@ impl FixedPartitionedSource {
         step_id: &StepId,
         for_part: &StateKey,
         resume_state: Option<PyObject>,
-    ) -> PyResult<StatefulPartition> {
+    ) -> PyResult<StatefulSourcePartition> {
         self.0
             .call_method1(
                 py,
@@ -467,10 +467,10 @@ impl FixedPartitionedSource {
 }
 
 /// Represents a `bytewax.inputs.StatefulSourcePartition` in Python.
-pub(crate) struct StatefulPartition(Py<PyAny>);
+pub(crate) struct StatefulSourcePartition(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for StatefulPartition {
+impl<'py> FromPyObject<'py> for StatefulSourcePartition {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
@@ -492,7 +492,7 @@ pub(crate) enum BatchResult {
     Batch(Vec<PyObject>),
 }
 
-impl StatefulPartition {
+impl StatefulSourcePartition {
     pub(crate) fn next_batch(&self, py: Python) -> PyResult<BatchResult> {
         match self.0.bind(py).call_method0(intern!(py, "next_batch")) {
             Err(err) if err.is_instance_of::<PyStopIteration>(py) => Ok(BatchResult::Eof),
@@ -530,7 +530,7 @@ impl StatefulPartition {
     }
 }
 
-impl Drop for StatefulPartition {
+impl Drop for StatefulSourcePartition {
     fn drop(&mut self) {
         unwrap_any!(Python::with_gil(|py| self
             .close(py)

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -654,14 +654,9 @@ where
             let mut awoken_keys_buffer: BTreeSet<StateKey> = BTreeSet::new();
 
             move |input_frontiers| {
-                // CODE_NOTE: The _span_guard variable here will be dropped at the end of the
-                // function closing the tracing span. This way we avoid an indentation level
-                // compared to `.in_scope`.
-                let _span_guard = tracing::debug_span!("operator", operator = op_name).entered();
+                let _guard = tracing::debug_span!("operator", operator = op_name).entered();
 
                 // If the output capabilities have been dropped, do nothing here.
-                // CODE_NOTE: This is a bit of dance to do the early check, again to avoid
-                // an indentation level
                 if kv_downstream_cap.is_none() || snap_cap.is_none() {
                     // Make sure that if the input frontiers are closed,
                     // output capabilities are dropped too.

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -892,7 +892,7 @@ where
                                     // Drain `awoken_keys_buffer` since the epoch is over.
                                     std::mem::take(&mut awoken_keys_buffer)
                                         .iter()
-                                        .map(|key| state.snap(py, key, &epoch))
+                                        .map(|key| state.snap(py, key.clone(), epoch))
                                         .collect::<PyResult<Vec<SerializedSnapshot>>>()
                                 }));
                                 state.write_snapshots(snaps.clone());
@@ -913,7 +913,7 @@ where
                                 // at each change.
                                 std::mem::take(&mut awoken_keys_buffer)
                                     .iter()
-                                    .map(|key| state.snap(py, key, &epoch))
+                                    .map(|key| state.snap(py, key.clone(), epoch))
                                     .collect::<PyResult<Vec<SerializedSnapshot>>>()
                             }));
                             state.write_snapshots(snaps.clone());

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -446,7 +446,6 @@ where
         py: Python,
         step_id: StepId,
         builder: TdPyCallable,
-        resume_epoch: ResumeEpoch,
         state: StatefulBatchState,
     ) -> PyResult<(Stream<S, TdPyAny>, Stream<S, SerializedSnapshot>)>;
 }
@@ -558,11 +557,11 @@ where
         _py: Python,
         step_id: StepId,
         builder: TdPyCallable,
-        resume_epoch: ResumeEpoch,
         mut state: StatefulBatchState,
     ) -> PyResult<(Stream<S, TdPyAny>, Stream<S, SerializedSnapshot>)> {
         let recovery_on = state.recovery_on();
         let immediate_snapshot = state.immediate_snapshot();
+        let resume_epoch = state.start_at();
         let this_worker = self.scope().w_index();
 
         // We have a "partition" per worker. List all workers.

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -447,11 +447,11 @@ where
         step_id: StepId,
         builder: TdPyCallable,
         resume_epoch: ResumeEpoch,
-        loads: &Stream<S, Snapshot>,
-    ) -> PyResult<(Stream<S, TdPyAny>, Stream<S, Snapshot>)>;
+        state: StatefulBatchState,
+    ) -> PyResult<(Stream<S, TdPyAny>, Stream<S, SerializedSnapshot>)>;
 }
 
-struct StatefulBatchLogic(PyObject);
+pub(crate) struct StatefulBatchLogic(PyObject);
 
 /// Do some eager type checking.
 impl<'py> FromPyObject<'py> for StatefulBatchLogic {
@@ -470,7 +470,7 @@ impl<'py> FromPyObject<'py> for StatefulBatchLogic {
     }
 }
 
-enum IsComplete {
+pub(crate) enum IsComplete {
     Retain,
     Discard,
 }
@@ -509,7 +509,7 @@ impl StatefulBatchLogic {
         Ok((emit, is_complete))
     }
 
-    fn on_batch<'py>(
+    pub(crate) fn on_batch<'py>(
         &'py self,
         py: Python<'py>,
         items: Vec<PyObject>,
@@ -521,17 +521,20 @@ impl StatefulBatchLogic {
         Self::extract_ret(res).reraise("error extracting `(emit, is_complete)`")
     }
 
-    fn on_notify<'py>(&'py self, py: Python<'py>) -> PyResult<(Vec<PyObject>, IsComplete)> {
+    pub(crate) fn on_notify<'py>(
+        &'py self,
+        py: Python<'py>,
+    ) -> PyResult<(Vec<PyObject>, IsComplete)> {
         let res = self.0.bind(py).call_method0(intern!(py, "on_notify"))?;
         Self::extract_ret(res).reraise("error extracting `(emit, is_complete)`")
     }
 
-    fn on_eof<'py>(&'py self, py: Python<'py>) -> PyResult<(Vec<PyObject>, IsComplete)> {
+    pub(crate) fn on_eof<'py>(&'py self, py: Python<'py>) -> PyResult<(Vec<PyObject>, IsComplete)> {
         let res = self.0.bind(py).call_method0("on_eof")?;
         Self::extract_ret(res).reraise("error extracting `(emit, is_complete)`")
     }
 
-    fn notify_at(&self, py: Python) -> PyResult<Option<DateTime<Utc>>> {
+    pub(crate) fn notify_at(&self, py: Python) -> PyResult<Option<DateTime<Utc>>> {
         let res = self.0.bind(py).call_method0(intern!(py, "notify_at"))?;
         res.extract().reraise_with(|| {
             format!(
@@ -541,8 +544,8 @@ impl StatefulBatchLogic {
         })
     }
 
-    fn snapshot(&self, py: Python) -> PyResult<PyObject> {
-        self.0.call_method0(py, intern!(py, "snapshot"))
+    pub(crate) fn snapshot(&self, py: Python) -> PyResult<TdPyAny> {
+        Ok(self.0.call_method0(py, intern!(py, "snapshot"))?.into())
     }
 }
 
@@ -556,22 +559,21 @@ where
         step_id: StepId,
         builder: TdPyCallable,
         resume_epoch: ResumeEpoch,
-        loads: &Stream<S, Snapshot>,
-    ) -> PyResult<(Stream<S, TdPyAny>, Stream<S, Snapshot>)> {
+        mut state: StatefulBatchState,
+    ) -> PyResult<(Stream<S, TdPyAny>, Stream<S, SerializedSnapshot>)> {
+        let recovery_on = state.recovery_on();
+        let immediate_snapshot = state.immediate_snapshot();
         let this_worker = self.scope().w_index();
 
-        let loads = loads.filter_snaps(step_id.clone());
         // We have a "partition" per worker. List all workers.
         let workers = self.scope().w_count().iter().to_stream(&mut self.scope());
         // TODO: Could expose this above.
         let self_pf = BuildHasherDefault::<DefaultHasher>::default();
-        let loads_pf = BuildHasherDefault::<DefaultHasher>::default();
         let partd_self = self.extract_key(step_id.clone()).partition(
             format!("{step_id}.self_partition"),
             &workers,
             self_pf,
         );
-        let partd_loads = loads.partition(format!("{step_id}.load_partition"), &workers, loads_pf);
 
         let op_name = format!("{step_id}.stateful_batch");
         let mut op_builder = OperatorBuilder::new(op_name.clone(), self.scope());
@@ -581,11 +583,6 @@ where
 
         let mut input_handle = op_builder.new_input_connection(
             &partd_self,
-            routed_exchange(),
-            vec![Antichain::from_elem(0), Antichain::from_elem(0)],
-        );
-        let mut loads_handle = op_builder.new_input_connection(
-            &partd_loads,
             routed_exchange(),
             vec![Antichain::from_elem(0), Antichain::from_elem(0)],
         );
@@ -618,10 +615,6 @@ where
             .f64_histogram("stateful_batch_notify_at_duration_seconds")
             .with_description("`StatefulBatchLogic.notify_at` duration in seconds")
             .init();
-        let snapshot_histogram = meter
-            .f64_histogram("snapshot_duration_seconds")
-            .with_description("`snapshot` duration in seconds")
-            .init();
         let labels = vec![
             KeyValue::new("step_id", step_id.0.to_string()),
             KeyValue::new("worker_index", this_worker.0.to_string()),
@@ -631,24 +624,15 @@ where
             // We have to retain separate capabilities
             // per-output. This seems to be only documented in
             // https://github.com/TimelyDataflow/timely-dataflow/pull/187
-            // In reverse order because of how [`Vec::pop`] removes
-            // from back.
+            // In reverse order because of how [`Vec::pop`] removes from back.
             let mut snap_cap = init_caps.pop();
             let mut kv_downstream_cap = init_caps.pop();
 
-            // State for each key. There is only a single state for
-            // each key representing the state at the frontier epoch;
-            // we only modify state carefully in epoch order once we
-            // know we won't be getting any input on closed epochs.
-            let mut logics: BTreeMap<StateKey, StatefulBatchLogic> = BTreeMap::new();
             // Contains the last known return value for
             // `logic.notify_at` for each key (if any). We don't
             // snapshot this because the logic itself should contain
             // any notify times within.
             let mut sched_cache: BTreeMap<StateKey, DateTime<Utc>> = BTreeMap::new();
-
-            // Here we have "buffers" that store items across
-            // activations.
 
             // Persistent across activations buffer keeping track of
             // out-of-order inputs. Push in here when Timely says we
@@ -656,374 +640,308 @@ where
             // process. This spans activations and will have epochs
             // removed from it as the input frontier progresses.
             let mut inbuf = InBuffer::new();
-            let mut loads_inbuf = InBuffer::new();
+
             // Persistent across activations buffer of what keys were
             // awoken during the most recent epoch. This is used to
             // only snapshot state of keys that could have resulted in
-            // state modifications. This is drained after each epoch
-            // is processed.
+            // state modifications.
+            // Depending on the recovery config this is drained either
+            // all at once after each epoch is processed, or gradually
+            // while taking snapshots during the run.
             let mut awoken_keys_buffer: BTreeSet<StateKey> = BTreeSet::new();
 
             move |input_frontiers| {
-                tracing::debug_span!("operator", operator = op_name).in_scope(|| {
-                    if let (Some(output_cap), Some(state_update_cap)) =
-                        (kv_downstream_cap.as_mut(), snap_cap.as_mut())
-                    {
-                        assert!(output_cap.time() == state_update_cap.time());
+                // CODE_NOTE: The _span variable here will be dropped at the end of the function
+                // closing the tracing span. This way we avoid an indentation level compared
+                // to `.in_scope`.
+                let _span = tracing::debug_span!("operator", operator = op_name).entered();
 
-                        let now = chrono::offset::Utc::now();
-
-                        // Buffer the inputs so we can apply them to
-                        // the state cache in epoch order.
-                        input_handle.for_each(|cap, incoming| {
-                            let epoch = cap.time();
-                            inbuf.extend(*epoch, incoming);
-                        });
-                        loads_handle.for_each(|cap, incoming| {
-                            let epoch = cap.time();
-                            loads_inbuf.extend(*epoch, incoming);
-                        });
-
-                        let last_output_epoch = *output_cap.time();
-                        let frontier_epoch = input_frontiers
-                            .simplify()
-                            // If we're at EOF and there's no "current
-                            // epoch", use the last seen epoch to
-                            // still allow output. EagerNotificator
-                            // does not allow this.
-                            .unwrap_or(last_output_epoch);
-
-                        // Now let's find out which epochs we should
-                        // wake up the logic for.
-                        let mut process_epochs: BTreeSet<S::Timestamp> = BTreeSet::new();
-
-                        // On the last activation, we eagerly executed
-                        // the frontier at that time (which may or may
-                        // not still be the frontier), even though it
-                        // wasn't closed. Thus, we haven't run the
-                        // "epoch closed" code yet. Make sure that
-                        // close code is run, since we might not have
-                        // any incoming items in that epoch in this
-                        // activation.
-                        process_epochs.insert(last_output_epoch);
-
-                        // Try to process all the epochs we have input
-                        // for.
-                        process_epochs.extend(inbuf.epochs());
-                        process_epochs.extend(loads_inbuf.epochs());
-
-                        // Filter out epochs that are not closed; the
-                        // state at the beginning of those epochs are
-                        // not truly known yet, so we can't apply
-                        // input in those epochs yet.
-                        process_epochs.retain(|e| input_frontiers.is_closed(e));
-
-                        // Except... eagerly execute the current
-                        // frontier (even though it's not closed) as
-                        // long as it could actually get data. All
-                        // inputs will have a flash of their frontier
-                        // being 0 before the resume epoch.
-                        if frontier_epoch >= resume_epoch.0 {
-                            process_epochs.insert(frontier_epoch);
-                        }
-
-                        let mut kv_downstream_handle = kv_downstream_output.activate();
-                        let mut snaps_handle = snaps_output.activate();
-                        // For each epoch in order.
-                        for epoch in process_epochs {
-                            tracing::trace!("Processing epoch {epoch:?}");
-                            // Since the frontier has advanced to at
-                            // least this epoch (because we're going
-                            // through them in order), say that we'll
-                            // not be sending output at any older
-                            // epochs. This also asserts "apply
-                            // changes in epoch order" to the state
-                            // cache.
-                            output_cap.downgrade(&epoch);
-                            state_update_cap.downgrade(&epoch);
-
-                            let mut kv_downstream_session =
-                                kv_downstream_handle.session(&output_cap);
-
-                            // First, call `on_batch` for all the input
-                            // items.
-                            if let Some(items) = inbuf.remove(&epoch) {
-                                item_inp_count.add(items.len() as u64, &labels);
-
-                                let mut keyed_items: BTreeMap<StateKey, Vec<PyObject>> = BTreeMap::new();
-                                for (worker, (key, value)) in items {
-                                    assert!(worker == this_worker);
-                                    keyed_items.entry(key).or_default().push(PyObject::from(value));
-                                }
-
-                                unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
-                                    let builder = builder.bind(py);
-
-                                    for (key, values) in keyed_items {
-                                        // Ok, let's actually run the logic code!
-                                        // Pull out or build the logic for the
-                                        // current key.
-                                        let logic =
-                                            logics.entry(key.clone()).or_insert_with(|| {
-                                                unwrap_any!((|| {
-                                                    builder
-                                                        .call1((None::<PyObject>, ))?
-                                                        .extract::<StatefulBatchLogic>()
-                                                })(
-                                                ))
-                                            });
-
-                                        let (output, is_complete) = with_timer!(
-                                            on_batch_histogram,
-                                            labels,
-                                            logic
-                                                .on_batch(py, values)
-                                                .reraise_with(|| format!(
-                                                    "error calling `StatefulBatchLogic.on_batch` in step {step_id} for key {key}"
-                                                ))?
-                                        );
-
-                                        item_out_count.add(output.len() as u64, &labels);
-                                        for value in output {
-                                            kv_downstream_session.give((key.clone(), TdPyAny::from(value)));
-                                        }
-
-                                        if let IsComplete::Discard = is_complete {
-                                            logics.remove(&key);
-                                            sched_cache.remove(&key);
-                                        }
-
-                                        awoken_keys_buffer.insert(key);
-                                    }
-
-                                    Ok(())
-                                }));
-                            }
-
-                            // Then call all logic that has a due
-                            // notification.
-                            let notify_keys: Vec<_> = sched_cache
-                                .iter()
-                                .filter(|(_key, sched)| **sched <= now)
-                                .map(|(key, sched)| (key.clone(), *sched))
-                                .collect();
-                            if !notify_keys.is_empty() {
-                                unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
-                                    for (key, _sched) in notify_keys {
-                                        // We should always have a
-                                        // logic for anything in
-                                        // `sched_cache`. If not, we
-                                        // forgot to remove it when we
-                                        // cleared the logic.
-                                        let logic = logics.get(&key).unwrap();
-
-                                        let (output, is_complete) = with_timer!(
-                                            on_notify_histogram,
-                                            labels,
-                                            logic.on_notify(py).reraise_with(|| format!(
-                                                "error calling `StatefulBatchLogic.on_notify` in {step_id} for key {key}"
-                                            ))?
-                                        );
-
-                                        item_out_count.add(output.len() as u64, &labels);
-                                        for value in output {
-                                            kv_downstream_session.give((key.clone(), TdPyAny::from(value)));
-                                        }
-
-                                        if let IsComplete::Discard = is_complete {
-                                            logics.remove(&key);
-                                            sched_cache.remove(&key);
-                                        } else {
-                                            // Even if we don't
-                                            // discard the logic, the
-                                            // previous scheduled
-                                            // notification only
-                                            // should fire once. The
-                                            // logic can re-schedule
-                                            // it by still returning
-                                            // it in `notify_at`.
-                                            sched_cache.remove(&key);
-                                        }
-
-                                        awoken_keys_buffer.insert(key);
-                                    }
-
-                                    Ok(())
-                                }));
-                            }
-
-                            // Then if EOF, call all logic that still
-                            // exists.
-                            if input_frontiers.is_eof() {
-                                let mut discarded_keys = Vec::new();
-
-                                unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
-                                    for (key, logic) in logics.iter() {
-                                        let (output, is_complete) = with_timer!(
-                                            on_eof_histogram,
-                                            labels,
-                                            logic.on_eof(py).reraise_with(|| format!(
-                                                "error calling `StatefulBatchLogic.on_eof` in {step_id} for key {key}"
-                                            ))?
-                                        );
-
-                                        item_out_count.add(output.len() as u64, &labels);
-                                        for value in output {
-                                            kv_downstream_session.give((key.clone(), TdPyAny::from(value)));
-                                        }
-
-                                        if let IsComplete::Discard = is_complete {
-                                            discarded_keys.push(key.clone());
-                                        }
-
-                                        awoken_keys_buffer.insert(key.clone());
-                                    }
-
-                                    Ok(())
-                                }));
-
-                                for key in discarded_keys {
-                                    logics.remove(&key);
-                                    sched_cache.remove(&key);
-                                }
-                            }
-
-                            // Then go through all awoken keys and
-                            // update the next scheduled notification
-                            // times.
-                            if !awoken_keys_buffer.is_empty() {
-                                unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
-                                    for key in awoken_keys_buffer.iter() {
-                                        // It's possible the logic was
-                                        // discarded on a previous
-                                        // activation but the epoch
-                                        // hasn't ended so the key is
-                                        // still in
-                                        // `awoken_keys_buffer`.
-                                        if let Some(logic) = logics.get(key) {
-                                            let sched = with_timer!(
-                                                notify_at_histogram,
-                                                labels,
-                                                logic.notify_at(py).reraise_with(|| {
-                                                    format!("error calling `StatefulBatchLogic.notify_at` in {step_id} for key {key}")
-                                                })?
-                                            );
-                                            if let Some(sched) = sched {
-                                                sched_cache.insert(key.clone(), sched);
-                                            }
-                                        }
-                                    }
-
-                                    Ok(())
-                                }));
-                            }
-
-                            // Snapshot and output state changes.
-                            if input_frontiers.is_closed(&epoch) {
-                                // Snapshot before loads. If we have an
-                                // incoming load, it means we have
-                                // recovery state already at the end of
-                                // the epoch.
-
-                                let mut snaps_session = snaps_handle.session(&state_update_cap);
-
-                                // Go through all keys awoken in this
-                                // epoch. This might involve keys from the
-                                // previous activation.
-                                unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
-                                    // Finally drain
-                                    // `awoken_keys_buffer` since the
-                                    // epoch is over.
-                                    for key in std::mem::take(&mut awoken_keys_buffer) {
-                                        let change = if let Some(logic) = logics.get(&key) {
-                                            let state = with_timer!(
-                                                snapshot_histogram,
-                                                labels,
-                                                logic.snapshot(py).reraise_with(|| {
-                                                    format!("error calling `StatefulBatchLogic.snapshot` in {step_id} for key {key}")
-                                                })?
-                                            );
-                                            StateChange::Upsert(TdPyAny::from(state))
-                                        } else {
-                                            // It's ok if there's no
-                                            // logic, because during
-                                            // this epoch it might
-                                            // have been discarded due
-                                            // to one of the `on_*`
-                                            // methods returning
-                                            // `IsComplete::Discard`.
-                                            StateChange::Discard
-                                        };
-                                        let snap = Snapshot(step_id.clone(), key, change);
-                                        snaps_session.give(snap);
-                                    }
-
-                                    Ok(())
-                                }));
-
-                                if let Some(loads) = loads_inbuf.remove(&epoch) {
-                                    unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
-                                        let builder = builder.bind(py);
-
-                                        for (worker, (key, change)) in loads {
-                                            tracing::trace!(
-                                                "Got load for {key:?} during epoch {epoch:?}"
-                                            );
-                                            assert!(worker == this_worker);
-                                            match change {
-                                                StateChange::Upsert(state) => {
-                                                    let state: PyObject = state.into();
-
-                                                    let logic = builder
-                                                        .call1((Some(state),))?
-                                                        .extract::<StatefulBatchLogic>()?;
-                                                    if let Some(notify_at) = logic.notify_at(py)? {
-                                                        sched_cache.insert(key.clone(), notify_at);
-                                                    }
-                                                    logics.insert(key, logic);
-                                                }
-                                                StateChange::Discard => {
-                                                    logics.remove(&key);
-                                                    sched_cache.remove(&key);
-                                                }
-                                            }
-                                        }
-
-                                        Ok(())
-                                    }));
-                                }
-                            }
-                        }
-
-                        let load_frontier = &input_frontiers[1];
-                        if load_frontier.is_eof() {
-                            // Since we might emit downstream without any incoming
-                            // items, like on window timeout, ensure we FFWD to the
-                            // resume epoch.
-                            init_caps.downgrade_all(&resume_epoch.0);
-                        }
-
-                        // Schedule operator activation at the soonest
-                        // requested notify at for any key.
-                        if let Some(next_notify_at) =
-                            sched_cache.values().map(|notify_at| *notify_at - now).min()
-                        {
-                            activator.activate_after(
-                                next_notify_at.to_std().unwrap_or(std::time::Duration::ZERO),
-                            );
-                        }
-                    }
-
+                // If the outputs are None, do nothing here.
+                // CODE_NOTE: This is a bit of dance to do the early check, again to avoid
+                // an indentation level
+                if kv_downstream_cap.is_none() || snap_cap.is_none() {
+                    // Make sure that if the input frontiers are closed, we
+                    // still drop the capabilities.
                     if input_frontiers.is_eof() {
                         kv_downstream_cap = None;
                         snap_cap = None;
                     }
+                    return;
+                }
+
+                // We can unwrap here since we just checked.
+                let output_cap = kv_downstream_cap.as_mut().unwrap();
+                let state_update_cap = snap_cap.as_mut().unwrap();
+
+                // Start the processing logic. Both outputs should be in sync.
+                assert!(output_cap.time() == state_update_cap.time());
+
+                let now = chrono::offset::Utc::now();
+
+                // Buffer the inputs so we can apply them to the state cache in epoch order.
+                input_handle.for_each(|cap, incoming| {
+                    let epoch = cap.time();
+                    inbuf.extend(*epoch, incoming);
                 });
+
+                let last_output_epoch = *output_cap.time();
+                let frontier_epoch = input_frontiers
+                    .simplify()
+                    // If we're at EOF and there's no "current epoch", use the last seen
+                    // epoch to still allow output. EagerNotificator does not allow this.
+                    .unwrap_or(last_output_epoch);
+
+                // Now let's find out which epochs we should wake up the logic for.
+                let mut process_epochs: BTreeSet<S::Timestamp> = BTreeSet::new();
+
+                // On the last activation, we eagerly executed the frontier at that time
+                // (which may or may not still be the frontier), even though it wasn't
+                // closed. Thus, we haven't run the "epoch closed" code yet. Make sure
+                // that close code is run, since we might not have any incoming items in
+                // that epoch in this activation.
+                process_epochs.insert(last_output_epoch);
+
+                // Try to process all the epochs we have input for.
+                process_epochs.extend(inbuf.epochs());
+
+                // Filter out epochs that are not closed; the state at the beginning of
+                // those epochs are not truly known yet, so we can't apply input in those
+                // epochs yet.
+                process_epochs.retain(|e| input_frontiers.is_closed(e));
+
+                // Except... eagerly execute the current frontier (even though it's not
+                // closed) as long as it could actually get data. All inputs will have a
+                // flash of their frontier being 0 before the resume epoch.
+                if frontier_epoch >= resume_epoch.0 {
+                    process_epochs.insert(frontier_epoch);
+                }
+
+                let mut kv_downstream_handle = kv_downstream_output.activate();
+                let mut snaps_handle = snaps_output.activate();
+
+                // For each epoch in order.
+                for epoch in process_epochs {
+                    tracing::trace!("Processing epoch {epoch:?}");
+                    // Since the frontier has advanced to at least this epoch (because
+                    // we're going through them in order), say that we'll not be sending
+                    // output at any older epochs. This also asserts "apply changes in
+                    // epoch order" to the state cache.
+                    output_cap.downgrade(&epoch);
+                    state_update_cap.downgrade(&epoch);
+
+                    let mut kv_downstream_session = kv_downstream_handle.session(&output_cap);
+
+                    // First, call `on_batch` for all the input items.
+                    if let Some(items) = inbuf.remove(&epoch) {
+                        item_inp_count.add(items.len() as u64, &labels);
+
+                        // Check that the worker is the right one for each item,
+                        // then convert it to PyObject and save it into a temporary map.
+                        let mut keyed_items: BTreeMap<StateKey, Vec<PyObject>> = BTreeMap::new();
+                        for (worker, (key, value)) in items {
+                            assert!(worker == this_worker);
+                            keyed_items
+                                .entry(key)
+                                .or_default()
+                                .push(PyObject::from(value));
+                        }
+
+                        // Ok, now let's actually run the logic code for each item!
+                        unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
+                            // Only bind the builder once.
+                            let builder = builder.bind(py);
+
+                            for (key, values) in keyed_items {
+                                // Build the logic if it wasn't in the state yet.
+                                if !state.contains_key(&key) {
+                                    let logic = builder
+                                        .call1((None::<PyObject>,))
+                                        .reraise("Error building logic for stateful_batch")?
+                                        .extract::<StatefulBatchLogic>()
+                                        .reraise("Error converting logic to StatefulBatchLogic")?;
+                                    state.insert(key.clone(), logic);
+                                }
+
+                                // Run the logic's on_batch function
+                                let (output, is_complete) = with_timer!(
+                                    on_batch_histogram,
+                                    labels,
+                                    state.on_batch(py, &key, values)?
+                                );
+                                // Update metrics
+                                item_out_count.add(output.len() as u64, &labels);
+
+                                // And send the output downstream.
+                                for value in output {
+                                    kv_downstream_session.give((key.clone(), TdPyAny::from(value)));
+                                }
+
+                                // Now remove the state if needed.
+                                if let IsComplete::Discard = is_complete {
+                                    state.remove(&key);
+                                    sched_cache.remove(&key);
+                                }
+                                // Finally keep track of the fact that this key was awoken.
+                                awoken_keys_buffer.insert(key);
+                            }
+
+                            Ok(())
+                        }));
+                    }
+
+                    // Then call all logic that has a due notification.
+                    let notify_keys: Vec<_> = sched_cache
+                        .iter()
+                        .filter(|(_key, sched)| **sched <= now)
+                        .map(|(key, sched)| (key.clone(), *sched))
+                        .collect();
+
+                    if !notify_keys.is_empty() {
+                        unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
+                            for (key, _sched) in notify_keys {
+                                // We should always have a logic for anything in
+                                // `sched_cache`. If not, we forgot to remove it when we
+                                // cleared the logic. on_notify will fail in that case.
+                                let (output, is_complete) = with_timer!(
+                                    on_notify_histogram,
+                                    labels,
+                                    state.on_notify(py, &key)?
+                                );
+                                // Update metrics
+                                item_out_count.add(output.len() as u64, &labels);
+
+                                // Send the output downstream.
+                                for value in output {
+                                    kv_downstream_session.give((key.clone(), TdPyAny::from(value)));
+                                }
+
+                                // Clear the state if needed
+                                if let IsComplete::Discard = is_complete {
+                                    state.remove(&key);
+                                }
+
+                                // Even if we don't discard the logic, the previous
+                                // scheduled notification only should fire once. The
+                                // logic can re-schedule it by still returning it
+                                // in `notify_at`.
+                                sched_cache.remove(&key);
+                                awoken_keys_buffer.insert(key);
+                            }
+
+                            Ok(())
+                        }));
+                    }
+
+                    // Then if EOF, call all logic that still
+                    // exists.
+                    if input_frontiers.is_eof() {
+                        let mut discarded_keys = Vec::new();
+
+                        unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
+                            for key in state.keys() {
+                                let (output, is_complete) =
+                                    with_timer!(on_eof_histogram, labels, state.on_eof(py, &key)?);
+
+                                // Update metrics.
+                                item_out_count.add(output.len() as u64, &labels);
+                                // Send items downstream.
+                                for value in output {
+                                    kv_downstream_session.give((key.clone(), TdPyAny::from(value)));
+                                }
+
+                                // Keep track of the fact we need to discard this.
+                                // We'll do this later on for all the keys at once.
+                                if let IsComplete::Discard = is_complete {
+                                    discarded_keys.push(key.clone());
+                                }
+
+                                awoken_keys_buffer.insert(key.clone());
+                            }
+
+                            Ok(())
+                        }));
+
+                        for key in discarded_keys {
+                            state.remove(&key);
+                            sched_cache.remove(&key);
+                        }
+                    }
+
+                    // Then go through all awoken keys and update the next scheduled
+                    // notification times.
+                    if !awoken_keys_buffer.is_empty() {
+                        unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
+                            for key in awoken_keys_buffer.iter() {
+                                if let Some(sched) = with_timer!(
+                                    notify_at_histogram,
+                                    labels,
+                                    state.notify_at(py, key)?
+                                ) {
+                                    sched_cache.insert(key.clone(), sched);
+                                }
+                            }
+                            Ok(())
+                        }));
+                    }
+
+                    // Snapshot and output state changes.
+                    // This is the `batch` approach, `immediate` approach right after this
+                    if input_frontiers.is_closed(&epoch) {
+                        if recovery_on {
+                            // Go through all keys awoken in this epoch.
+                            // This might involve keys from the previous activation.
+                            let mut snaps_session = snaps_handle.session(&state_update_cap);
+                            unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
+                                // Drain `awoken_keys_buffer` since the epoch is over.
+                                let mut snaps = std::mem::take(&mut awoken_keys_buffer)
+                                    .iter()
+                                    .map(|key| state.snap(py, key, &epoch))
+                                    .collect::<PyResult<Vec<SerializedSnapshot>>>()?;
+                                state.write_snapshots(snaps.clone());
+                                snaps_session.give_vec(&mut snaps);
+                                Ok(())
+                            }));
+                        } else {
+                            awoken_keys_buffer.clear();
+                        }
+                    } else if immediate_snapshot {
+                        // Go through all keys awoken in this
+                        // epoch. This might involve keys from the
+                        // previous activation.
+                        let mut snaps_session = snaps_handle.session(&state_update_cap);
+                        unwrap_any!(Python::with_gil(|py| -> PyResult<()> {
+                            // Drain `awoken_keys_buffer` since we won't need this info
+                            // at the end of the epoch given we are snapshotting
+                            // at each change.
+                            let mut snaps = std::mem::take(&mut awoken_keys_buffer)
+                                .iter()
+                                .map(|key| state.snap(py, key, &epoch))
+                                .collect::<PyResult<Vec<SerializedSnapshot>>>()?;
+                            state.write_snapshots(snaps.clone());
+                            snaps_session.give_vec(&mut snaps);
+                            Ok(())
+                        }));
+                    }
+                }
+
+                // Schedule operator activation at the soonest
+                // requested notify at for any key.
+                if let Some(next_notify_at) =
+                    sched_cache.values().map(|notify_at| *notify_at - now).min()
+                {
+                    activator.activate_after(
+                        next_notify_at.to_std().unwrap_or(std::time::Duration::ZERO),
+                    );
+                }
+
+                if input_frontiers.is_eof() {
+                    kv_downstream_cap = None;
+                    snap_cap = None;
+                }
             }
         });
 
         let downstream = kv_downstream.wrap_key();
-
         Ok((downstream, snaps))
     }
 }

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -101,7 +101,7 @@ impl FixedPartitionedSink {
         step_id: &StepId,
         for_part: &StateKey,
         resume_state: Option<PyObject>,
-    ) -> PyResult<StatefulPartition> {
+    ) -> PyResult<StatefulSinkPartition> {
         self.0
             .call_method1(
                 py,
@@ -119,10 +119,10 @@ impl FixedPartitionedSink {
 }
 
 /// Represents a `bytewax.outputs.StatefulSinkPartition` in Python.
-pub(crate) struct StatefulPartition(Py<PyAny>);
+pub(crate) struct StatefulSinkPartition(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for StatefulPartition {
+impl<'py> FromPyObject<'py> for StatefulSinkPartition {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
@@ -138,7 +138,7 @@ impl<'py> FromPyObject<'py> for StatefulPartition {
     }
 }
 
-impl StatefulPartition {
+impl StatefulSinkPartition {
     pub(crate) fn write_batch(&self, py: Python, values: Vec<PyObject>) -> PyResult<()> {
         let _ = self
             .0
@@ -156,7 +156,7 @@ impl StatefulPartition {
     }
 }
 
-impl Drop for StatefulPartition {
+impl Drop for StatefulSinkPartition {
     fn drop(&mut self) {
         unwrap_any!(
             Python::with_gil(|py| self.close(py)).reraise("error closing StatefulSinkPartition")

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -339,7 +339,7 @@ where
                                                 snapshot_histogram,
                                                 labels,
                                                 state
-                                                    .snap(py, key, epoch)
+                                                    .snap(py, key.clone(), *epoch)
                                                     .reraise("error snapshotting StatefulSink")
                                             )
                                         )));
@@ -378,7 +378,7 @@ where
                                     snapshot_histogram,
                                     labels,
                                     state
-                                        .snap(py, key, epoch)
+                                        .snap(py, key.clone(), *epoch)
                                         .reraise("error snapshotting StatefulSink")
                                 ))));
                                 false

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -74,7 +74,7 @@ impl IntoPy<Py<PyAny>> for Backup {
 impl Default for Backup {
     fn default() -> Self {
         unwrap_any!(Python::with_gil(|py| {
-            get_dummy_backup(py).reraise("Error getting default Backup class")
+            get_testing_backup(py).reraise("Error getting default Backup class")
         }))
     }
 }
@@ -104,37 +104,17 @@ impl Backup {
     }
 }
 
-static BACKUP_MODULE: GILOnceCell<Py<PyModule>> = GILOnceCell::new();
+static TESTING_BACKUP: GILOnceCell<Backup> = GILOnceCell::new();
 
-fn get_backup_module(py: Python) -> PyResult<&Bound<'_, PyModule>> {
-    Ok(BACKUP_MODULE
-        .get_or_try_init(py, || -> PyResult<Py<PyModule>> {
-            Ok(py.import_bound("bytewax.backup")?.into())
-        })?
-        .bind(py))
-}
-
-static BACKUP_ABC: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
-
-fn get_backup_abc(py: Python) -> PyResult<&Bound<'_, PyAny>> {
-    Ok(BACKUP_ABC
-        .get_or_try_init(py, || -> PyResult<Py<PyAny>> {
-            Ok(get_backup_module(py)?.getattr("Backup")?.into())
-        })?
-        .bind(py))
-}
-
-static DUMMY_BACKUP: GILOnceCell<Backup> = GILOnceCell::new();
-
-fn get_dummy_backup(py: Python) -> PyResult<Backup> {
-    Ok(DUMMY_BACKUP
+fn get_testing_backup(py: Python) -> PyResult<Backup> {
+    Ok(TESTING_BACKUP
         .get_or_try_init(py, || -> PyResult<Backup> {
-            get_backup_module(py)
+            py.import_bound("bytewax.backup")
                 .reraise("Can't find backup module")?
                 .getattr("TestingBackup")
                 .reraise("Can't find TestingBackup")?
                 .call0()
-                .reraise("Error init")?
+                .reraise("Error initializing TestingBackup")?
                 .extract()
         })?
         .clone())
@@ -172,366 +152,56 @@ impl StatefulLogicKind {
             Self::Output(logic) => logic.snapshot(py),
         }
     }
-
-    pub(crate) fn as_input(&self) -> Result<&inputs::StatefulPartition, ()> {
+    pub(crate) fn as_input(&self) -> &inputs::StatefulPartition {
+        assert!(
+            matches!(self, Self::Input(_)),
+            "Trying to treat input state as a state for a different operator. \
+            This is a bug in Bytewax, aborting!"
+        );
         match self {
-            Self::Input(logic) => Ok(logic),
-            _ => Err(()),
+            Self::Input(logic) => logic,
+            _ => unreachable!(),
         }
     }
-
-    pub(crate) fn as_unary(&self) -> Result<&StatefulBatchLogic, ()> {
+    pub(crate) fn as_output(&self) -> &outputs::StatefulPartition {
+        assert!(
+            matches!(self, Self::Output(_)),
+            "Trying to treat output state as a state for a different operator. \
+            This is a bug in Bytewax, aborting!"
+        );
         match self {
-            Self::Stateful(logic) => Ok(logic),
-            _ => Err(()),
+            Self::Output(logic) => logic,
+            _ => unreachable!(),
         }
     }
-
-    pub(crate) fn as_output(&self) -> Result<&outputs::StatefulPartition, ()> {
+    pub(crate) fn as_stateful(&self) -> &StatefulBatchLogic {
+        assert!(
+            matches!(self, Self::Stateful(_)),
+            "Trying to treat stateful_batch state as a state for a different operator. \
+            This is a bug in Bytewax, aborting!"
+        );
         match self {
-            Self::Output(logic) => Ok(logic),
-            _ => Err(()),
+            Self::Stateful(logic) => logic,
+            _ => unreachable!(),
         }
     }
 }
 
-// TODO: Split the responsabilities between different structs, this one
-//       started as the state_store_cache but is now doing everything.
-pub(crate) struct StateStoreCache {
+pub(crate) struct StateStore {
     flow_id: String,
     worker_index: usize,
     worker_count: usize,
-    logics: HashMap<StepId, BTreeMap<StateKey, StatefulLogicKind>>,
-
     recovery_config: Option<RecoveryConfig>,
-    conn: Option<Rc<RefCell<Connection>>>,
+
+    cache: HashMap<StepId, BTreeMap<StateKey, StatefulLogicKind>>,
+    conn: Option<Connection>,
+
     resume_from: ResumeFrom,
     seg_num: u64,
     prev_epoch: u64,
 }
 
-/// Trait to group common operations that are used in all stateful operators.
-/// It just needs to know how to borrow the StateStoreCache and how to retrieve
-/// the step_id to manipulate state and local store.
-pub(crate) trait StateManager {
-    fn borrow_state(&self) -> Ref<StateStoreCache>;
-    fn borrow_state_mut(&self) -> RefMut<StateStoreCache>;
-    fn step_id(&self) -> &StepId;
-
-    fn snap(&self, py: Python, key: &StateKey, epoch: &u64) -> PyResult<SerializedSnapshot> {
-        self.borrow_state().snap(py, self.step_id(), key, epoch)
-    }
-    fn write_snapshots(&self, snaps: Vec<SerializedSnapshot>) {
-        self.borrow_state().write_snapshots(snaps);
-    }
-    fn recovery_on(&self) -> bool {
-        self.borrow_state().recovery_config.is_some()
-    }
-    fn immediate_snapshot(&self) -> bool {
-        self.borrow_state()
-            .recovery_config
-            .as_ref()
-            .is_some_and(|rc| !rc.batch_backup)
-    }
-    fn contains_key(&self, key: &StateKey) -> bool {
-        self.borrow_state().contains_key(self.step_id(), key)
-    }
-    fn insert(&self, key: StateKey, logic: impl Into<StatefulLogicKind>) {
-        self.borrow_state_mut()
-            .insert(self.step_id().clone(), key, logic.into());
-    }
-    fn remove(&mut self, key: &StateKey) {
-        self.borrow_state_mut().remove(self.step_id(), key);
-    }
-    fn keys(&self) -> Vec<StateKey> {
-        self.borrow_state()
-            .get_logics(self.step_id())
-            .keys()
-            .cloned()
-            .collect()
-    }
-}
-
-pub(crate) struct OutputState {
-    step_id: StepId,
-    state_store_cache: Rc<RefCell<StateStoreCache>>,
-}
-
-impl StateManager for OutputState {
-    fn borrow_state(&self) -> Ref<StateStoreCache> {
-        self.state_store_cache.borrow()
-    }
-
-    fn borrow_state_mut(&self) -> RefMut<StateStoreCache> {
-        self.state_store_cache.borrow_mut()
-    }
-
-    fn step_id(&self) -> &StepId {
-        &self.step_id
-    }
-}
-
-impl OutputState {
-    pub fn hydrate(&mut self, sink: &outputs::FixedPartitionedSink) {
-        Python::with_gil(|py| {
-            // Get the parts list. If any state_key is not part of this list,
-            // it means the parts changed since last execution, and we can't
-            // handle that.
-            let parts_list = unwrap_any!(sink.list_parts(py));
-
-            let builder = |state_key: &_, state| {
-                assert!(
-                    parts_list.contains(state_key),
-                    "State found for unknown key {} in the recovery store for {}. \
-                    Known partitions: {}. \
-                    Fixed partitions cannot change between executions, aborting.",
-                    state_key,
-                    &self.step_id,
-                    parts_list
-                        .iter()
-                        .map(|sk| format!("\"{}\"", sk.0))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-                let part = sink
-                    .build_part(py, &self.step_id, state_key, state)
-                    .unwrap();
-                StatefulLogicKind::Output(part)
-            };
-
-            self.state_store_cache
-                .borrow_mut()
-                .hydrate(&self.step_id, builder);
-        })
-    }
-
-    pub fn new(step_id: StepId, state_store_cache: Rc<RefCell<StateStoreCache>>) -> Self {
-        Self {
-            step_id,
-            state_store_cache,
-        }
-    }
-
-    pub fn write_batch(&self, py: Python, key: &StateKey, batch: Vec<PyObject>) -> PyResult<()> {
-        self.state_store_cache
-            .borrow()
-            .get(&self.step_id, key)
-            .unwrap()
-            .as_output()
-            .unwrap()
-            .write_batch(py, batch)
-    }
-}
-
-pub(crate) struct InputState {
-    step_id: StepId,
-    state_store_cache: Rc<RefCell<StateStoreCache>>,
-}
-
-impl StateManager for InputState {
-    fn borrow_state(&self) -> Ref<StateStoreCache> {
-        self.state_store_cache.borrow()
-    }
-
-    fn borrow_state_mut(&self) -> RefMut<StateStoreCache> {
-        self.state_store_cache.borrow_mut()
-    }
-
-    fn step_id(&self) -> &StepId {
-        &self.step_id
-    }
-}
-
-impl InputState {
-    pub fn new(step_id: StepId, state_store_cache: Rc<RefCell<StateStoreCache>>) -> Self {
-        Self {
-            step_id,
-            state_store_cache,
-        }
-    }
-
-    pub fn hydrate(&mut self, source: &inputs::FixedPartitionedSource) {
-        Python::with_gil(|py| {
-            // Get the parts list. If any state_key is not part of this list,
-            // it means the parts changed since last execution, and we can't
-            // handle that.
-            let parts_list = unwrap_any!(source.list_parts(py));
-
-            let builder = |state_key: &_, state| {
-                assert!(
-                    parts_list.contains(state_key),
-                    "State found for unknown key {} in the recovery store for {}. \
-                    Known partitions: {}. \
-                    Fixed partitions cannot change between executions, aborting.",
-                    state_key,
-                    self.step_id,
-                    parts_list
-                        .iter()
-                        .map(|sk| format!("\"{}\"", sk.0))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-
-                let part = source
-                    .build_part(py, &self.step_id, state_key, state)
-                    .unwrap();
-                StatefulLogicKind::Input(part)
-            };
-
-            self.state_store_cache
-                .borrow_mut()
-                .hydrate(&self.step_id, builder);
-        })
-    }
-    pub fn next_batch(&self, py: Python, key: &StateKey) -> PyResult<BatchResult> {
-        self.state_store_cache
-            .borrow()
-            .get(&self.step_id, key)
-            .unwrap()
-            .as_input()
-            .unwrap()
-            .next_batch(py)
-            .reraise_with(|| {
-                format!(
-                    "error calling `StatefulSourcePartition.next_batch` in \
-                    step {} for partition {}",
-                    self.step_id, key
-                )
-            })
-    }
-    pub fn next_awake(&self, py: Python, key: &StateKey) -> PyResult<Option<DateTime<Utc>>> {
-        self.state_store_cache
-            .borrow()
-            .get(&self.step_id, key)
-            .unwrap()
-            .as_input()
-            .unwrap()
-            .next_awake(py)
-            .reraise_with(|| {
-                format!(
-                    "error calling \
-                    `StatefulSourcePartition.next_awake` in \
-                    step {} for partition {}",
-                    self.step_id, key
-                )
-            })
-    }
-}
-
-pub(crate) struct StatefulBatchState {
-    step_id: StepId,
-    state_store_cache: Rc<RefCell<StateStoreCache>>,
-}
-
-impl StateManager for StatefulBatchState {
-    fn borrow_state(&self) -> Ref<StateStoreCache> {
-        self.state_store_cache.borrow()
-    }
-
-    fn borrow_state_mut(&self) -> RefMut<StateStoreCache> {
-        self.state_store_cache.borrow_mut()
-    }
-
-    fn step_id(&self) -> &StepId {
-        &self.step_id
-    }
-}
-
-impl StatefulBatchState {
-    pub fn new(step_id: StepId, state_store_cache: Rc<RefCell<StateStoreCache>>) -> Self {
-        Self {
-            step_id,
-            state_store_cache,
-        }
-    }
-    pub fn hydrate(&mut self, builder: &TdPyCallable) {
-        Python::with_gil(|py| {
-            let builder = builder.bind(py);
-            let state_builder = |_state_key: &_, state| {
-                let part = builder
-                    .call1((state,))
-                    .unwrap()
-                    .extract::<StatefulBatchLogic>()
-                    .unwrap();
-                StatefulLogicKind::Stateful(part)
-            };
-            self.state_store_cache
-                .borrow_mut()
-                .hydrate(&self.step_id, state_builder);
-        })
-    }
-    pub fn on_batch(
-        &self,
-        py: Python,
-        key: &StateKey,
-        values: Vec<PyObject>,
-    ) -> PyResult<(Vec<PyObject>, crate::operators::IsComplete)> {
-        self.borrow_state()
-            .get(&self.step_id, key)
-            .unwrap()
-            .as_unary()
-            .unwrap()
-            .on_batch(py, values)
-            .reraise_with(|| {
-                format!(
-                    "error calling `StatefulBatch.on_batch` in step {} for key {}",
-                    self.step_id, &key
-                )
-            })
-    }
-    pub fn on_notify(
-        &self,
-        py: Python,
-        key: &StateKey,
-    ) -> PyResult<(Vec<PyObject>, crate::operators::IsComplete)> {
-        self.state_store_cache
-            .borrow()
-            .get(&self.step_id, key)
-            .unwrap()
-            .as_unary()
-            .unwrap()
-            .on_notify(py)
-            .reraise_with(|| {
-                format!(
-                    "error calling `StatefulBatchLogic.on_notify` in {} for key {}",
-                    self.step_id, key
-                )
-            })
-    }
-    pub fn notify_at(&self, py: Python, key: &StateKey) -> PyResult<Option<DateTime<Utc>>> {
-        if let Some(logic) = self.state_store_cache.borrow().get(&self.step_id, key) {
-            logic.as_unary().unwrap().notify_at(py).reraise_with(|| {
-                format!(
-                    "error calling `StatefulBatchLogic.notify_at` in {} for key {}",
-                    self.step_id, key
-                )
-            })
-        } else {
-            Ok(None)
-        }
-    }
-    pub fn on_eof(
-        &self,
-        py: Python,
-        key: &StateKey,
-    ) -> PyResult<(Vec<PyObject>, crate::operators::IsComplete)> {
-        self.state_store_cache
-            .borrow()
-            .get(&self.step_id, key)
-            .unwrap()
-            .as_unary()
-            .unwrap()
-            .on_eof(py)
-            .reraise_with(|| {
-                format!(
-                    "error calling `StatefulBatchLogic.on_eof` in {} for key {}",
-                    self.step_id, key
-                )
-            })
-    }
-}
-
-impl StateStoreCache {
+impl StateStore {
     pub fn new(
         recovery_config: Option<RecoveryConfig>,
         flow_id: String,
@@ -574,11 +244,8 @@ impl StateStoreCache {
             })
             .unwrap_or_default();
 
-        // Wrap the connection into Rc and RefCell so we can share it among operators.
-        let conn = conn.map(|conn| Rc::new(RefCell::new(conn)));
-
         Ok(Self {
-            logics: HashMap::new(),
+            cache: HashMap::new(),
             recovery_config,
             conn,
             flow_id,
@@ -590,36 +257,33 @@ impl StateStoreCache {
         })
     }
 
-    fn add_step(&mut self, step_id: StepId) {
-        // We never want to add a step twice, so panic if that's tried.
-        assert!(
-            !self.logics.contains_key(&step_id),
-            "Trying to hydrate state twice, this is probably a bug"
-        );
-        self.logics.insert(step_id.clone(), Default::default());
-    }
-
     pub fn hydrate(
         &mut self,
         step_id: &StepId,
         builder: impl Fn(&StateKey, Option<PyObject>) -> StatefulLogicKind,
-    ) {
-        self.add_step(step_id.clone());
+    ) -> PyResult<()> {
+        // We never want to add a step twice, so panic if that's tried.
+        assert!(
+            !self.cache.contains_key(step_id),
+            "Trying to hydrate state twice, this is probably a bug"
+        );
+        self.cache.insert(step_id.clone(), Default::default());
 
         // If no db connection is present, we don't need to do anything else.
         if self.conn.is_none() {
-            return;
+            return Ok(());
         }
 
         // Get all the snapshots in the store for this specific step_id,
         // deserialize them, then call the builder function to make them
         // the right StatefulLogicKind variant.
-        let deserialized_snaps: Vec<_> = Python::with_gil(|py| {
-            let pickle = unwrap_any!(py.import_bound("pickle"));
-            self.conn
+        let deserialized_snaps = Python::with_gil(|py| -> PyResult<Vec<_>> {
+            let pickle = py.import_bound("pickle")?;
+            Ok(self
+                .conn
                 .as_ref()
+                // Unwrap here since we already checked conn is some.
                 .unwrap()
-                .borrow_mut()
                 // Retrieve all the snapshots for the latest epoch saved
                 // in the recovery store that's <= than resume_from..
                 .prepare(
@@ -628,7 +292,7 @@ impl StateStoreCache {
                     WHERE epoch <= ?1 AND step_id = ?2
                     GROUP BY step_id, state_key",
                 )
-                .unwrap()
+                .reraise("Error preparing query for recovery db.")?
                 .query_map((&self.resume_from.1 .0, &step_id.0), |row| {
                     Ok(SerializedSnapshot(
                         StepId(row.get(0)?),
@@ -637,7 +301,7 @@ impl StateStoreCache {
                         row.get(3)?,
                     ))
                 })
-                .unwrap()
+                .reraise("Error binding query parameters in recovery store")?
                 .map(|res| res.expect("Error unpacking SerializedSnapshot"))
                 .map(|SerializedSnapshot(_, key, _, ser_state)| {
                     let state = ser_state.map(|ser_state| {
@@ -651,16 +315,13 @@ impl StateStoreCache {
                     });
                     (key, state)
                 })
-                .collect()
-        });
+                .collect())
+        })?;
 
         for (state_key, state) in deserialized_snaps {
-            self.insert(
-                step_id.clone(),
-                state_key.clone(),
-                builder(&state_key, state),
-            );
+            self.insert(step_id, state_key.clone(), builder(&state_key, state));
         }
+        Ok(())
     }
 
     pub fn backup(&self) -> Option<Backup> {
@@ -681,56 +342,36 @@ impl StateStoreCache {
             .is_some_and(|rc| !rc.batch_backup)
     }
 
+    // Api for managing the store from here on.
+    // Always assume that the step_id is present, as we expect it to be added
+    // when the operator is instanced. If that's not the case, it's a bug
+    // on our side and we should abort.
     pub fn get(&self, step_id: &StepId, key: &StateKey) -> Option<&StatefulLogicKind> {
-        self.logics.get(step_id).and_then(|s| s.get(key))
+        self.cache.get(step_id).unwrap().get(key)
     }
 
     pub fn get_logics(&self, step_id: &StepId) -> &BTreeMap<StateKey, StatefulLogicKind> {
-        self.logics.get(step_id).unwrap()
+        self.cache.get(step_id).unwrap()
     }
 
     pub fn contains_key(&self, step_id: &StepId, key: &StateKey) -> bool {
-        self.logics.get(step_id).unwrap().contains_key(key)
+        self.cache.get(step_id).unwrap().contains_key(key)
     }
 
-    pub fn insert(&mut self, step_id: StepId, key: StateKey, logic: StatefulLogicKind) {
-        self.logics.entry(step_id).or_default().insert(key, logic);
+    pub fn insert(&mut self, step_id: &StepId, key: StateKey, logic: StatefulLogicKind) {
+        self.cache.get_mut(step_id).unwrap().insert(key, logic);
     }
 
     pub fn remove(&mut self, step_id: &StepId, key: &StateKey) -> Option<StatefulLogicKind> {
-        self.logics.get_mut(step_id).and_then(|s| s.remove(key))
+        self.cache.get_mut(step_id).unwrap().remove(key)
     }
 
-    fn ser_snap(
-        &self,
-        py: Python,
-        step_id: StepId,
-        key: StateKey,
-        snap_change: StateChange,
-        epoch: u64,
-    ) -> PyResult<SerializedSnapshot> {
-        let ser_change = match snap_change {
-            StateChange::Upsert(snap) => {
-                let snap = PyObject::from(snap);
-                let pickle = py.import_bound("pickle").unwrap();
-                let ser_snap = pickle
-                    .call_method1(intern!(py, "dumps"), (snap.bind(py),))
-                    .unwrap()
-                    .downcast::<PyBytes>()
-                    .unwrap()
-                    .as_bytes()
-                    .to_vec();
-                Some(ser_snap)
-            }
-            StateChange::Discard => None,
-        };
-
-        let snap_epoch = SnapshotEpoch(epoch);
-        Ok(SerializedSnapshot(step_id, key, snap_epoch, ser_change))
-    }
-
-    pub(crate) fn write_snapshots(&self, snaps: Vec<SerializedSnapshot>) {
-        let mut conn = self.conn.as_ref().unwrap().borrow_mut();
+    pub(crate) fn write_snapshots(&mut self, snaps: Vec<SerializedSnapshot>) {
+        assert!(
+            self.conn.is_some(),
+            "Trying to snapshot state without an open db connection"
+        );
+        let conn = self.conn.as_mut().unwrap();
         let txn = conn.transaction().unwrap();
         for snap in snaps {
             tracing::trace!("Writing {snap:?}");
@@ -751,21 +392,43 @@ impl StateStoreCache {
     pub fn snap(
         &self,
         py: Python,
-        step_id: &StepId,
-        key: &StateKey,
-        epoch: &u64,
+        step_id: StepId,
+        key: StateKey,
+        epoch: u64,
     ) -> PyResult<SerializedSnapshot> {
-        let change = if let Some(logic) = self.get(step_id, key) {
-            let state = logic.snapshot(py).reraise_with(|| {
-                format!("error calling `StatefulBatchLogic.snapshot` in {step_id} for key {key}")
-            })?;
+        let snap_change = if let Some(logic) = self.get(&step_id, &key) {
+            let state = logic
+                .snapshot(py)
+                .reraise_with(|| format!("error calling `snapshot` in {step_id} for key {key}"))?;
             StateChange::Upsert(state)
         } else {
-            // It's ok if there's no logic, because during this epoch it might have been discarded
+            // It's ok if there's no logic, because it might have been discarded
             // due to one of the `on_*` methods returning `IsComplete::Discard`.
             StateChange::Discard
         };
-        self.ser_snap(py, step_id.clone(), key.clone(), change.clone(), *epoch)
+
+        let ser_change = match snap_change {
+            StateChange::Upsert(snap) => {
+                let snap = PyObject::from(snap);
+                let pickle = py.import_bound(intern!(py, "pickle"))?;
+                let ser_snap = pickle
+                    .call_method1(intern!(py, "dumps"), (snap.bind(py),))
+                    .reraise("Error serializing snapshot")?
+                    .downcast::<PyBytes>()
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec();
+                Some(ser_snap)
+            }
+            StateChange::Discard => None,
+        };
+
+        Ok(SerializedSnapshot(
+            step_id,
+            key,
+            SnapshotEpoch(epoch),
+            ser_change,
+        ))
     }
 
     pub fn open_segment(&mut self, epoch: u64) -> (Connection, PathBuf) {
@@ -804,9 +467,9 @@ impl StateStoreCache {
     pub fn frontier_query(&self, txn: &Transaction, epoch: u64) -> PyResult<()> {
         txn.execute(
             "INSERT INTO meta (flow_id, ex_num, worker_index, worker_count, cluster_frontier)
-                 VALUES (?1, ?2, ?3, ?4, ?5)
-                 ON CONFLICT (flow_id, ex_num, worker_index) DO UPDATE
-                 SET cluster_frontier = EXCLUDED.cluster_frontier",
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT (flow_id, ex_num, worker_index) DO UPDATE
+            SET cluster_frontier = EXCLUDED.cluster_frontier",
             (
                 &self.flow_id,
                 self.resume_from.0 .0,
@@ -820,17 +483,346 @@ impl StateStoreCache {
     }
 
     pub fn write_frontier(&mut self, epoch: u64) -> PyResult<()> {
-        if let Some(conn) = self.conn.as_ref() {
-            let mut borrowed_conn = conn.borrow_mut();
-            let txn = borrowed_conn.transaction().unwrap();
-            tracing::trace!("Writing epoch {epoch:?}");
-            self.frontier_query(&txn, epoch)?;
-            txn.commit().reraise("Error committing cluster_frontier")
-        } else {
-            Err(tracked_err::<PyRuntimeError>(
-                "DB Connection lost before writing frontier",
-            ))
+        assert!(
+            self.conn.is_some(),
+            "Trying to snapshot state without an open db connection"
+        );
+        let conn = self.conn.as_mut().unwrap();
+        let txn = conn.transaction().unwrap();
+        tracing::trace!("Writing epoch {epoch:?}");
+        txn.execute(
+            "INSERT INTO meta (flow_id, ex_num, worker_index, worker_count, cluster_frontier)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT (flow_id, ex_num, worker_index) DO UPDATE
+            SET cluster_frontier = EXCLUDED.cluster_frontier",
+            (
+                &self.flow_id,
+                self.resume_from.0 .0,
+                self.worker_index,
+                self.worker_count,
+                epoch,
+            ),
+        )
+        .reraise("Error initing transaction")?;
+        txn.commit().reraise("Error committing cluster_frontier")
+    }
+}
+
+/// Trait to group common operations that are used in all stateful operators.
+/// It just needs to know how to borrow the StateStore and how to retrieve
+/// the step_id to manipulate state and local store.
+pub(crate) trait StateManager {
+    fn borrow_state(&self) -> Ref<StateStore>;
+    fn borrow_state_mut(&self) -> RefMut<StateStore>;
+    fn step_id(&self) -> &StepId;
+
+    fn snap(&self, py: Python, key: StateKey, epoch: u64) -> PyResult<SerializedSnapshot> {
+        self.borrow_state()
+            .snap(py, self.step_id().clone(), key, epoch)
+    }
+    fn write_snapshots(&self, snaps: Vec<SerializedSnapshot>) {
+        self.borrow_state_mut().write_snapshots(snaps);
+    }
+    fn recovery_on(&self) -> bool {
+        self.borrow_state().recovery_config.is_some()
+    }
+    fn immediate_snapshot(&self) -> bool {
+        self.borrow_state()
+            .recovery_config
+            .as_ref()
+            .is_some_and(|rc| !rc.batch_backup)
+    }
+    fn contains_key(&self, key: &StateKey) -> bool {
+        self.borrow_state().contains_key(self.step_id(), key)
+    }
+    fn insert(&self, key: StateKey, logic: impl Into<StatefulLogicKind>) {
+        self.borrow_state_mut()
+            .insert(self.step_id(), key, logic.into());
+    }
+    fn remove(&mut self, key: &StateKey) {
+        self.borrow_state_mut().remove(self.step_id(), key);
+    }
+    fn keys(&self) -> Vec<StateKey> {
+        self.borrow_state()
+            .get_logics(self.step_id())
+            .keys()
+            .cloned()
+            .collect()
+    }
+}
+
+pub(crate) struct OutputState {
+    step_id: StepId,
+    state_store: Rc<RefCell<StateStore>>,
+}
+
+impl StateManager for OutputState {
+    fn borrow_state(&self) -> Ref<StateStore> {
+        self.state_store.borrow()
+    }
+
+    fn borrow_state_mut(&self) -> RefMut<StateStore> {
+        self.state_store.borrow_mut()
+    }
+
+    fn step_id(&self) -> &StepId {
+        &self.step_id
+    }
+}
+
+impl OutputState {
+    pub fn hydrate(&mut self, sink: &outputs::FixedPartitionedSink) -> PyResult<()> {
+        Python::with_gil(|py| {
+            // Get the parts list. If any state_key is not part of this list,
+            // it means the parts changed since last execution, and we can't
+            // handle that.
+            let parts_list = unwrap_any!(sink.list_parts(py));
+
+            let builder = |state_key: &_, state| {
+                assert!(
+                    parts_list.contains(state_key),
+                    "State found for unknown key {} in the recovery store for {}. \
+                    Known partitions: {}. \
+                    Fixed partitions cannot change between executions, aborting.",
+                    state_key,
+                    &self.step_id,
+                    parts_list
+                        .iter()
+                        .map(|sk| format!("\"{}\"", sk.0))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                let part = sink
+                    .build_part(py, &self.step_id, state_key, state)
+                    .unwrap();
+                StatefulLogicKind::Output(part)
+            };
+
+            self.state_store
+                .borrow_mut()
+                .hydrate(&self.step_id, builder)
+        })
+    }
+
+    pub fn new(step_id: StepId, state_store: Rc<RefCell<StateStore>>) -> Self {
+        Self {
+            step_id,
+            state_store,
         }
+    }
+
+    pub fn write_batch(&self, py: Python, key: &StateKey, batch: Vec<PyObject>) -> PyResult<()> {
+        self.state_store
+            .borrow()
+            .get(&self.step_id, key)
+            .unwrap()
+            .as_output()
+            .write_batch(py, batch)
+    }
+}
+
+pub(crate) struct InputState {
+    step_id: StepId,
+    state_store: Rc<RefCell<StateStore>>,
+}
+
+impl StateManager for InputState {
+    fn borrow_state(&self) -> Ref<StateStore> {
+        self.state_store.borrow()
+    }
+
+    fn borrow_state_mut(&self) -> RefMut<StateStore> {
+        self.state_store.borrow_mut()
+    }
+
+    fn step_id(&self) -> &StepId {
+        &self.step_id
+    }
+}
+
+impl InputState {
+    pub fn new(step_id: StepId, state_store: Rc<RefCell<StateStore>>) -> Self {
+        Self {
+            step_id,
+            state_store,
+        }
+    }
+
+    pub fn hydrate(&mut self, source: &inputs::FixedPartitionedSource) -> PyResult<()> {
+        Python::with_gil(|py| {
+            // Get the parts list. If any state_key is not part of this list,
+            // it means the parts changed since last execution, and we can't
+            // handle that.
+            let parts_list = unwrap_any!(source.list_parts(py));
+
+            let builder = |state_key: &_, state| {
+                assert!(
+                    parts_list.contains(state_key),
+                    "State found for unknown key {} in the recovery store for {}. \
+                    Known partitions: {}. \
+                    Fixed partitions cannot change between executions, aborting.",
+                    state_key,
+                    self.step_id,
+                    parts_list
+                        .iter()
+                        .map(|sk| format!("\"{}\"", sk.0))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+
+                let part = source
+                    .build_part(py, &self.step_id, state_key, state)
+                    .unwrap();
+                StatefulLogicKind::Input(part)
+            };
+
+            self.state_store
+                .borrow_mut()
+                .hydrate(&self.step_id, builder)
+        })
+    }
+
+    pub fn next_batch(&self, py: Python, key: &StateKey) -> PyResult<BatchResult> {
+        self.state_store
+            .borrow()
+            .get(&self.step_id, key)
+            .unwrap()
+            .as_input()
+            .next_batch(py)
+            .reraise_with(|| {
+                format!(
+                    "error calling `StatefulSourcePartition.next_batch` in \
+                    step {} for partition {}",
+                    self.step_id, key
+                )
+            })
+    }
+
+    pub fn next_awake(&self, py: Python, key: &StateKey) -> PyResult<Option<DateTime<Utc>>> {
+        self.state_store
+            .borrow()
+            .get(&self.step_id, key)
+            .unwrap()
+            .as_input()
+            .next_awake(py)
+            .reraise_with(|| {
+                format!(
+                    "error calling \
+                    `StatefulSourcePartition.next_awake` in \
+                    step {} for partition {}",
+                    self.step_id, key
+                )
+            })
+    }
+}
+
+pub(crate) struct StatefulBatchState {
+    step_id: StepId,
+    state_store: Rc<RefCell<StateStore>>,
+}
+
+impl StateManager for StatefulBatchState {
+    fn borrow_state(&self) -> Ref<StateStore> {
+        self.state_store.borrow()
+    }
+
+    fn borrow_state_mut(&self) -> RefMut<StateStore> {
+        self.state_store.borrow_mut()
+    }
+
+    fn step_id(&self) -> &StepId {
+        &self.step_id
+    }
+}
+
+impl StatefulBatchState {
+    pub fn new(step_id: StepId, state_store: Rc<RefCell<StateStore>>) -> Self {
+        Self {
+            step_id,
+            state_store,
+        }
+    }
+    pub fn hydrate(&mut self, builder: &TdPyCallable) -> PyResult<()> {
+        Python::with_gil(|py| {
+            let builder = builder.bind(py);
+            let state_builder = |_state_key: &_, state| {
+                let part = builder
+                    .call1((state,))
+                    .unwrap()
+                    .extract::<StatefulBatchLogic>()
+                    .unwrap();
+                StatefulLogicKind::Stateful(part)
+            };
+            self.state_store
+                .borrow_mut()
+                .hydrate(&self.step_id, state_builder)
+        })
+    }
+    pub fn on_batch(
+        &self,
+        py: Python,
+        key: &StateKey,
+        values: Vec<PyObject>,
+    ) -> PyResult<(Vec<PyObject>, crate::operators::IsComplete)> {
+        self.borrow_state()
+            .get(&self.step_id, key)
+            .unwrap()
+            .as_stateful()
+            .on_batch(py, values)
+            .reraise_with(|| {
+                format!(
+                    "error calling `StatefulBatch.on_batch` in step {} for key {}",
+                    self.step_id, &key
+                )
+            })
+    }
+    pub fn on_notify(
+        &self,
+        py: Python,
+        key: &StateKey,
+    ) -> PyResult<(Vec<PyObject>, crate::operators::IsComplete)> {
+        self.state_store
+            .borrow()
+            .get(&self.step_id, key)
+            .unwrap()
+            .as_stateful()
+            .on_notify(py)
+            .reraise_with(|| {
+                format!(
+                    "error calling `StatefulBatchLogic.on_notify` in {} for key {}",
+                    self.step_id, key
+                )
+            })
+    }
+    pub fn notify_at(&self, py: Python, key: &StateKey) -> PyResult<Option<DateTime<Utc>>> {
+        if let Some(logic) = self.state_store.borrow().get(&self.step_id, key) {
+            logic.as_stateful().notify_at(py).reraise_with(|| {
+                format!(
+                    "error calling `StatefulBatchLogic.notify_at` in {} for key {}",
+                    self.step_id, key
+                )
+            })
+        } else {
+            Ok(None)
+        }
+    }
+    pub fn on_eof(
+        &self,
+        py: Python,
+        key: &StateKey,
+    ) -> PyResult<(Vec<PyObject>, crate::operators::IsComplete)> {
+        self.state_store
+            .borrow()
+            .get(&self.step_id, key)
+            .unwrap()
+            .as_stateful()
+            .on_eof(py)
+            .reraise_with(|| {
+                format!(
+                    "error calling `StatefulBatchLogic.on_eof` in {} for key {}",
+                    self.step_id, key
+                )
+            })
     }
 }
 
@@ -1057,7 +1049,7 @@ impl RecoveryConfig {
             backup
         } else {
             Python::with_gil(|py| {
-                get_dummy_backup(py).reraise("Error getting default Backup class")
+                get_testing_backup(py).reraise("Error getting default Backup class")
             })?
         };
 
@@ -1161,140 +1153,18 @@ fn migrations_valid() -> rusqlite_migration::Result<()> {
     Python::with_gil(|py| get_migrations(py).validate())
 }
 
-trait FrontierOp<S, D>
-where
-    S: Scope,
-    D: Data,
-{
-    /// Emit downstream this worker's current frontier.
-    ///
-    /// Although the [`ExecutionNumber`] and [`WorkerIndex`] are both
-    /// already within the [`FrontierMeta`], duplicate them in the key
-    /// position so we can partition and route on them.
-    ///
-    /// The emit happens just before the frontier advances, and thus
-    /// is actually within the previous epoch.
-    ///
-    /// Doesn't emit the "empty frontier" (even though that is the
-    /// true frontier) on dataflow termination to allow dataflow
-    /// continuation.
-    fn frontier(
-        &self,
-        resume_from: ResumeFrom,
-    ) -> Stream<S, ((ExecutionNumber, WorkerIndex), FrontierMeta)>;
-}
-
-impl<S, D> FrontierOp<S, D> for Stream<S, D>
-where
-    S: Scope<Timestamp = u64>,
-    D: Data,
-{
-    fn frontier(
-        &self,
-        resume_from: ResumeFrom,
-    ) -> Stream<S, ((ExecutionNumber, WorkerIndex), FrontierMeta)> {
-        let worker_index = self.scope().w_index();
-        let ResumeFrom(ex_num, resume_epoch) = resume_from;
-
-        // We can't use a notificator for progress because it's
-        // possible a worker, due to partitioning, will have no input
-        // data. We still need to write out that the worker made it
-        // through the resume epoch in that case.
-        let name = String::from("worker_frontier");
-        let mut op_builder = OperatorBuilder::new(name.clone(), self.scope());
-
-        let mut input = op_builder.new_input(self, Pipeline);
-
-        let (mut frontiers_output, frontiers) = op_builder.new_output();
-
-        // Sort of "emit at end of epoch" but Timely doesn't give us
-        // that.
-        op_builder.build(move |mut init_caps| {
-            // Since we might emit downstream without any incoming
-            // items, like reporting progress on EOF, ensure we FFWD
-            // to the resume epoch.
-            init_caps.downgrade_all(&resume_epoch.0);
-            let mut cap = init_caps.pop();
-
-            let mut inbuf = Vec::new();
-
-            move |input_frontiers| {
-                tracing::debug_span!("operator", operator = name).in_scope(|| {
-                    input.for_each(|_cap, incoming| {
-                        assert!(inbuf.is_empty());
-                        incoming.swap(&mut inbuf);
-                        // We have to drain the incoming data, but we just
-                        // care about the epoch so drop it.
-                        inbuf.clear();
-                    });
-
-                    cap = cap.take().and_then(|cap| {
-                        let frontier = input_frontiers.simplify();
-                        // EOF counts as progress. This will also filter
-                        // out the flash of 0 epoch upon resume.
-                        let frontier_progressed = frontier.map_or(true, |f| f > *cap.time());
-                        if frontier_progressed {
-                            // There's no way to guarantee that "last
-                            // frontier + 1" is actually the resume epoch
-                            // on the next execution, but mark that this
-                            // worker is ready to resume there on
-                            // EOF. It's also possible that this results
-                            // in a "too small" resume epoch: if for some
-                            // reason this operator isn't activated during
-                            // every epoch, we might miss the "largest"
-                            // epoch and so we'll mark down the resume
-                            // epoch as one too small. That's fine, we
-                            // just might resume further back than is
-                            // optimal.
-                            let frontier_epoch = frontier.unwrap_or(*cap.time() + 1);
-                            let front =
-                                FrontierMeta(ex_num, worker_index, ClusterFrontier(frontier_epoch));
-                            tracing::trace!("Frontier now epoch {frontier_epoch:?}");
-                            let key = (ex_num, worker_index);
-
-                            // Do not delay cap before the write; we will
-                            // delay downstream progress messages longer than
-                            // necessary if so. This would manifest as
-                            // resuming from an epoch that seems "too
-                            // early". Write out the progress at the end of
-                            // each epoch and where the frontier has moved.
-                            frontiers_output.activate().session(&cap).give((key, front));
-
-                            // If EOF, drop caps after the write.
-                            frontier.map(|f| {
-                                // We should never delay to something like
-                                // frontier + 1, otherwise chained progress
-                                // operators will "drift" forward and GC will
-                                // happen too early. If the frontier is empty,
-                                // also drop the capability.
-                                cap.delayed(&f)
-                            })
-                        // If there was no frontier progress on this
-                        // awake, maintain the current cap and do nothing.
-                        } else {
-                            Some(cap)
-                        }
-                    });
-                });
-            }
-        });
-
-        frontiers
-    }
-}
-
 pub(crate) trait CompactFrontiersOp<S>
 where
     S: Scope,
 {
-    fn compact_frontiers(&self, state_store_cache: Rc<RefCell<StateStoreCache>>) -> ClockStream<S>;
+    fn compact_frontiers(&self, state_store: Rc<RefCell<StateStore>>) -> ClockStream<S>;
 }
 
 impl<S> CompactFrontiersOp<S> for ClockStream<S>
 where
     S: Scope<Timestamp = u64>,
 {
-    fn compact_frontiers(&self, state_store_cache: Rc<RefCell<StateStoreCache>>) -> ClockStream<S> {
+    fn compact_frontiers(&self, state_store: Rc<RefCell<StateStore>>) -> ClockStream<S> {
         let mut op_builder = OperatorBuilder::new("frontier_compactor".to_string(), self.scope());
         let mut input = op_builder.new_input(self, Pipeline);
         let (mut output, clock) = op_builder.new_output();
@@ -1313,7 +1183,7 @@ where
                         let cap = &caps[0];
                         let epoch = cap.time();
                         // Write cluster frontier
-                        unwrap_any!(state_store_cache.borrow_mut().write_frontier(*epoch));
+                        unwrap_any!(state_store.borrow_mut().write_frontier(*epoch));
                         // And finally allow the dataflow to advance its epoch.
                         output.activate().session(cap).give(());
                     },
@@ -1328,20 +1198,14 @@ pub(crate) trait FrontierSegmentOp<S>
 where
     S: Scope,
 {
-    fn frontier_segment(
-        &self,
-        state_store_cache: Rc<RefCell<StateStoreCache>>,
-    ) -> Stream<S, PathBuf>;
+    fn frontier_segment(&self, state_store: Rc<RefCell<StateStore>>) -> Stream<S, PathBuf>;
 }
 
 impl<S> FrontierSegmentOp<S> for ClockStream<S>
 where
     S: Scope<Timestamp = u64>,
 {
-    fn frontier_segment(
-        &self,
-        state_store_cache: Rc<RefCell<StateStoreCache>>,
-    ) -> Stream<S, PathBuf> {
+    fn frontier_segment(&self, state_store: Rc<RefCell<StateStore>>) -> Stream<S, PathBuf> {
         let mut op_builder = OperatorBuilder::new("frontier_compactor".to_string(), self.scope());
         let mut input = op_builder.new_input(self, Pipeline);
         let (mut segments_output, segments) = op_builder.new_output();
@@ -1363,15 +1227,12 @@ where
                         let mut session = handle.session(clock_cap);
 
                         let epochs = inbuffer.epochs().collect::<Vec<_>>();
+                        let mut state = state_store.borrow_mut();
                         for epoch in epochs {
-                            let (mut conn, file_name) =
-                                state_store_cache.borrow_mut().open_segment(epoch);
+                            let (mut conn, file_name) = state.open_segment(epoch);
                             let txn = conn.transaction().unwrap();
                             inbuffer.remove(&epoch);
-                            state_store_cache
-                                .borrow()
-                                .frontier_query(&txn, epoch)
-                                .unwrap();
+                            state.frontier_query(&txn, epoch).unwrap();
                             txn.commit().unwrap();
                             session.give(file_name);
                         }
@@ -1454,20 +1315,14 @@ pub(crate) trait CompactorOp<S>
 where
     S: Scope,
 {
-    fn compact_snapshots(
-        &self,
-        state_store_cache: Rc<RefCell<StateStoreCache>>,
-    ) -> Stream<S, PathBuf>;
+    fn compact_snapshots(&self, state_store: Rc<RefCell<StateStore>>) -> Stream<S, PathBuf>;
 }
 
 impl<S> CompactorOp<S> for Stream<S, SerializedSnapshot>
 where
     S: Scope<Timestamp = u64>,
 {
-    fn compact_snapshots(
-        &self,
-        state_store_cache: Rc<RefCell<StateStoreCache>>,
-    ) -> Stream<S, PathBuf> {
+    fn compact_snapshots(&self, state_store: Rc<RefCell<StateStore>>) -> Stream<S, PathBuf> {
         let mut op_builder = OperatorBuilder::new("compactor".to_string(), self.scope());
         let mut input = op_builder.new_input(self, Pipeline);
 
@@ -1475,7 +1330,7 @@ where
         let (mut batch_segments_output, batch_segments) = op_builder.new_output();
         let segments = immediate_segments.concatenate(vec![batch_segments]);
 
-        let immediate_snapshot = state_store_cache.borrow().immediate_snapshot();
+        let immediate_snapshot = state_store.borrow().immediate_snapshot();
 
         op_builder.build(move |init_caps| {
             // TODO: EagerNotificator is probably not the right tool here
@@ -1499,7 +1354,7 @@ where
                             let epochs = inbuffer.borrow().epochs().collect::<Vec<_>>();
                             for epoch in epochs {
                                 let (mut conn, file_name) =
-                                    state_store_cache.borrow_mut().open_segment(epoch);
+                                    state_store.borrow_mut().open_segment(epoch);
                                 let txn = conn.transaction().unwrap();
                                 for snap in inbuffer.borrow_mut().remove(&epoch).unwrap() {
                                     let SerializedSnapshot(
@@ -1531,7 +1386,7 @@ where
                         let epochs = inbuffer.borrow().epochs().collect::<Vec<_>>();
                         for epoch in epochs {
                             let (mut conn, file_name) =
-                                state_store_cache.borrow_mut().open_segment(epoch);
+                                state_store.borrow_mut().open_segment(epoch);
                             let txn = conn.transaction().unwrap();
                             for snap in inbuffer.borrow_mut().remove(&epoch).unwrap() {
                                 let SerializedSnapshot(step_id, state_key, snap_epoch, ser_change) =

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -35,7 +35,6 @@ use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::Concatenate;
 use timely::dataflow::Scope;
 use timely::dataflow::Stream;
-use timely::Data;
 
 use crate::errors::tracked_err;
 use crate::errors::PythonException;
@@ -506,6 +505,10 @@ impl StateStore {
         .reraise("Error initing transaction")?;
         txn.commit().reraise("Error committing cluster_frontier")
     }
+
+    pub fn set_resume_epoch(&mut self, epoch: u64) {
+        self.resume_from.1 .0 = epoch;
+    }
 }
 
 /// Trait to group common operations that are used in all stateful operators.
@@ -525,6 +528,9 @@ pub(crate) trait StateManager {
     }
     fn recovery_on(&self) -> bool {
         self.borrow_state().recovery_config.is_some()
+    }
+    fn start_at(&self) -> ResumeEpoch {
+        self.borrow_state().resume_from.1
     }
     fn immediate_snapshot(&self) -> bool {
         self.borrow_state()

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -3,89 +3,853 @@
 //! For a user-centric version of recovery, read the
 //! `bytewax.recovery` Python module docstring. Read that first.
 
+use std::cell::Ref;
 use std::cell::RefCell;
-use std::collections::BTreeSet;
+use std::cell::RefMut;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::ffi::OsStr;
 use std::fmt;
 use std::fmt::Debug;
-use std::fs;
-use std::hash::BuildHasherDefault;
 use std::hash::Hash;
-use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use chrono::TimeDelta;
-use pyo3::create_exception;
+use chrono::DateTime;
+use chrono::Utc;
 use pyo3::exceptions::PyFileNotFoundError;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::exceptions::PyTypeError;
-use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::sync::GILOnceCell;
 use pyo3::types::PyBytes;
 use rusqlite::Connection;
 use rusqlite::OpenFlags;
+use rusqlite::Transaction;
 use rusqlite_migration::Migrations;
 use rusqlite_migration::M;
-use seahash::SeaHasher;
 use serde::Deserialize;
 use serde::Serialize;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use timely::dataflow::operators::Broadcast;
-use timely::dataflow::operators::Concat;
-use timely::dataflow::operators::Delay;
-use timely::dataflow::operators::Map;
-use timely::dataflow::operators::Operator;
+use timely::dataflow::operators::Concatenate;
 use timely::dataflow::Scope;
 use timely::dataflow::Stream;
-use timely::progress::Timestamp;
 use timely::Data;
-use tracing::instrument;
 
+use crate::errors::tracked_err;
 use crate::errors::PythonException;
-use crate::inputs::EpochInterval;
+use crate::inputs;
+use crate::inputs::BatchResult;
+use crate::operators::StatefulBatchLogic;
+use crate::outputs;
 use crate::pyo3_extensions::TdPyAny;
+use crate::pyo3_extensions::TdPyCallable;
 use crate::timely::*;
 use crate::unwrap_any;
 
-/// IDs a specific recovery partition.
+#[derive(Clone, Debug)]
+pub(crate) struct Backup(PyObject);
+
+impl<'py> FromPyObject<'py> for Backup {
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let py = obj.py();
+        let abc = py.import_bound("bytewax.backup")?.getattr("Backup")?;
+        if !obj.is_instance(&abc)? {
+            Err(tracked_err::<PyTypeError>(
+                "backup must subclass `bytewax.backup.Backup`",
+            ))
+        } else {
+            Ok(Self(obj.to_object(py)))
+        }
+    }
+}
+
+impl IntoPy<Py<PyAny>> for Backup {
+    fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
+        self.0
+    }
+}
+
+impl Default for Backup {
+    fn default() -> Self {
+        unwrap_any!(Python::with_gil(|py| {
+            get_dummy_backup(py).reraise("Error getting default Backup class")
+        }))
+    }
+}
+
+impl Backup {
+    pub(crate) fn list_keys(&self, py: Python) -> PyResult<Vec<String>> {
+        self.0
+            .call_method0(py, intern!(py, "list_keys"))?
+            .extract(py)
+    }
+
+    pub(crate) fn upload(&self, py: Python, from_local: PathBuf, to_key: String) -> PyResult<()> {
+        self.0
+            .call_method_bound(py, intern!(py, "upload"), (from_local, to_key), None)?;
+        Ok(())
+    }
+
+    pub(crate) fn download(&self, py: Python, from_key: String, to_local: PathBuf) -> PyResult<()> {
+        self.0
+            .call_method_bound(py, intern!(py, "download"), (from_key, to_local), None)?;
+        Ok(())
+    }
+
+    pub(crate) fn delete(&self, py: Python, key: String) -> PyResult<()> {
+        self.0.call_method1(py, intern!(py, "delete"), (key,))?;
+        Ok(())
+    }
+}
+
+static BACKUP_MODULE: GILOnceCell<Py<PyModule>> = GILOnceCell::new();
+
+fn get_backup_module(py: Python) -> PyResult<&Bound<'_, PyModule>> {
+    Ok(BACKUP_MODULE
+        .get_or_try_init(py, || -> PyResult<Py<PyModule>> {
+            Ok(py.import_bound("bytewax.backup")?.into())
+        })?
+        .bind(py))
+}
+
+static BACKUP_ABC: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
+
+fn get_backup_abc(py: Python) -> PyResult<&Bound<'_, PyAny>> {
+    Ok(BACKUP_ABC
+        .get_or_try_init(py, || -> PyResult<Py<PyAny>> {
+            Ok(get_backup_module(py)?.getattr("Backup")?.into())
+        })?
+        .bind(py))
+}
+
+static DUMMY_BACKUP: GILOnceCell<Backup> = GILOnceCell::new();
+
+fn get_dummy_backup(py: Python) -> PyResult<Backup> {
+    Ok(DUMMY_BACKUP
+        .get_or_try_init(py, || -> PyResult<Backup> {
+            get_backup_module(py)
+                .reraise("Can't find backup module")?
+                .getattr("TestingBackup")
+                .reraise("Can't find TestingBackup")?
+                .call0()
+                .reraise("Error init")?
+                .extract()
+        })?
+        .clone())
+}
+
+pub(crate) enum StatefulLogicKind {
+    Stateful(StatefulBatchLogic),
+    Input(inputs::StatefulPartition),
+    Output(outputs::StatefulPartition),
+}
+
+impl From<StatefulBatchLogic> for StatefulLogicKind {
+    fn from(val: StatefulBatchLogic) -> Self {
+        StatefulLogicKind::Stateful(val)
+    }
+}
+
+impl From<inputs::StatefulPartition> for StatefulLogicKind {
+    fn from(val: inputs::StatefulPartition) -> Self {
+        StatefulLogicKind::Input(val)
+    }
+}
+
+impl From<outputs::StatefulPartition> for StatefulLogicKind {
+    fn from(val: outputs::StatefulPartition) -> Self {
+        StatefulLogicKind::Output(val)
+    }
+}
+
+impl StatefulLogicKind {
+    pub(crate) fn snapshot(&self, py: Python) -> PyResult<TdPyAny> {
+        match self {
+            Self::Stateful(logic) => logic.snapshot(py),
+            Self::Input(logic) => logic.snapshot(py),
+            Self::Output(logic) => logic.snapshot(py),
+        }
+    }
+
+    pub(crate) fn as_input(&self) -> Result<&inputs::StatefulPartition, ()> {
+        match self {
+            Self::Input(logic) => Ok(logic),
+            _ => Err(()),
+        }
+    }
+
+    pub(crate) fn as_unary(&self) -> Result<&StatefulBatchLogic, ()> {
+        match self {
+            Self::Stateful(logic) => Ok(logic),
+            _ => Err(()),
+        }
+    }
+
+    pub(crate) fn as_output(&self) -> Result<&outputs::StatefulPartition, ()> {
+        match self {
+            Self::Output(logic) => Ok(logic),
+            _ => Err(()),
+        }
+    }
+}
+
+// TODO: Split the responsabilities between different structs, this one
+//       started as the state_store_cache but is now doing everything.
+pub(crate) struct StateStoreCache {
+    flow_id: String,
+    worker_index: usize,
+    worker_count: usize,
+    logics: HashMap<StepId, BTreeMap<StateKey, StatefulLogicKind>>,
+
+    recovery_config: Option<RecoveryConfig>,
+    conn: Option<Rc<RefCell<Connection>>>,
+    resume_from: ResumeFrom,
+    seg_num: u64,
+    prev_epoch: u64,
+}
+
+/// Trait to group common operations that are used in all stateful operators.
+/// It just needs to know how to borrow the StateStoreCache and how to retrieve
+/// the step_id to manipulate state and local store.
+pub(crate) trait StateManager {
+    fn borrow_state(&self) -> Ref<StateStoreCache>;
+    fn borrow_state_mut(&self) -> RefMut<StateStoreCache>;
+    fn step_id(&self) -> &StepId;
+
+    fn snap(&self, py: Python, key: &StateKey, epoch: &u64) -> PyResult<SerializedSnapshot> {
+        self.borrow_state().snap(py, self.step_id(), key, epoch)
+    }
+    fn write_snapshots(&self, snaps: Vec<SerializedSnapshot>) {
+        self.borrow_state().write_snapshots(snaps);
+    }
+    fn recovery_on(&self) -> bool {
+        self.borrow_state().recovery_config.is_some()
+    }
+    fn immediate_snapshot(&self) -> bool {
+        self.borrow_state()
+            .recovery_config
+            .as_ref()
+            .is_some_and(|rc| !rc.batch_backup)
+    }
+    fn contains_key(&self, key: &StateKey) -> bool {
+        self.borrow_state().contains_key(self.step_id(), key)
+    }
+    fn insert(&self, key: StateKey, logic: impl Into<StatefulLogicKind>) {
+        self.borrow_state_mut()
+            .insert(self.step_id().clone(), key, logic.into());
+    }
+    fn remove(&mut self, key: &StateKey) {
+        self.borrow_state_mut().remove(self.step_id(), key);
+    }
+    fn keys(&self) -> Vec<StateKey> {
+        self.borrow_state()
+            .get_logics(self.step_id())
+            .keys()
+            .cloned()
+            .collect()
+    }
+}
+
+pub(crate) struct OutputState {
+    step_id: StepId,
+    state_store_cache: Rc<RefCell<StateStoreCache>>,
+}
+
+impl StateManager for OutputState {
+    fn borrow_state(&self) -> Ref<StateStoreCache> {
+        self.state_store_cache.borrow()
+    }
+
+    fn borrow_state_mut(&self) -> RefMut<StateStoreCache> {
+        self.state_store_cache.borrow_mut()
+    }
+
+    fn step_id(&self) -> &StepId {
+        &self.step_id
+    }
+}
+
+impl OutputState {
+    pub fn hydrate(&mut self, sink: &outputs::FixedPartitionedSink) {
+        Python::with_gil(|py| {
+            // Get the parts list. If any state_key is not part of this list,
+            // it means the parts changed since last execution, and we can't
+            // handle that.
+            let parts_list = unwrap_any!(sink.list_parts(py));
+
+            let builder = |state_key: &_, state| {
+                assert!(
+                    parts_list.contains(state_key),
+                    "State found for unknown key {} in the recovery store for {}. \
+                    Known partitions: {}. \
+                    Fixed partitions cannot change between executions, aborting.",
+                    state_key,
+                    &self.step_id,
+                    parts_list
+                        .iter()
+                        .map(|sk| format!("\"{}\"", sk.0))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                let part = sink
+                    .build_part(py, &self.step_id, state_key, state)
+                    .unwrap();
+                StatefulLogicKind::Output(part)
+            };
+
+            self.state_store_cache
+                .borrow_mut()
+                .hydrate(&self.step_id, builder);
+        })
+    }
+
+    pub fn new(step_id: StepId, state_store_cache: Rc<RefCell<StateStoreCache>>) -> Self {
+        Self {
+            step_id,
+            state_store_cache,
+        }
+    }
+
+    pub fn write_batch(&self, py: Python, key: &StateKey, batch: Vec<PyObject>) -> PyResult<()> {
+        self.state_store_cache
+            .borrow()
+            .get(&self.step_id, key)
+            .unwrap()
+            .as_output()
+            .unwrap()
+            .write_batch(py, batch)
+    }
+}
+
+pub(crate) struct InputState {
+    step_id: StepId,
+    state_store_cache: Rc<RefCell<StateStoreCache>>,
+}
+
+impl StateManager for InputState {
+    fn borrow_state(&self) -> Ref<StateStoreCache> {
+        self.state_store_cache.borrow()
+    }
+
+    fn borrow_state_mut(&self) -> RefMut<StateStoreCache> {
+        self.state_store_cache.borrow_mut()
+    }
+
+    fn step_id(&self) -> &StepId {
+        &self.step_id
+    }
+}
+
+impl InputState {
+    pub fn new(step_id: StepId, state_store_cache: Rc<RefCell<StateStoreCache>>) -> Self {
+        Self {
+            step_id,
+            state_store_cache,
+        }
+    }
+
+    pub fn hydrate(&mut self, source: &inputs::FixedPartitionedSource) {
+        Python::with_gil(|py| {
+            // Get the parts list. If any state_key is not part of this list,
+            // it means the parts changed since last execution, and we can't
+            // handle that.
+            let parts_list = unwrap_any!(source.list_parts(py));
+
+            let builder = |state_key: &_, state| {
+                assert!(
+                    parts_list.contains(state_key),
+                    "State found for unknown key {} in the recovery store for {}. \
+                    Known partitions: {}. \
+                    Fixed partitions cannot change between executions, aborting.",
+                    state_key,
+                    self.step_id,
+                    parts_list
+                        .iter()
+                        .map(|sk| format!("\"{}\"", sk.0))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+
+                let part = source
+                    .build_part(py, &self.step_id, state_key, state)
+                    .unwrap();
+                StatefulLogicKind::Input(part)
+            };
+
+            self.state_store_cache
+                .borrow_mut()
+                .hydrate(&self.step_id, builder);
+        })
+    }
+    pub fn next_batch(&self, py: Python, key: &StateKey) -> PyResult<BatchResult> {
+        self.state_store_cache
+            .borrow()
+            .get(&self.step_id, key)
+            .unwrap()
+            .as_input()
+            .unwrap()
+            .next_batch(py)
+            .reraise_with(|| {
+                format!(
+                    "error calling `StatefulSourcePartition.next_batch` in \
+                    step {} for partition {}",
+                    self.step_id, key
+                )
+            })
+    }
+    pub fn next_awake(&self, py: Python, key: &StateKey) -> PyResult<Option<DateTime<Utc>>> {
+        self.state_store_cache
+            .borrow()
+            .get(&self.step_id, key)
+            .unwrap()
+            .as_input()
+            .unwrap()
+            .next_awake(py)
+            .reraise_with(|| {
+                format!(
+                    "error calling \
+                    `StatefulSourcePartition.next_awake` in \
+                    step {} for partition {}",
+                    self.step_id, key
+                )
+            })
+    }
+}
+
+pub(crate) struct StatefulBatchState {
+    step_id: StepId,
+    state_store_cache: Rc<RefCell<StateStoreCache>>,
+}
+
+impl StateManager for StatefulBatchState {
+    fn borrow_state(&self) -> Ref<StateStoreCache> {
+        self.state_store_cache.borrow()
+    }
+
+    fn borrow_state_mut(&self) -> RefMut<StateStoreCache> {
+        self.state_store_cache.borrow_mut()
+    }
+
+    fn step_id(&self) -> &StepId {
+        &self.step_id
+    }
+}
+
+impl StatefulBatchState {
+    pub fn new(step_id: StepId, state_store_cache: Rc<RefCell<StateStoreCache>>) -> Self {
+        Self {
+            step_id,
+            state_store_cache,
+        }
+    }
+    pub fn hydrate(&mut self, builder: &TdPyCallable) {
+        Python::with_gil(|py| {
+            let builder = builder.bind(py);
+            let state_builder = |_state_key: &_, state| {
+                let part = builder
+                    .call1((state,))
+                    .unwrap()
+                    .extract::<StatefulBatchLogic>()
+                    .unwrap();
+                StatefulLogicKind::Stateful(part)
+            };
+            self.state_store_cache
+                .borrow_mut()
+                .hydrate(&self.step_id, state_builder);
+        })
+    }
+    pub fn on_batch(
+        &self,
+        py: Python,
+        key: &StateKey,
+        values: Vec<PyObject>,
+    ) -> PyResult<(Vec<PyObject>, crate::operators::IsComplete)> {
+        self.borrow_state()
+            .get(&self.step_id, key)
+            .unwrap()
+            .as_unary()
+            .unwrap()
+            .on_batch(py, values)
+            .reraise_with(|| {
+                format!(
+                    "error calling `StatefulBatch.on_batch` in step {} for key {}",
+                    self.step_id, &key
+                )
+            })
+    }
+    pub fn on_notify(
+        &self,
+        py: Python,
+        key: &StateKey,
+    ) -> PyResult<(Vec<PyObject>, crate::operators::IsComplete)> {
+        self.state_store_cache
+            .borrow()
+            .get(&self.step_id, key)
+            .unwrap()
+            .as_unary()
+            .unwrap()
+            .on_notify(py)
+            .reraise_with(|| {
+                format!(
+                    "error calling `StatefulBatchLogic.on_notify` in {} for key {}",
+                    self.step_id, key
+                )
+            })
+    }
+    pub fn notify_at(&self, py: Python, key: &StateKey) -> PyResult<Option<DateTime<Utc>>> {
+        if let Some(logic) = self.state_store_cache.borrow().get(&self.step_id, key) {
+            logic.as_unary().unwrap().notify_at(py).reraise_with(|| {
+                format!(
+                    "error calling `StatefulBatchLogic.notify_at` in {} for key {}",
+                    self.step_id, key
+                )
+            })
+        } else {
+            Ok(None)
+        }
+    }
+    pub fn on_eof(
+        &self,
+        py: Python,
+        key: &StateKey,
+    ) -> PyResult<(Vec<PyObject>, crate::operators::IsComplete)> {
+        self.state_store_cache
+            .borrow()
+            .get(&self.step_id, key)
+            .unwrap()
+            .as_unary()
+            .unwrap()
+            .on_eof(py)
+            .reraise_with(|| {
+                format!(
+                    "error calling `StatefulBatchLogic.on_eof` in {} for key {}",
+                    self.step_id, key
+                )
+            })
+    }
+}
+
+impl StateStoreCache {
+    pub fn new(
+        recovery_config: Option<RecoveryConfig>,
+        flow_id: String,
+        worker_index: usize,
+        worker_count: usize,
+    ) -> PyResult<Self> {
+        // Init or load the recovery db is recovery was configured.
+        let mut conn = recovery_config
+            .as_ref()
+            .map(|rc| rc.db_connection(&flow_id, worker_index))
+            .transpose()?;
+
+        // Calculate resume_from.
+        // If recovery is configured, read the latest execution number from the db,
+        // otherwise start from the defaults.
+        let resume_from = conn
+            .as_mut()
+            .map(|conn| {
+                let res = conn.transaction().unwrap().query_row(
+                    "SELECT ex_num, cluster_frontier, worker_count, worker_index
+                    FROM meta
+                    WHERE (ex_num, flow_id) IN (SELECT MAX(ex_num), flow_id FROM meta)",
+                    (),
+                    |row| {
+                        let ex_num = row.get::<_, Option<u64>>(0)?.map(ExecutionNumber);
+                        let resume_epoch = row.get::<_, Option<u64>>(1)?.map(ResumeEpoch);
+                        Ok(ex_num
+                            .zip(resume_epoch)
+                            // Advance the execution number here.
+                            .map(|(en, re)| ResumeFrom(en.next(), re)))
+                    },
+                );
+                match res {
+                    // If no rows in the db, it was empty, so use the default.
+                    Err(rusqlite::Error::QueryReturnedNoRows) => ResumeFrom::default(),
+                    // Any other error was an error reading from the db, we should stop here.
+                    Err(err) => std::panic::panic_any(err),
+                    Ok(row) => row.unwrap_or_default(),
+                }
+            })
+            .unwrap_or_default();
+
+        // Wrap the connection into Rc and RefCell so we can share it among operators.
+        let conn = conn.map(|conn| Rc::new(RefCell::new(conn)));
+
+        Ok(Self {
+            logics: HashMap::new(),
+            recovery_config,
+            conn,
+            flow_id,
+            worker_index,
+            worker_count,
+            seg_num: 0,
+            resume_from,
+            prev_epoch: 0,
+        })
+    }
+
+    fn add_step(&mut self, step_id: StepId) {
+        // We never want to add a step twice, so panic if that's tried.
+        assert!(
+            !self.logics.contains_key(&step_id),
+            "Trying to hydrate state twice, this is probably a bug"
+        );
+        self.logics.insert(step_id.clone(), Default::default());
+    }
+
+    pub fn hydrate(
+        &mut self,
+        step_id: &StepId,
+        builder: impl Fn(&StateKey, Option<PyObject>) -> StatefulLogicKind,
+    ) {
+        self.add_step(step_id.clone());
+
+        // If no db connection is present, we don't need to do anything else.
+        if self.conn.is_none() {
+            return;
+        }
+
+        // Get all the snapshots in the store for this specific step_id,
+        // deserialize them, then call the builder function to make them
+        // the right StatefulLogicKind variant.
+        let deserialized_snaps: Vec<_> = Python::with_gil(|py| {
+            let pickle = unwrap_any!(py.import_bound("pickle"));
+            self.conn
+                .as_ref()
+                .unwrap()
+                .borrow_mut()
+                .prepare(
+                    "SELECT step_id, state_key, epoch, ser_change
+                FROM snaps
+                WHERE epoch = ?1 AND step_id = ?2
+                ",
+                )
+                .unwrap()
+                .query_map((self.resume_from.1 .0, &step_id.0), |row| {
+                    Ok(SerializedSnapshot(
+                        StepId(row.get(0)?),
+                        StateKey(row.get(1)?),
+                        SnapshotEpoch(row.get(2)?),
+                        row.get(3)?,
+                    ))
+                })
+                .unwrap()
+                .map(|res| res.expect("Error unpacking SerializedSnapshot"))
+                .map(|SerializedSnapshot(_, key, _, ser_state)| {
+                    let state = ser_state.map(|ser_state| {
+                        pickle
+                            .call_method1(
+                                intern!(py, "loads"),
+                                (PyBytes::new_bound(py, &ser_state),),
+                            )
+                            .unwrap()
+                            .unbind()
+                    });
+                    (key, state)
+                })
+                .collect()
+        });
+
+        for (state_key, state) in deserialized_snaps {
+            self.insert(
+                step_id.clone(),
+                state_key.clone(),
+                builder(&state_key, state),
+            );
+        }
+    }
+
+    pub fn backup(&self) -> Option<Backup> {
+        self.recovery_config.as_ref().map(|rc| rc.backup())
+    }
+
+    pub fn resume_from(&self) -> ResumeFrom {
+        self.resume_from
+    }
+
+    pub fn recovery_on(&self) -> bool {
+        self.recovery_config.is_some()
+    }
+
+    pub fn immediate_snapshot(&self) -> bool {
+        self.recovery_config
+            .as_ref()
+            .is_some_and(|rc| !rc.batch_backup)
+    }
+
+    pub fn get(&self, step_id: &StepId, key: &StateKey) -> Option<&StatefulLogicKind> {
+        self.logics.get(step_id).and_then(|s| s.get(key))
+    }
+
+    pub fn get_logics(&self, step_id: &StepId) -> &BTreeMap<StateKey, StatefulLogicKind> {
+        self.logics.get(step_id).unwrap()
+    }
+
+    pub fn contains_key(&self, step_id: &StepId, key: &StateKey) -> bool {
+        self.logics.get(step_id).unwrap().contains_key(key)
+    }
+
+    pub fn insert(&mut self, step_id: StepId, key: StateKey, logic: StatefulLogicKind) {
+        self.logics.entry(step_id).or_default().insert(key, logic);
+    }
+
+    pub fn remove(&mut self, step_id: &StepId, key: &StateKey) -> Option<StatefulLogicKind> {
+        self.logics.get_mut(step_id).and_then(|s| s.remove(key))
+    }
+
+    fn ser_snap(
+        &self,
+        py: Python,
+        step_id: StepId,
+        key: StateKey,
+        snap_change: StateChange,
+        epoch: u64,
+    ) -> PyResult<SerializedSnapshot> {
+        let ser_change = match snap_change {
+            StateChange::Upsert(snap) => {
+                let snap = PyObject::from(snap);
+                let pickle = py.import_bound("pickle").unwrap();
+                let ser_snap = pickle
+                    .call_method1(intern!(py, "dumps"), (snap.bind(py),))
+                    .unwrap()
+                    .downcast::<PyBytes>()
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec();
+                Some(ser_snap)
+            }
+            StateChange::Discard => None,
+        };
+
+        let snap_epoch = SnapshotEpoch(epoch);
+        Ok(SerializedSnapshot(step_id, key, snap_epoch, ser_change))
+    }
+
+    pub(crate) fn write_snapshots(&self, snaps: Vec<SerializedSnapshot>) {
+        let mut conn = self.conn.as_ref().unwrap().borrow_mut();
+        let txn = conn.transaction().unwrap();
+        for snap in snaps {
+            tracing::trace!("Writing {snap:?}");
+            let SerializedSnapshot(step_id, state_key, snap_epoch, ser_change) = snap;
+            txn.execute(
+                "INSERT INTO snaps (step_id, state_key, epoch, ser_change)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT (step_id, state_key, epoch) DO UPDATE
+                 SET ser_change = EXCLUDED.ser_change",
+                (step_id.0, state_key.0, snap_epoch.0, ser_change),
+            )
+            .unwrap();
+        }
+        txn.commit().unwrap();
+    }
+
+    /// Generates and returns a fully serialized snapshot
+    pub fn snap(
+        &self,
+        py: Python,
+        step_id: &StepId,
+        key: &StateKey,
+        epoch: &u64,
+    ) -> PyResult<SerializedSnapshot> {
+        let change = if let Some(logic) = self.get(step_id, key) {
+            let state = logic.snapshot(py).reraise_with(|| {
+                format!("error calling `StatefulBatchLogic.snapshot` in {step_id} for key {key}")
+            })?;
+            StateChange::Upsert(state)
+        } else {
+            // It's ok if there's no logic, because during this epoch it might have been discarded
+            // due to one of the `on_*` methods returning `IsComplete::Discard`.
+            StateChange::Discard
+        };
+        self.ser_snap(py, step_id.clone(), key.clone(), change.clone(), *epoch)
+    }
+
+    pub fn open_segment(&mut self, epoch: u64) -> (Connection, PathBuf) {
+        let worker_index = self.worker_index;
+        let ex_num = self.resume_from.0;
+        if epoch != self.prev_epoch {
+            self.seg_num = 1;
+            self.prev_epoch = epoch;
+        } else {
+            self.seg_num += 1;
+        }
+        let seg_num = self.seg_num;
+
+        let file_name =
+            format!("ex-{ex_num}:epoch-{epoch}:segment-{seg_num}:_:worker-{worker_index}.sqlite3");
+        let mut path = self.recovery_config.as_ref().unwrap().db_dir.clone();
+        path.push(file_name);
+        let mut conn = Connection::open_with_flags(
+            path.clone(),
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_CREATE
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .reraise("can't open recovery DB")
+        .unwrap();
+        rusqlite::vtab::series::load_module(&conn).unwrap();
+        conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+        conn.pragma_update(None, "journal_mode", "WAL").unwrap();
+        conn.pragma_update(None, "busy_timeout", "5000").unwrap();
+        Python::with_gil(|py| {
+            get_migrations(py).to_latest(&mut conn).unwrap();
+        });
+        (conn, path)
+    }
+
+    pub fn frontier_query(&self, txn: &Transaction, epoch: u64) -> PyResult<()> {
+        txn.execute(
+            "INSERT INTO meta (flow_id, ex_num, worker_index, worker_count, cluster_frontier)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT (flow_id, ex_num, worker_index) DO UPDATE
+                 SET cluster_frontier = EXCLUDED.cluster_frontier",
+            (
+                &self.flow_id,
+                self.resume_from.0 .0,
+                self.worker_index,
+                self.worker_count,
+                epoch,
+            ),
+        )
+        .reraise("Error initing transaction")
+        .map(|_| ())
+    }
+
+    pub fn write_frontier(&mut self, epoch: u64) -> PyResult<()> {
+        if let Some(conn) = self.conn.as_ref() {
+            let mut borrowed_conn = conn.borrow_mut();
+            let txn = borrowed_conn.transaction().unwrap();
+            tracing::trace!("Writing epoch {epoch:?}");
+            self.frontier_query(&txn, epoch)?;
+            txn.commit().reraise("Error committing cluster_frontier")
+        } else {
+            Err(tracked_err::<PyRuntimeError>(
+                "DB Connection lost before writing frontier",
+            ))
+        }
+    }
+}
+
+/// Metadata about a recovery db.
 ///
-/// The inner value will be up to [`PartitionCount`].
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub(crate) struct PartitionIndex(usize);
-
-impl fmt::Display for PartitionIndex {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// Total number of recovery partitions.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, FromPyObject)]
-pub(crate) struct PartitionCount(usize);
-
-impl PartitionCount {
-    /// Return an iter of all partitions.
-    fn iter(&self) -> impl Iterator<Item = PartitionIndex> {
-        (0..self.0).map(PartitionIndex)
-    }
-}
-
-impl fmt::Display for PartitionCount {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// Metadata about a recovery partition.
-///
-/// This represents a row in the `parts` table.
+/// This represents a row in the `meta` table.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct PartitionMeta(PartitionIndex, PartitionCount);
+pub(crate) struct ClusterMeta(
+    FlowId,
+    ExecutionNumber,
+    WorkerIndex,
+    WorkerCount,
+    ClusterFrontier,
+);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct FlowId(String);
+
+/// The oldest epoch for which work is still outstanding on the cluster.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClusterFrontier(u64);
 
 /// Incrementing ID representing how many times a dataflow has been
 /// executed to completion or failure.
@@ -96,6 +860,13 @@ pub(crate) struct PartitionMeta(PartitionIndex, PartitionCount);
 /// As you resume a dataflow, this will increase by 1 each time.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub(crate) struct ExecutionNumber(u64);
+
+impl ExecutionNumber {
+    pub(crate) fn next(mut self) -> Self {
+        self.0 += 1;
+        self
+    }
+}
 
 impl fmt::Display for ExecutionNumber {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -122,62 +893,11 @@ impl fmt::Display for ResumeEpoch {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ExecutionMeta(ExecutionNumber, WorkerCount, ResumeEpoch);
 
-/// The oldest epoch for which work is still outstanding on a worker.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct WorkerFrontier(u64);
-
-impl fmt::Display for WorkerFrontier {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 /// Metadata about the current frontier of a worker.
 ///
 /// This represents a row in the `fronts` table.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct FrontierMeta(ExecutionNumber, WorkerIndex, WorkerFrontier);
-
-/// Metadata about a commit in a recovery partition.
-///
-/// This represents a row in the `commits` table.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct CommitMeta(PartitionIndex, u64);
-
-/// System time duration to keep around state snapshots, even after
-/// they are no longer needed by the current execution.
-///
-/// This is used to delay GC of state data so that if durable backup
-/// of recovery partitions are not instantaneous or synchronized, we
-/// can ensure that there's some resume epoch shared by all partitions
-/// we can use when resuming from a backup that might not be the most
-/// recent.
-#[derive(Debug, Copy, Clone)]
-pub(crate) struct BackupInterval(TimeDelta);
-
-impl Default for BackupInterval {
-    fn default() -> Self {
-        Self(TimeDelta::zero())
-    }
-}
-
-impl IntoPy<Py<PyAny>> for BackupInterval {
-    fn into_py(self, py: Python<'_>) -> Py<PyAny> {
-        self.0.into_py(py)
-    }
-}
-
-impl<'py> FromPyObject<'py> for BackupInterval {
-    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
-        if let Ok(duration) = obj.extract::<TimeDelta>() {
-            Ok(Self(duration))
-        } else {
-            Err(PyTypeError::new_err(
-                "backup interval must be a `datetime.timedelta`",
-            ))
-        }
-    }
-}
+pub(crate) struct FrontierMeta(ExecutionNumber, WorkerIndex, ClusterFrontier);
 
 /// To resume a dataflow execution, you need to know which epoch to
 /// resume for state, but also which execution to label progress data
@@ -287,136 +1007,101 @@ struct SnapshotEpoch(u64);
 ///
 /// This represents a row in the `snaps` table.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct SerializedSnapshot(StepId, StateKey, SnapshotEpoch, Option<Vec<u8>>);
+pub(crate) struct SerializedSnapshot(StepId, StateKey, SnapshotEpoch, Option<Vec<u8>>);
+
+impl fmt::Display for SerializedSnapshot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{}: {}, epoch {}", self.0, self.1, self.2 .0))
+    }
+}
 
 /// Configuration settings for recovery.
 ///
-/// :arg db_dir: Local filesystem directory to search for recovery
+/// :arg db_dir: Local filesystem directory to use for recovery
 ///     database partitions.
 ///
 /// :type db_dir: pathlib.Path
 ///
-/// :arg backup_interval: Amount of system time to wait to permanently
-///     delete a state snapshot after it is no longer needed. You
-///     should set this to the interval at which you are backing up
-///     the recovery partitions off of the workers into archival
-///     storage (e.g. S3). Defaults to zero duration.
+/// :arg backup: Class to use to save recovery files to a durable
+///     storage like amazon's S3.
 ///
-/// :type backup_interval: typing.Optional[datetime.timedelta]
+/// :type backup: typing.Optional[bytewax.backup.Backup]
+///
+/// :arg batch_backup: Whether to take state snapshots at the end
+///     of the epoch, rather than at every state change. Defaults
+///     to False.
+///
+/// :type batch_backup: bool
 #[pyclass(module = "bytewax.recovery")]
+#[derive(Clone, Debug)]
 pub(crate) struct RecoveryConfig {
     #[pyo3(get)]
     db_dir: PathBuf,
     #[pyo3(get)]
-    backup_interval: BackupInterval,
+    backup: Backup,
+    #[pyo3(get)]
+    pub(crate) batch_backup: bool,
 }
 
 #[pymethods]
 impl RecoveryConfig {
     #[new]
-    fn new(db_dir: PathBuf, backup_interval: Option<BackupInterval>) -> Self {
-        Self {
+    fn new(db_dir: PathBuf, backup: Option<Backup>, batch_backup: Option<bool>) -> PyResult<Self> {
+        let batch_backup = batch_backup.unwrap_or(false);
+
+        // Manually unpack so we can propagate the error
+        // if default initialization fails.
+        let backup = if let Some(backup) = backup {
+            backup
+        } else {
+            Python::with_gil(|py| {
+                get_dummy_backup(py).reraise("Error getting default Backup class")
+            })?
+        };
+
+        Ok(Self {
             db_dir,
-            backup_interval: backup_interval.unwrap_or_default(),
-        }
+            batch_backup,
+            backup,
+        })
     }
 }
 
 impl RecoveryConfig {
-    /// Build the Rust-side bundle from the Python-side recovery
-    /// config.
-    #[instrument(name = "build_recovery", skip_all)]
-    pub(crate) fn build(&self, py: Python) -> PyResult<(RecoveryBundle, BackupInterval)> {
-        let mut part_paths = HashMap::new();
-        let sqlite_ext = OsStr::new("sqlite3");
+    pub(crate) fn db_connection(
+        &self,
+        flow_id: &String,
+        worker_index: usize,
+    ) -> PyResult<Connection> {
         if !self.db_dir.is_dir() {
             return Err(PyFileNotFoundError::new_err(format!(
-                "recovery directory {:?} does not exist; see the `bytewax.recovery` module docstring for more info",
+                "recovery directory {:?} does not exist; \
+                see the `bytewax.recovery` module docstring for more info",
                 self.db_dir
             )));
         }
-        for entry in fs::read_dir(self.db_dir.clone()).reraise("Error listing recovery DB dir")? {
-            let path = entry.reraise("Error accessing recovery DB file")?.path();
-            if path.extension().map_or(false, |ext| *ext == *sqlite_ext) {
-                let part =
-                    RecoveryPart::open(py, &path).reraise("Error opening recovery DB file")?;
-                let mut part_loader = part.part_loader();
-                while let Some(batch) = part_loader.next_batch() {
-                    for PartitionMeta(index, _count) in batch {
-                        tracing::info!("Access to partition {index:?} at {path:?}");
-                        part_paths.insert(index, path.clone());
-                    }
-                }
-            }
-        }
+        let file_name = format!("flow_{flow_id}_worker_{worker_index}.sqlite3");
+        let mut path = self.db_dir.clone();
+        path.push(file_name);
 
-        let bundle = RecoveryBundle {
-            part_paths: Rc::new(part_paths),
-            built_parts: Rc::new(RefCell::new(HashMap::new())),
-        };
-        let backup_interval = self.backup_interval;
-
-        Ok((bundle, backup_interval))
-    }
-}
-
-/// Clone-able reference to all local recovery partition info.
-pub(crate) struct RecoveryBundle {
-    /// This is a map to all known local partitions.
-    ///
-    /// It is an [`Rc`] because the builder functions created by
-    /// [`new_builder`] need to retain a handle to this to be able to
-    /// look up the relevant path. No [`RefCell`] because they don't
-    /// need to modify it.
-    part_paths: Rc<HashMap<PartitionIndex, PathBuf>>,
-    /// This is a cache of already built [`RecoveryDB`].
-    ///
-    /// The map itself is an [`Rc<RefCell>`] because the builder
-    /// functions need to own a reference and update the cache so only
-    /// one partition is built, even if it is requested multiple
-    /// times. The values are [`Rc<RefCell<RecoveryDb>`] so that this
-    /// cache and the Timely operators themselves all have ownership
-    /// access to the partition.
-    built_parts: Rc<RefCell<HashMap<PartitionIndex, Rc<RefCell<RecoveryPart>>>>>,
-}
-
-impl RecoveryBundle {
-    pub(crate) fn clone_ref(&self, _py: Python) -> Self {
-        Self {
-            part_paths: self.part_paths.clone(),
-            built_parts: self.built_parts.clone(),
-        }
+        let mut conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_CREATE
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .reraise("can't open recovery DB")?;
+        rusqlite::vtab::series::load_module(&conn).unwrap();
+        conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+        conn.pragma_update(None, "journal_mode", "WAL").unwrap();
+        conn.pragma_update(None, "busy_timeout", "5000").unwrap();
+        Python::with_gil(|py| get_migrations(py).to_latest(&mut conn))
+            .reraise("Error running migrations on the db")?;
+        Ok(conn)
     }
 
-    fn local_parts(&self) -> Vec<PartitionIndex> {
-        self.part_paths.keys().copied().collect()
-    }
-
-    /// Create a new builder function that the partitioned read and
-    /// write and commit operators can use to build partitions.
-    ///
-    /// This clones all the [`Rc`]s appropriately internally so that
-    /// the cache is used.
-    fn new_builder(&self) -> impl FnMut(&PartitionIndex) -> Rc<RefCell<RecoveryPart>> {
-        let part_paths = self.part_paths.clone();
-        let built_parts = self.built_parts.clone();
-        move |part_key| {
-            built_parts
-                .borrow_mut()
-                .entry(*part_key)
-                .or_insert_with_key(|part_key| {
-                    let path = part_paths
-                        .get(part_key)
-                        .unwrap_or_else(|| {
-                            panic!("Trying to build RecoveryPartition for {part_key:?} but no path is known");
-                        });
-
-                    let part = unwrap_any!(Python::with_gil(|py| RecoveryPart::open(py, path)));
-
-                    Rc::new(RefCell::new(part))
-                })
-                .clone()
-        }
+    pub(crate) fn backup(&self) -> Backup {
+        self.backup.clone()
     }
 }
 
@@ -432,14 +1117,6 @@ impl<T> PythonException<T> for Result<T, rusqlite_migration::Error> {
     }
 }
 
-/// Wrapper around an SQLite DB connection with methods for our
-/// recovery operations.
-struct RecoveryPart {
-    /// This is [`Rc<RefCell>`] so that our reader and writer structs
-    /// can maintain an internal connection reference across batches.
-    conn: Rc<RefCell<Connection>>,
-}
-
 // The `'static` lifetime within [`Migrations`] is saying that the
 // [`str`]s composing the migrations are `'static`.
 //
@@ -451,56 +1128,25 @@ fn get_migrations(py: Python) -> &Migrations<'static> {
     MIGRATIONS.get_or_init(py, || {
         Migrations::new(vec![
             M::up(
-                "CREATE TABLE parts (
-                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                 part_index INTEGER PRIMARY KEY NOT NULL CHECK (part_index >= 0),
-                 part_count INTEGER NOT NULL CHECK (part_count > 0),
-                 CHECK (part_index < part_count)
+                "CREATE TABLE meta (
+                    modified_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    flow_id TEXT NOT NULL,
+                    ex_num INTEGER NOT NULL,
+                    worker_index INTEGER NOT NULL CHECK (worker_index >= 0),
+                    worker_count INTEGER NOT NULL CHECK (worker_count > 0),
+                    cluster_frontier INTEGER NOT NULL,
+                    CHECK (worker_index < worker_count),
+                    PRIMARY KEY (flow_id, ex_num, worker_index)
                  ) STRICT",
             ),
-            // This is a sharded table.
-            M::up(
-                "CREATE TABLE exs (
-                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                 ex_num INTEGER NOT NULL PRIMARY KEY,
-                 worker_count INTEGER NOT NULL CHECK (worker_count > 0),
-                 resume_epoch INTEGER NOT NULL
-                 ) STRICT",
-            ),
-            // This is a sharded table.
-            //
-            // We can't do a foreign key constraint because we don't
-            // know what partition the row in `ex` will be in; we'd
-            // need a "sharded foreign key" kinda thing.
-            M::up(
-                "CREATE TABLE fronts (
-                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                 ex_num INTEGER NOT NULL,
-                 worker_index INTEGER NOT NULL CHECK (worker_index >= 0),
-                 worker_frontier INTEGER NOT NULL,
-                 PRIMARY KEY (ex_num, worker_index)
-                 ) STRICT",
-            ),
-            // This is _not_ a sharded table. Commits affect a whole
-            // partition and thus will only be written to the same
-            // shard as partition definitions. We don't use a foreign
-            // key here, though so we don't have to deal with flow_id.
-            M::up(
-                "CREATE TABLE commits (
-                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                 part_index INTEGER PRIMARY KEY NOT NULL,
-                 commit_epoch INTEGER NOT NULL
-                 ) STRICT",
-            ),
-            // This is a sharded table.
             M::up(
                 "CREATE TABLE snaps (
-                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                 step_id TEXT NOT NULL,
-                 state_key TEXT NOT NULL,
-                 snap_epoch INTEGER NOT NULL,
-                 ser_change BLOB,
-                 PRIMARY KEY (step_id, state_key, snap_epoch)
+                    modified_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    step_id TEXT NOT NULL,
+                    state_key TEXT NOT NULL,
+                    epoch INTEGER NOT NULL,
+                    ser_change BLOB,
+                    PRIMARY KEY (step_id, state_key, epoch)
                  ) STRICT",
             ),
         ])
@@ -511,876 +1157,6 @@ fn get_migrations(py: Python) -> &Migrations<'static> {
 fn migrations_valid() -> rusqlite_migration::Result<()> {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| get_migrations(py).validate())
-}
-
-/// Setup our connection-level pragmas. Run this on each connection.
-fn setup_conn(py: Python, conn: &Rc<RefCell<Connection>>) {
-    let mut conn = conn.borrow_mut();
-
-    rusqlite::vtab::series::load_module(&conn).unwrap();
-    conn.pragma_update(None, "foreign_keys", "ON").unwrap();
-    // These are recommended by Litestream.
-    conn.pragma_update(None, "journal_mode", "WAL").unwrap();
-    conn.pragma_update(None, "busy_timeout", "5000").unwrap();
-    get_migrations(py).to_latest(&mut conn).unwrap();
-}
-
-struct PartitionMetaWriter {
-    conn: Rc<RefCell<Connection>>,
-}
-
-impl Writer for PartitionMetaWriter {
-    type Item = PartitionMeta;
-
-    fn write_batch(&mut self, items: Vec<Self::Item>) {
-        let mut conn = self.conn.borrow_mut();
-        let txn = conn.transaction().unwrap();
-        for part in items {
-            tracing::trace!("Writing {part:?}");
-            let PartitionMeta(part_index, part_count) = part;
-            txn.execute(
-                "INSERT INTO parts (part_index, part_count)
-                 VALUES (?1, ?2)",
-                (part_index.0, part_count.0),
-            )
-            .unwrap();
-        }
-        txn.commit().unwrap();
-    }
-}
-
-struct ExecutionMetaWriter {
-    conn: Rc<RefCell<Connection>>,
-}
-
-impl Writer for ExecutionMetaWriter {
-    type Item = ExecutionMeta;
-
-    fn write_batch(&mut self, items: Vec<Self::Item>) {
-        let mut conn = self.conn.borrow_mut();
-        let txn = conn.transaction().unwrap();
-        for ex in items {
-            tracing::trace!("Writing {ex:?}");
-            let ExecutionMeta(ex_num, worker_count, resume_epoch) = ex;
-            // Do not upsert because we should never see an execution
-            // twice.
-            txn.execute(
-                "INSERT INTO exs (ex_num, worker_count, resume_epoch)
-                 VALUES (?1, ?2, ?3)",
-                (ex_num.0, worker_count.0, resume_epoch.0),
-            )
-            .unwrap();
-        }
-        txn.commit().unwrap();
-    }
-}
-
-struct FrontierWriter {
-    conn: Rc<RefCell<Connection>>,
-}
-
-impl Writer for FrontierWriter {
-    type Item = FrontierMeta;
-
-    fn write_batch(&mut self, items: Vec<Self::Item>) {
-        let mut conn = self.conn.borrow_mut();
-        let txn = conn.transaction().unwrap();
-        for front in items {
-            tracing::trace!("Writing {front:?}");
-            let FrontierMeta(ex, worker_count, wf) = front;
-            txn.execute(
-                "INSERT INTO fronts (ex_num, worker_index, worker_frontier)
-                 VALUES (?1, ?2, ?3)
-                 ON CONFLICT (ex_num, worker_index) DO UPDATE
-                 SET worker_frontier = EXCLUDED.worker_frontier",
-                (ex.0, worker_count.0, wf.0),
-            )
-            .unwrap();
-        }
-        txn.commit().unwrap();
-    }
-}
-
-struct SerializedSnapshotWriter {
-    conn: Rc<RefCell<Connection>>,
-}
-
-impl Writer for SerializedSnapshotWriter {
-    type Item = SerializedSnapshot;
-
-    fn write_batch(&mut self, items: Vec<Self::Item>) {
-        let mut conn = self.conn.borrow_mut();
-        let txn = conn.transaction().unwrap();
-        for snap in items {
-            tracing::trace!("Writing {snap:?}");
-            let SerializedSnapshot(step_id, state_key, snap_epoch, ser_change) = snap;
-            txn.execute(
-                "INSERT INTO snaps (step_id, state_key, snap_epoch, ser_change)
-                 VALUES (?1, ?2, ?3, ?4)
-                 ON CONFLICT (step_id, state_key, snap_epoch) DO UPDATE
-                 SET ser_change = EXCLUDED.ser_change",
-                (step_id.0, state_key.0, snap_epoch.0, ser_change),
-            )
-            .unwrap();
-        }
-        txn.commit().unwrap();
-    }
-}
-
-struct CommitWriter {
-    conn: Rc<RefCell<Connection>>,
-}
-
-impl Writer for CommitWriter {
-    type Item = CommitMeta;
-
-    fn write_batch(&mut self, items: Vec<Self::Item>) {
-        let mut conn = self.conn.borrow_mut();
-        let txn = conn.transaction().unwrap();
-        for commit in items {
-            tracing::trace!("Writing {commit:?}");
-            let CommitMeta(part_idx, commit_epoch) = commit;
-            txn.execute(
-                "INSERT INTO commits (part_index, commit_epoch)
-                 VALUES (?1, ?2)",
-                (part_idx.0, commit_epoch),
-            )
-            .unwrap();
-        }
-        txn.commit().unwrap();
-    }
-}
-
-struct PartitionMetaLoader {
-    conn: Rc<RefCell<Connection>>,
-    done: bool,
-}
-
-impl PartitionMetaLoader {
-    fn new(conn: Rc<RefCell<Connection>>) -> Self {
-        Self { conn, done: false }
-    }
-}
-
-impl BatchIterator for PartitionMetaLoader {
-    type Item = PartitionMeta;
-
-    fn next_batch(&mut self) -> Option<Vec<Self::Item>> {
-        if !self.done {
-            let batch = self
-                .conn
-                .borrow_mut()
-                .prepare(
-                    "SELECT part_index, part_count
-                     FROM parts",
-                )
-                .unwrap()
-                .query_map((), |row| {
-                    Ok(PartitionMeta(
-                        PartitionIndex(row.get(0)?),
-                        PartitionCount(row.get(1)?),
-                    ))
-                })
-                .unwrap()
-                .map(|res| res.expect("error unpacking PartitionMeta"))
-                // We have to collect so that we don't need to retain a
-                // reference to the connection in the iterator. Progress
-                // info is "small" so it's ok to load it all into
-                // memory. TODO: One day we could make a generic version
-                // of [`SnapIterator`] that keeps an [`Rc`] and paginates.
-                .collect();
-            self.done = true;
-            Some(batch)
-        } else {
-            None
-        }
-    }
-}
-
-struct ExecutionMetaLoader {
-    conn: Rc<RefCell<Connection>>,
-    done: bool,
-}
-
-impl ExecutionMetaLoader {
-    fn new(conn: Rc<RefCell<Connection>>) -> Self {
-        Self { conn, done: false }
-    }
-}
-
-impl BatchIterator for ExecutionMetaLoader {
-    type Item = ExecutionMeta;
-
-    fn next_batch(&mut self) -> Option<Vec<Self::Item>> {
-        if !self.done {
-            let batch = self
-                .conn
-                .borrow_mut()
-                .prepare(
-                    "SELECT ex_num, worker_count, resume_epoch
-                     FROM exs",
-                )
-                .unwrap()
-                .query_map((), |row| {
-                    Ok(ExecutionMeta(
-                        ExecutionNumber(row.get(0)?),
-                        WorkerCount(row.get(1)?),
-                        ResumeEpoch(row.get(2)?),
-                    ))
-                })
-                .unwrap()
-                .map(|res| res.expect("error unpacking ExecutionMeta"))
-                .collect();
-            self.done = true;
-            Some(batch)
-        } else {
-            None
-        }
-    }
-}
-
-struct FrontierLoader {
-    conn: Rc<RefCell<Connection>>,
-    done: bool,
-}
-
-impl FrontierLoader {
-    fn new(conn: Rc<RefCell<Connection>>) -> Self {
-        Self { conn, done: false }
-    }
-}
-
-impl BatchIterator for FrontierLoader {
-    type Item = FrontierMeta;
-
-    fn next_batch(&mut self) -> Option<Vec<Self::Item>> {
-        if !self.done {
-            let batch = self
-                .conn
-                .borrow()
-                .prepare(
-                    "SELECT ex_num, worker_index, worker_frontier
-                     FROM fronts",
-                )
-                .unwrap()
-                .query_map((), |row| {
-                    Ok(FrontierMeta(
-                        ExecutionNumber(row.get(0)?),
-                        WorkerIndex(row.get(1)?),
-                        WorkerFrontier(row.get(2)?),
-                    ))
-                })
-                .unwrap()
-                .map(|res| res.expect("error unpacking FrontierMeta"))
-                .collect();
-            self.done = true;
-            Some(batch)
-        } else {
-            None
-        }
-    }
-}
-
-enum Cursor<T> {
-    /// We haven't started reading the table.
-    Uninit,
-    /// We should read from position T next.
-    InProgress(T),
-    /// We're done reading the table.
-    Done,
-}
-
-/// Iterator that keeps a connection ref so we don't keep an open txn
-/// the entire time we're dumping batches out of all state snapshots.
-struct SerializedSnapshotLoader {
-    conn: Rc<RefCell<Connection>>,
-    before: ResumeEpoch,
-    batch_size: usize,
-    cursor: Cursor<(StepId, StateKey)>,
-}
-
-impl SerializedSnapshotLoader {
-    fn new(conn: Rc<RefCell<Connection>>, before: ResumeEpoch, batch_size: usize) -> Self {
-        Self {
-            conn,
-            before,
-            batch_size,
-            cursor: Cursor::Uninit,
-        }
-    }
-
-    fn select(
-        &self,
-        cursor: Option<(&StepId, &StateKey)>,
-    ) -> (Vec<SerializedSnapshot>, Cursor<(StepId, StateKey)>) {
-        let (cursor_step_id, cursor_state_key) = cursor.unzip();
-
-        let batch: Vec<_> = self
-            .conn
-            .borrow()
-            // Filters in SQL down to just the last relevant snapshot per
-            // (step_id, state_key) to reduce redundant reads. Remember,
-            // must be <, not <= resume epoch.  The WHERE clause is whack
-            // because we want to use the "most recently read (step_id,
-            // state_key)" as a "resume position". We're ordering the
-            // results by that, and since there is only one row per
-            // (step_id, state_key), the LIMIT clause causes it to batch.
-            .prepare(
-                "WITH max_epoch_snaps AS (
-                 SELECT step_id, state_key, MAX(snap_epoch) AS snap_epoch
-                 FROM snaps
-                 WHERE snap_epoch < ?1
-                 GROUP BY step_id, state_key
-                 )
-                 SELECT step_id, state_key, snap_epoch, ser_change
-                 FROM snaps
-                 JOIN max_epoch_snaps USING (step_id, state_key, snap_epoch)
-                 WHERE ?2 IS NULL OR ?3 IS NULL OR (step_id, state_key) > (?2, ?3)
-                 ORDER BY step_id, state_key
-                 LIMIT ?4",
-            )
-            .unwrap()
-            .query_map(
-                (
-                    self.before.0,
-                    cursor_step_id.map(|s| &s.0),
-                    cursor_state_key.map(|s| &s.0),
-                    self.batch_size,
-                ),
-                |row| {
-                    Ok(SerializedSnapshot(
-                        StepId(row.get(0)?),
-                        StateKey(row.get(1)?),
-                        SnapshotEpoch(row.get(2)?),
-                        row.get(3)?,
-                    ))
-                },
-            )
-            .unwrap()
-            .map(|res| {
-                let snap = res.expect("error unpacking SerializedSnapshot");
-                tracing::trace!("Read {snap:?}");
-                snap
-            })
-            .collect();
-
-        let cursor = if let Some(SerializedSnapshot(step_id, state_key, _snap_epoch, _ser_change)) =
-            batch.last()
-        {
-            Cursor::InProgress((step_id.clone(), state_key.clone()))
-        } else {
-            Cursor::Done
-        };
-
-        (batch, cursor)
-    }
-}
-
-impl BatchIterator for SerializedSnapshotLoader {
-    type Item = SerializedSnapshot;
-
-    fn next_batch(&mut self) -> Option<Vec<Self::Item>> {
-        let (batch, next_cursor) = match &self.cursor {
-            Cursor::Uninit => {
-                let (batch, cursor) = self.select(None);
-                (Some(batch), cursor)
-            }
-            Cursor::InProgress((step_id, state_key)) => {
-                let (batch, cursor) = self.select(Some((step_id, state_key)));
-                (Some(batch), cursor)
-            }
-            Cursor::Done => (None, Cursor::Done),
-        };
-
-        self.cursor = next_cursor;
-        batch
-    }
-}
-
-struct CommitLoader {
-    conn: Rc<RefCell<Connection>>,
-    done: bool,
-}
-
-impl CommitLoader {
-    fn new(conn: Rc<RefCell<Connection>>) -> Self {
-        Self { conn, done: false }
-    }
-}
-
-impl BatchIterator for CommitLoader {
-    type Item = CommitMeta;
-
-    fn next_batch(&mut self) -> Option<Vec<Self::Item>> {
-        if !self.done {
-            let batch = self
-                .conn
-                .borrow()
-                .prepare(
-                    "SELECT part_index, commit_epoch
-                     FROM commits",
-                )
-                .unwrap()
-                .query_map((), |row| {
-                    Ok(CommitMeta(PartitionIndex(row.get(0)?), row.get(1)?))
-                })
-                .unwrap()
-                .map(|res| res.expect("error unpacking CommitMeta"))
-                .collect();
-            self.done = true;
-            Some(batch)
-        } else {
-            None
-        }
-    }
-}
-
-struct RecoveryCommitter {
-    conn: Rc<RefCell<Connection>>,
-    part_key: PartitionIndex,
-}
-
-impl Committer<u64> for RecoveryCommitter {
-    /// This will be called when `epoch` is the earliest possible
-    /// resume epoch.
-    fn commit(&mut self, epoch: &u64) {
-        tracing::trace!("Committing / GCing epoch {epoch:?}");
-        let mut conn = self.conn.borrow_mut();
-        let txn = conn.transaction().unwrap();
-        txn.execute(
-            "INSERT INTO commits (part_index, commit_epoch)
-             VALUES (?1, ?2)
-             ON CONFLICT (part_index) DO UPDATE
-             SET commit_epoch = EXCLUDED.commit_epoch",
-            (self.part_key.0, epoch),
-        )
-        .unwrap();
-        // Find the most recent snapshot including the commited epoch
-        // (since we can GC everything before that epoch). Then find
-        // all less recent snapshots and delete those. So we never
-        // want to delete a snapshot in the commited epoch, but since
-        // the most recent snapshot is not deleted it's ok for this to
-        // be `<=`.
-        txn.execute(
-            "WITH max_epoch_snapshots AS (
-             SELECT step_id, state_key, MAX(snap_epoch) AS snap_epoch
-             FROM snaps
-             WHERE snap_epoch <= ?1
-             GROUP BY step_id, state_key
-             ),
-             garbage_snapshots AS (
-             SELECT step_id, state_key, snaps.snap_epoch
-             FROM snaps
-             JOIN max_epoch_snapshots USING (step_id, state_key)
-             WHERE snaps.snap_epoch < max_epoch_snapshots.snap_epoch
-             )
-             DELETE FROM snaps
-             WHERE (step_id, state_key, snap_epoch) IN garbage_snapshots",
-            (epoch,),
-        )
-        .unwrap();
-        txn.commit().unwrap();
-    }
-}
-
-#[test]
-fn gc_leaves_only_final_snap() {
-    pyo3::prepare_freethreaded_python();
-    let conn = Python::with_gil(|py| RecoveryPart::init_open_mem(py));
-    conn.snap_writer().write_batch(vec![
-        SerializedSnapshot(
-            StepId(String::from("step_1")),
-            StateKey(String::from("a")),
-            SnapshotEpoch(1),
-            Some("PICKLED_DATA1".as_bytes().to_vec()),
-        ),
-        SerializedSnapshot(
-            StepId(String::from("step_1")),
-            StateKey(String::from("a")),
-            SnapshotEpoch(2),
-            Some("PICKLED_DATA2".as_bytes().to_vec()),
-        ),
-        SerializedSnapshot(
-            StepId(String::from("step_1")),
-            StateKey(String::from("a")),
-            SnapshotEpoch(5),
-            Some("PICKLED_DATA5".as_bytes().to_vec()),
-        ),
-    ]);
-    conn.committer(PartitionIndex(0)).commit(&5);
-
-    let found = conn
-        .conn
-        .borrow()
-        .prepare(
-            "SELECT step_id, state_key, COUNT(*) AS num_snaps
-            FROM snaps
-            GROUP BY step_id, state_key
-            HAVING num_snaps > 1",
-        )
-        .unwrap()
-        .query_map((), |row| {
-            let step_id = StepId(row.get(0)?);
-            let state_key = StateKey(row.get(1)?);
-            let num_snaps: usize = row.get(2)?;
-
-            Ok((step_id, state_key, num_snaps))
-        })
-        .unwrap()
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
-    let expected = Vec::new();
-    assert_eq!(found, expected);
-}
-
-create_exception!(
-    bytewax.recovery,
-    InconsistentPartitionsError,
-    PyValueError,
-    "Raised when two recovery partitions are from very different times.
-
-Bytewax only keeps around state snapshots for the backup interval.
-This means that if you are resuming a dataflow with one recovery
-partition much newer than another, it's not possible to find a
-consistent set of snapshots between them.
-
-This is probably due to not restoring a consistent set of recovery
-partition backups onto all workers or the backup process has been
-continously failing on only some workers."
-);
-
-create_exception!(
-    bytewax.recovery,
-    NoPartitionsError,
-    PyFileNotFoundError,
-    "Raised when no recovery partitions are found on any worker.
-
-This is probably due to the wrong recovery directory being specified."
-);
-
-create_exception!(
-    bytewax.recovery,
-    MissingPartitionsError,
-    PyFileNotFoundError,
-    "Raised when an incomplete set of recovery partitions is detected."
-);
-
-impl RecoveryPart {
-    fn init(py: Python, file: &Path, index: PartitionIndex, count: PartitionCount) -> PyResult<()> {
-        tracing::debug!("Init recovery partition {index:?} / {count:?} at {file:?}");
-        let conn = Rc::new(RefCell::new(
-            Connection::open_with_flags(
-                file,
-                OpenFlags::SQLITE_OPEN_READ_WRITE
-                    | OpenFlags::SQLITE_OPEN_CREATE
-                    | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-            )
-            .reraise("can't open recovery DB")?,
-        ));
-        setup_conn(py, &conn);
-
-        let _self = Self { conn };
-        _self
-            .part_writer()
-            .write_batch(vec![PartitionMeta(index, count)]);
-
-        Ok(())
-    }
-
-    fn open(py: Python, file: &Path) -> PyResult<Self> {
-        tracing::debug!("Opening recovery partition at {file:?}");
-        let conn = Rc::new(RefCell::new(
-            Connection::open_with_flags(
-                file,
-                OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-            )
-            .reraise("can't open recovery DB")?,
-        ));
-        setup_conn(py, &conn);
-
-        Ok(Self { conn })
-    }
-
-    fn init_open_mem(py: Python) -> Self {
-        let conn = Rc::new(RefCell::new(Connection::open_in_memory().unwrap()));
-        setup_conn(py, &conn);
-
-        Self { conn }
-    }
-
-    fn part_writer(&self) -> PartitionMetaWriter {
-        PartitionMetaWriter {
-            conn: self.conn.clone(),
-        }
-    }
-
-    fn ex_writer(&self) -> ExecutionMetaWriter {
-        ExecutionMetaWriter {
-            conn: self.conn.clone(),
-        }
-    }
-
-    fn front_writer(&self) -> FrontierWriter {
-        FrontierWriter {
-            conn: self.conn.clone(),
-        }
-    }
-
-    fn snap_writer(&self) -> SerializedSnapshotWriter {
-        SerializedSnapshotWriter {
-            conn: self.conn.clone(),
-        }
-    }
-
-    fn commit_writer(&self) -> CommitWriter {
-        CommitWriter {
-            conn: self.conn.clone(),
-        }
-    }
-
-    fn part_loader(&self) -> PartitionMetaLoader {
-        PartitionMetaLoader::new(self.conn.clone())
-    }
-
-    fn ex_loader(&self) -> ExecutionMetaLoader {
-        ExecutionMetaLoader::new(self.conn.clone())
-    }
-
-    fn front_loader(&self) -> FrontierLoader {
-        FrontierLoader::new(self.conn.clone())
-    }
-
-    /// Will only read the most recent snapshot (epoch-wise) for each
-    /// `(step_id, state_key)` from before the provided epoch.
-    fn snap_loader(&self, before: ResumeEpoch) -> SerializedSnapshotLoader {
-        // TODO: Do we need to futz with the batch size?
-        SerializedSnapshotLoader::new(self.conn.clone(), before, 1000)
-    }
-
-    fn commit_loader(&self) -> CommitLoader {
-        CommitLoader::new(self.conn.clone())
-    }
-
-    fn committer(&self, part_key: PartitionIndex) -> RecoveryCommitter {
-        RecoveryCommitter {
-            conn: self.conn.clone(),
-            part_key,
-        }
-    }
-
-    /// Calculate the resume execution and epoch. You must use this on
-    /// a DB that has all progress data from all partitions written to
-    /// it, so it must be an in-mem one during the resume from
-    /// calculation.
-    fn resume_from(&self) -> PyResult<ResumeFrom> {
-        let mut conn = self.conn.borrow_mut();
-        let txn = conn.transaction().unwrap();
-
-        let part_counts = txn
-            .prepare("SELECT DISTINCT(part_count) FROM parts")
-            .unwrap()
-            .query_map((), |row| Ok(PartitionCount(row.get(0)?)))
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
-        if part_counts.is_empty() {
-            let msg = "No recovery partitions found on any worker; can't resume";
-            return Err(NoPartitionsError::new_err(msg));
-        } else if part_counts.len() > 1 {
-            let msg = "Inconsistent partition counts in recovery partitions; can't resume";
-            return Err(PyValueError::new_err(msg));
-        }
-
-        let part_count = part_counts[0];
-        let expected_parts: BTreeSet<_> = part_count.iter().collect();
-        let found_parts = txn
-            .prepare("SELECT part_index FROM parts")
-            .unwrap()
-            .query_map((), |row| Ok(PartitionIndex(row.get(0)?)))
-            .unwrap()
-            .collect::<Result<BTreeSet<_>, _>>()
-            .unwrap();
-        let missing_parts = &expected_parts - &found_parts;
-        if !missing_parts.is_empty() {
-            let msg = format!(
-                "Missing recovery partitions {missing_parts:?} of {part_count}; can't resume"
-            );
-            return Err(MissingPartitionsError::new_err(msg));
-        }
-
-        let resume_from = txn
-            .query_row(
-                "WITH max_ex AS (
-                 SELECT ex_num, worker_count, resume_epoch
-                 FROM exs
-                 WHERE ex_num = (SELECT MAX(ex_num) FROM exs)
-                 ),
-                 default_progress AS (
-                 SELECT ex_num, value AS worker_index, resume_epoch AS worker_frontier
-                 FROM generate_series(0, (SELECT worker_count - 1 FROM max_ex))
-                 CROSS JOIN max_ex
-                 ),
-                 explicit_progress AS (
-                 SELECT ex_num, worker_index, worker_frontier
-                 FROM fronts
-                 WHERE ex_num = (SELECT MAX(ex_num) FROM exs)
-                 ),
-                 max_progress AS (
-                 SELECT ex_num, worker_index, MAX(worker_frontier) AS worker_frontier
-                 FROM (SELECT * FROM explicit_progress UNION SELECT * FROM default_progress)
-                 GROUP BY ex_num, worker_index
-                 )
-                 SELECT ex_num + 1, MIN(worker_frontier)
-                 FROM max_progress",
-                (),
-                // `MIN(worker_frontier)` always returns a
-                // single row with possible NULL, so we have
-                // to handle the NULL within the row fn,
-                // instead of assuming the result set might be
-                // empty.
-                |row| {
-                    let ex_num = row.get::<_, Option<u64>>(0)?.map(ExecutionNumber);
-                    let resume_epoch = row.get::<_, Option<u64>>(1)?.map(ResumeEpoch);
-                    Ok(ex_num.zip(resume_epoch).map(|(en, re)| ResumeFrom(en, re)))
-                },
-            )
-            .unwrap()
-            .unwrap_or_default();
-
-        let ResumeFrom(_resume_ex, resume_epoch) = resume_from;
-        // These are partitions which for some reason have already
-        // been GC'd and so might be missing data in the resume epoch.
-        let state_missing_parts = txn
-            .prepare("SELECT part_index FROM commits WHERE commit_epoch > ?1")
-            .unwrap()
-            .query_map((resume_epoch.0,), |row| Ok(PartitionIndex(row.get(0)?)))
-            .unwrap()
-            .collect::<Result<BTreeSet<_>, _>>()
-            .unwrap();
-        if !state_missing_parts.is_empty() {
-            let delayed_parts = &expected_parts - &state_missing_parts;
-            let msg = format!(
-                "Recovery partitions {delayed_parts:?} of {part_count} are too old to resume from epoch {resume_epoch} without data loss; \
-                 do you have a newer backup of these partitions?"
-            );
-            return Err(InconsistentPartitionsError::new_err(msg));
-        }
-
-        Ok(resume_from)
-    }
-}
-
-#[test]
-fn resume_from_only_parts() {
-    pyo3::prepare_freethreaded_python();
-    let conn = Python::with_gil(|py| RecoveryPart::init_open_mem(py));
-    conn.part_writer()
-        .write_batch(vec![PartitionMeta(PartitionIndex(0), PartitionCount(1))]);
-
-    let found = conn.resume_from().unwrap();
-    let expected = ResumeFrom(ExecutionNumber(0), ResumeEpoch(1));
-    assert_eq!(found, expected);
-}
-
-#[test]
-fn resume_from_all_explict_fronts() {
-    pyo3::prepare_freethreaded_python();
-    let conn = Python::with_gil(|py| RecoveryPart::init_open_mem(py));
-    conn.part_writer()
-        .write_batch(vec![PartitionMeta(PartitionIndex(0), PartitionCount(1))]);
-    conn.ex_writer().write_batch(vec![ExecutionMeta(
-        ExecutionNumber(1),
-        WorkerCount(3),
-        ResumeEpoch(11),
-    )]);
-    conn.front_writer().write_batch(vec![
-        FrontierMeta(ExecutionNumber(1), WorkerIndex(0), WorkerFrontier(13)),
-        FrontierMeta(ExecutionNumber(1), WorkerIndex(1), WorkerFrontier(12)),
-        FrontierMeta(ExecutionNumber(1), WorkerIndex(2), WorkerFrontier(13)),
-    ]);
-    conn.commit_writer()
-        .write_batch(vec![CommitMeta(PartitionIndex(0), 12)]);
-
-    let found = conn.resume_from().unwrap();
-    let expected = ResumeFrom(ExecutionNumber(2), ResumeEpoch(12));
-    assert_eq!(found, expected);
-}
-
-#[test]
-fn resume_from_default_fronts() {
-    pyo3::prepare_freethreaded_python();
-    let conn = Python::with_gil(|py| RecoveryPart::init_open_mem(py));
-    conn.part_writer()
-        .write_batch(vec![PartitionMeta(PartitionIndex(0), PartitionCount(1))]);
-    conn.ex_writer().write_batch(vec![ExecutionMeta(
-        ExecutionNumber(1),
-        WorkerCount(3),
-        ResumeEpoch(11),
-    )]);
-    conn.front_writer().write_batch(vec![
-        FrontierMeta(ExecutionNumber(1), WorkerIndex(0), WorkerFrontier(13)),
-        FrontierMeta(ExecutionNumber(1), WorkerIndex(2), WorkerFrontier(13)),
-    ]);
-    conn.commit_writer()
-        .write_batch(vec![CommitMeta(PartitionIndex(0), 11)]);
-
-    let found = conn.resume_from().unwrap();
-    let expected = ResumeFrom(ExecutionNumber(2), ResumeEpoch(11));
-    assert_eq!(found, expected);
-}
-
-#[test]
-fn resume_from_inconsistent_error() {
-    pyo3::prepare_freethreaded_python();
-    Python::with_gil(|py| {
-        let conn = RecoveryPart::init_open_mem(py);
-        conn.part_writer().write_batch(vec![
-            PartitionMeta(PartitionIndex(0), PartitionCount(2)),
-            PartitionMeta(PartitionIndex(1), PartitionCount(2)),
-        ]);
-        conn.ex_writer().write_batch(vec![ExecutionMeta(
-            ExecutionNumber(1),
-            WorkerCount(3),
-            ResumeEpoch(11),
-        )]);
-        conn.front_writer().write_batch(vec![
-            FrontierMeta(ExecutionNumber(1), WorkerIndex(0), WorkerFrontier(13)),
-            FrontierMeta(ExecutionNumber(1), WorkerIndex(2), WorkerFrontier(13)),
-        ]);
-        conn.commit_writer().write_batch(vec![
-            CommitMeta(PartitionIndex(0), 12),
-            CommitMeta(PartitionIndex(1), 12),
-        ]);
-
-        let found = conn.resume_from().unwrap_err();
-        assert!(found.is_instance_of::<InconsistentPartitionsError>(py));
-    });
-}
-
-/// Create and init a set of empty recovery partitions.
-///
-/// :arg db_dir: Local directory to create partitions in.
-///
-/// :type db_dir: pathlib.Path
-///
-/// :arg count: Number of partitions to create.
-///
-/// :type count: int
-#[pyfunction]
-fn init_db_dir(py: Python, db_dir: PathBuf, count: PartitionCount) -> PyResult<()> {
-    tracing::warn!("Creating {count:?} recovery partitions in {db_dir:?}");
-    if !db_dir.is_dir() {
-        return Err(PyFileNotFoundError::new_err(format!(
-            "recovery directory {:?} does not exist; please create it with `mkdir`",
-            db_dir
-        )));
-    }
-    for index in count.iter() {
-        let part_file = db_dir.join(format!("part-{}.sqlite3", index.0));
-        RecoveryPart::init(py, &part_file, index, count)
-            .reraise("error init-ing recovery partition")?;
-    }
-    Ok(())
 }
 
 trait FrontierOp<S, D>
@@ -1470,7 +1246,7 @@ where
                             // optimal.
                             let frontier_epoch = frontier.unwrap_or(*cap.time() + 1);
                             let front =
-                                FrontierMeta(ex_num, worker_index, WorkerFrontier(frontier_epoch));
+                                FrontierMeta(ex_num, worker_index, ClusterFrontier(frontier_epoch));
                             tracing::trace!("Frontier now epoch {frontier_epoch:?}");
                             let key = (ex_num, worker_index);
 
@@ -1505,447 +1281,280 @@ where
     }
 }
 
-trait SerializeSnapshotOp<S>
-where
-    S: Scope<Timestamp = u64>,
-{
-    /// Serialize state snapshots using the provided serde.
-    ///
-    /// Although the [`StepId`] and [`StateKey`] are both already
-    /// within the [`SerializedSnapshot`], duplicate them in the key
-    /// position so we can partition and route on them.
-    fn ser_snap(&self) -> Stream<S, ((StepId, StateKey), SerializedSnapshot)>;
-}
-
-impl<S> SerializeSnapshotOp<S> for Stream<S, Snapshot>
-where
-    S: Scope<Timestamp = u64>,
-{
-    fn ser_snap(&self) -> Stream<S, ((StepId, StateKey), SerializedSnapshot)> {
-        // Effectively map-with-epoch.
-        self.unary(Pipeline, "ser_snap", move |_init_cap, _info| {
-            let mut inbuf = Vec::new();
-            let pickle = Python::with_gil(|py| unwrap_any!(py.import_bound("pickle")).unbind());
-
-            move |snaps_input, ser_snaps_output| {
-                snaps_input.for_each(|cap, incoming| {
-                    incoming.swap(&mut inbuf);
-
-                    let epoch = cap.time();
-                    Python::with_gil(|py| {
-                        let ser_snaps =
-                            inbuf
-                                .drain(..)
-                                .map(|Snapshot(step_id, state_key, snap_change)| {
-                                    let ser_change = match snap_change {
-                                        StateChange::Upsert(snap) => {
-                                            let snap = PyObject::from(snap);
-                                            let bytes = unwrap_any!(|| -> PyResult<Vec<u8>> {
-                                                Ok(pickle
-                                                    .bind(py)
-                                                    .call_method1(
-                                                        intern!(py, "dumps"),
-                                                        (snap.bind(py),),
-                                                    )?
-                                                    .downcast::<PyBytes>()?
-                                                    .as_bytes()
-                                                    .to_vec())
-                                            }(
-                                            ));
-                                            Some(bytes)
-                                        }
-                                        StateChange::Discard => None,
-                                    };
-
-                                    let snap_epoch = SnapshotEpoch(*epoch);
-                                    let ser_snap = SerializedSnapshot(
-                                        step_id.clone(),
-                                        state_key.clone(),
-                                        snap_epoch,
-                                        ser_change,
-                                    );
-                                    let key = (step_id, state_key);
-
-                                    (key, ser_snap)
-                                });
-                        ser_snaps_output.session(&cap).give_iterator(ser_snaps);
-                    });
-                });
-            }
-        })
-    }
-}
-
-trait DeserializeSnapshotOp<S>
+pub(crate) trait CompactFrontiersOp<S>
 where
     S: Scope,
 {
-    /// Deserialize state snapshots using the provided serde.
-    fn de_snap(&self) -> Stream<S, Snapshot>;
+    fn compact_frontiers(&self, state_store_cache: Rc<RefCell<StateStoreCache>>) -> ClockStream<S>;
 }
 
-impl<S> DeserializeSnapshotOp<S> for Stream<S, SerializedSnapshot>
-where
-    S: Scope,
-{
-    fn de_snap(&self) -> Stream<S, Snapshot> {
-        self.map(
-            move |SerializedSnapshot(step_id, state_key, _snap_epoch, ser_change)| {
-                let snap_change = match ser_change {
-                    Some(ser_snap) => {
-                        let snap = unwrap_any!(Python::with_gil(|py| -> PyResult<PyObject> {
-                            let pickle = py.import_bound("pickle")?;
-                            Ok(pickle
-                                .call_method1(
-                                    intern!(py, "loads"),
-                                    (PyBytes::new_bound(py, &ser_snap),),
-                                )?
-                                .unbind())
-                        }));
-                        StateChange::Upsert(snap.into())
-                    }
-                    None => StateChange::Discard,
-                };
-
-                Snapshot(step_id, state_key, snap_change)
-            },
-        )
-    }
-}
-
-pub(crate) trait LoadSnapsOp<S>
+impl<S> CompactFrontiersOp<S> for ClockStream<S>
 where
     S: Scope<Timestamp = u64>,
 {
-    /// Read state data from the recovery partitions into the production dataflow.
-    ///
-    /// You will still need to route it to the correct steps. See
-    /// [`FilterSnapsOp::filter_snaps`].
-    ///
-    /// This will dump all state in the epoch of the snapshot so that
-    /// operators can load in epoch order.
-    fn load_snaps(&mut self, before: ResumeEpoch, bundle: RecoveryBundle) -> Stream<S, Snapshot>
-    where
-        S: Scope;
-}
-
-impl<S> LoadSnapsOp<S> for S
-where
-    S: Scope<Timestamp = u64>,
-{
-    fn load_snaps(&mut self, before: ResumeEpoch, bundle: RecoveryBundle) -> Stream<S, Snapshot> {
-        let mut new_part = bundle.new_builder();
-
-        self.partd_load(
-            String::from("load_snaps"),
-            bundle.local_parts(),
-            move |part| new_part(part).borrow().snap_loader(before),
-            S::Timestamp::minimum(),
-        )
-        .delay(
-            |SerializedSnapshot(_step_id, _state_key, snap_epoch, _ser_change), _load_epoch| {
-                snap_epoch.0
-            },
-        )
-        .de_snap()
-    }
-}
-
-pub(crate) trait FilterSnapsOp<S>
-where
-    S: Scope,
-{
-    /// Filter a stream of snapshots to just one for this step.
-    ///
-    /// In general, you'll use this within a stateful operator.
-    ///
-    /// This strips out all the extraneous data from the snapshot.
-    fn filter_snaps(&self, for_step: StepId) -> Stream<S, (StateKey, StateChange)>;
-}
-
-impl<S> FilterSnapsOp<S> for Stream<S, Snapshot>
-where
-    S: Scope,
-{
-    fn filter_snaps(&self, for_step: StepId) -> Stream<S, (StateKey, StateChange)> {
-        self.flat_map(move |Snapshot(step_id, state_key, snap_change)| {
-            if step_id == for_step {
-                Some((state_key, snap_change))
-            } else {
-                None
-            }
-        })
-    }
-}
-
-pub(crate) trait RecoveryWriteOp<S>
-where
-    S: Scope<Timestamp = u64>,
-{
-    /// Write out a stream of all snapshot data being produced by all
-    /// stateful steps in a dataflow. This is basically the entire
-    /// production dataflow recovery system.
-    ///
-    /// You'll add this on at the end of the production dataflow.
-    ///
-    /// Probe the downstream clock to rate limit the dataflow.
-    fn write_recovery(
-        &self,
-        resume_from: ResumeFrom,
-        bundle: RecoveryBundle,
-        epoch_interval: EpochInterval,
-        backup_interval: BackupInterval,
-    ) -> ClockStream<S>;
-}
-
-impl<S> RecoveryWriteOp<S> for Stream<S, Snapshot>
-where
-    S: Scope<Timestamp = u64>,
-{
-    fn write_recovery(
-        &self,
-        resume_from: ResumeFrom,
-        bundle: RecoveryBundle,
-        epoch_interval: EpochInterval,
-        backup_interval: BackupInterval,
-    ) -> ClockStream<S> {
-        let scope = self.scope();
-        let local_parts = bundle.local_parts();
-
-        let mut new_ex_part = bundle.new_builder();
-
-        let ResumeFrom(ex_num, resume_epoch) = resume_from;
-        let write_ex_clock = Some((ex_num, ExecutionMeta(ex_num, scope.w_count(), resume_epoch)))
-            .into_stream_once_at(&scope, resume_epoch.0)
-            .partd_write(
-                String::from("recovery_ex_writer"),
-                local_parts.clone(),
-                BuildHasherDefault::<SeaHasher>::default(),
-                move |part_key| {
-                    let part = new_ex_part(part_key);
-                    let writer = part.borrow().ex_writer();
-                    writer
-                },
-            );
-
-        let mut new_snap_part = bundle.new_builder();
-        let mut new_front_part = bundle.new_builder();
-        let mut new_commit_part = bundle.new_builder();
-
-        let write_snap_clock = self.ser_snap().partd_write(
-            String::from("recovery_snap_writer"),
-            local_parts.clone(),
-            BuildHasherDefault::<SeaHasher>::default(),
-            move |part_key| {
-                let part = new_snap_part(part_key);
-                let writer = part.borrow().snap_writer();
-                writer
-            },
-        );
-
-        write_ex_clock
-            .concat(&write_snap_clock)
-            // We do not have to monitor output progress because that
-            // only makes sense on stateful outputs and their progress
-            // will be captured in the snapshot stream already.
-            .frontier(resume_from)
-            .partd_write(
-                String::from("recovery_front_writer"),
-                local_parts.clone(),
-                BuildHasherDefault::<SeaHasher>::default(),
-                move |part_key| {
-                    let part = new_front_part(part_key);
-                    let writer = part.borrow().front_writer();
-                    writer
-                },
-            )
-            .broadcast()
-            .partd_commit(
-                String::from("recovery_committer"),
-                local_parts,
-                move |part_key| {
-                    let part = new_commit_part(part_key);
-                    let committer = part.borrow().committer(*part_key);
-                    committer
-                },
-                epoch_interval.epochs_per(backup_interval.0),
-            )
-    }
-}
-
-pub(crate) type ProgressStream<S> = (
-    Stream<S, PartitionMeta>,
-    Stream<S, ExecutionMeta>,
-    Stream<S, FrontierMeta>,
-    Stream<S, CommitMeta>,
-);
-
-pub(crate) trait ReadProgressOp {
-    /// Read all progress data into a dataflow.
-    ///
-    /// This'll be used in the calculate resume dataflow.
-    fn read_progress<S>(self, scope: &mut S) -> ProgressStream<S>
-    where
-        S: Scope<Timestamp = u64>;
-}
-
-impl ReadProgressOp for RecoveryBundle {
-    fn read_progress<S>(self, scope: &mut S) -> ProgressStream<S>
-    where
-        S: Scope<Timestamp = u64>,
-    {
-        let mut new_part_part = self.new_builder();
-        let mut new_ex_part = self.new_builder();
-        let mut new_front_part = self.new_builder();
-        let mut new_commit_part = self.new_builder();
-        let parts = scope.partd_load(
-            String::from("recovery_part_loader"),
-            self.local_parts(),
-            move |part| new_part_part(part).borrow().part_loader(),
-            S::Timestamp::minimum(),
-        );
-        let exs = scope.partd_load(
-            String::from("recovery_ex_loader"),
-            self.local_parts(),
-            move |part| new_ex_part(part).borrow().ex_loader(),
-            S::Timestamp::minimum(),
-        );
-        let fronts = scope.partd_load(
-            String::from("recovery_front_loader"),
-            self.local_parts(),
-            move |part| new_front_part(part).borrow().front_loader(),
-            S::Timestamp::minimum(),
-        );
-        let commits = scope.partd_load(
-            String::from("recovery_commit_loader"),
-            self.local_parts(),
-            move |part| new_commit_part(part).borrow().commit_loader(),
-            S::Timestamp::minimum(),
-        );
-        (parts, exs, fronts, commits)
-    }
-}
-
-/// Use to calculate [`ResumeEpoch`] with
-/// [`ResumeFromOp::resume_from`].
-pub(crate) struct ResumeCalc(RecoveryPart);
-
-impl ResumeCalc {
-    pub(crate) fn new(py: Python) -> Self {
-        Self(RecoveryPart::init_open_mem(py))
-    }
-
-    pub(crate) fn resume_from(&self) -> PyResult<ResumeFrom> {
-        self.0.resume_from()
-    }
-}
-
-pub(crate) trait ResumeFromOp<S>
-where
-    S: Scope<Timestamp = u64>,
-{
-    /// Read in streams of progress data and at the end of each epoch
-    /// emit the calculated resume from.
-    ///
-    /// This'll be used in the calculate resume dataflow. Since all
-    /// progress data is read in a single epoch in that dataflow, this
-    /// works.
-    fn resume_from(
-        &self,
-        parts: &Stream<S, PartitionMeta>,
-        exs: &Stream<S, ExecutionMeta>,
-        fronts: &Stream<S, FrontierMeta>,
-        commits: &Stream<S, CommitMeta>,
-        resume_calc: Rc<RefCell<ResumeCalc>>,
-    ) -> Stream<S, ()>;
-}
-
-impl<S> ResumeFromOp<S> for S
-where
-    S: Scope<Timestamp = u64>,
-{
-    fn resume_from(
-        &self,
-        parts: &Stream<S, PartitionMeta>,
-        exs: &Stream<S, ExecutionMeta>,
-        fronts: &Stream<S, FrontierMeta>,
-        commits: &Stream<S, CommitMeta>,
-        resume_calc: Rc<RefCell<ResumeCalc>>,
-    ) -> Stream<S, ()> {
-        let mut op_builder = OperatorBuilder::new(String::from("resume_from"), self.clone());
-
-        let mut parts_input = op_builder.new_input(parts, Pipeline);
-        let mut exs_input = op_builder.new_input(exs, Pipeline);
-        let mut fronts_input = op_builder.new_input(fronts, Pipeline);
-        let mut commits_input = op_builder.new_input(commits, Pipeline);
-
-        let (mut resume_from_output, resume_from) = op_builder.new_output();
+    fn compact_frontiers(&self, state_store_cache: Rc<RefCell<StateStoreCache>>) -> ClockStream<S> {
+        let mut op_builder = OperatorBuilder::new("frontier_compactor".to_string(), self.scope());
+        let mut input = op_builder.new_input(self, Pipeline);
+        let (mut output, clock) = op_builder.new_output();
 
         op_builder.build(move |init_caps| {
-            let mut parts_inbuf = InBuffer::new();
-            let mut exs_inbuf = InBuffer::new();
-            let mut fronts_inbuf = InBuffer::new();
-            let mut commits_inbuf = InBuffer::new();
-            let mut ncater = EagerNotificator::new(init_caps, resume_calc);
+            let mut inbuffer = InBuffer::new();
+            let mut ncater = EagerNotificator::new(init_caps, ());
 
             move |input_frontiers| {
-                parts_input.buffer_notify(&mut parts_inbuf, &mut ncater);
-                exs_input.buffer_notify(&mut exs_inbuf, &mut ncater);
-                fronts_input.buffer_notify(&mut fronts_inbuf, &mut ncater);
-                commits_input.buffer_notify(&mut commits_inbuf, &mut ncater);
+                input.buffer_notify(&mut inbuffer, &mut ncater);
 
                 ncater.for_each(
                     input_frontiers,
-                    |caps, resume_calc| {
+                    |_caps, ()| {},
+                    |caps, ()| {
                         let cap = &caps[0];
                         let epoch = cap.time();
-
-                        let in_mem = &resume_calc.borrow().0;
-
-                        if let Some(parts) = parts_inbuf.remove(epoch) {
-                            let mut part_writer = in_mem.part_writer();
-                            part_writer.write_batch(parts);
-                        }
-                        if let Some(exs) = exs_inbuf.remove(epoch) {
-                            let mut ex_writer = in_mem.ex_writer();
-                            ex_writer.write_batch(exs);
-                        }
-                        if let Some(fronts) = fronts_inbuf.remove(epoch) {
-                            let mut front_writer = in_mem.front_writer();
-                            front_writer.write_batch(fronts);
-                        }
-                        if let Some(commits) = commits_inbuf.remove(epoch) {
-                            let mut commit_writer = in_mem.commit_writer();
-                            commit_writer.write_batch(commits);
-                        }
+                        // Write cluster frontier
+                        unwrap_any!(state_store_cache.borrow_mut().write_frontier(*epoch));
+                        // And finally allow the dataflow to advance its epoch.
+                        output.activate().session(cap).give(());
                     },
-                    |caps, _in_mem| {
-                        let cap = &caps[0];
-
-                        resume_from_output.activate().session(cap).give(());
-                    },
-                );
+                )
             }
         });
-
-        resume_from
+        clock
     }
 }
 
-pub(crate) fn register(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(init_db_dir, m)?)?;
+pub(crate) trait FrontierSegmentOp<S>
+where
+    S: Scope,
+{
+    fn frontier_segment(
+        &self,
+        state_store_cache: Rc<RefCell<StateStoreCache>>,
+    ) -> Stream<S, PathBuf>;
+}
+
+impl<S> FrontierSegmentOp<S> for ClockStream<S>
+where
+    S: Scope<Timestamp = u64>,
+{
+    fn frontier_segment(
+        &self,
+        state_store_cache: Rc<RefCell<StateStoreCache>>,
+    ) -> Stream<S, PathBuf> {
+        let mut op_builder = OperatorBuilder::new("frontier_compactor".to_string(), self.scope());
+        let mut input = op_builder.new_input(self, Pipeline);
+        let (mut segments_output, segments) = op_builder.new_output();
+
+        op_builder.build(move |init_caps| {
+            let mut inbuffer = InBuffer::new();
+            let mut ncater = EagerNotificator::new(init_caps, ());
+
+            move |input_frontiers| {
+                input.buffer_notify(&mut inbuffer, &mut ncater);
+
+                ncater.for_each(
+                    input_frontiers,
+                    |_caps, ()| {},
+                    |caps, ()| {
+                        let clock_cap = &caps[0];
+
+                        let mut handle = segments_output.activate();
+                        let mut session = handle.session(clock_cap);
+
+                        let epochs = inbuffer.epochs().collect::<Vec<_>>();
+                        for epoch in epochs {
+                            let (mut conn, file_name) =
+                                state_store_cache.borrow_mut().open_segment(epoch);
+                            let txn = conn.transaction().unwrap();
+                            inbuffer.remove(&epoch);
+                            state_store_cache
+                                .borrow()
+                                .frontier_query(&txn, epoch)
+                                .unwrap();
+                            txn.commit().unwrap();
+                            session.give(file_name);
+                        }
+                    },
+                )
+            }
+        });
+        segments
+    }
+}
+
+pub(crate) trait DurableBackupOp<S>
+where
+    S: Scope,
+{
+    fn durable_backup(&self, backup: Backup, immediate_backup: bool) -> ClockStream<S>;
+}
+
+impl<S> DurableBackupOp<S> for Stream<S, PathBuf>
+where
+    S: Scope<Timestamp = u64>,
+{
+    fn durable_backup(&self, backup: Backup, immediate_backup: bool) -> ClockStream<S> {
+        let mut op_builder = OperatorBuilder::new("compactor".to_string(), self.scope());
+        let mut input = op_builder.new_input(self, Pipeline);
+        let (mut output, clock) = op_builder.new_output();
+
+        op_builder.build(move |init_caps| {
+            // TODO: EagerNotificator is probably not the right tool here
+            //       since the logic is the same, only the eager one is optional
+            //       depending on a condition, so a slightly different notificator
+            //       might avoid some code duplication and the Rc<RefCell<_>>
+            let inbuffer = Rc::new(RefCell::new(InBuffer::new()));
+            let mut ncater = EagerNotificator::new(init_caps, ());
+
+            move |input_frontiers| {
+                input.buffer_notify(&mut inbuffer.borrow_mut(), &mut ncater);
+
+                ncater.for_each(
+                    input_frontiers,
+                    |_caps, ()| {
+                        if immediate_backup {
+                            // Do the upload
+                            Python::with_gil(|py| {
+                                let epochs = inbuffer.borrow().epochs().collect::<Vec<_>>();
+                                for epoch in epochs {
+                                    for path in inbuffer.borrow_mut().remove(&epoch).unwrap() {
+                                        backup
+                                            .upload(py, path.clone(), "test_key".to_string())
+                                            .unwrap();
+                                    }
+                                }
+                            });
+                        }
+                    },
+                    |caps, ()| {
+                        let cap = &caps[0];
+                        // Do the upload
+                        Python::with_gil(|py| {
+                            let epochs = inbuffer.borrow().epochs().collect::<Vec<_>>();
+                            for epoch in epochs {
+                                for path in inbuffer.borrow_mut().remove(&epoch).unwrap() {
+                                    backup
+                                        .upload(py, path.clone(), "test_key".to_string())
+                                        .unwrap();
+                                }
+                            }
+                        });
+                        // And then
+                        output.activate().session(cap).give(());
+                    },
+                )
+            }
+        });
+        clock
+    }
+}
+
+pub(crate) trait CompactorOp<S>
+where
+    S: Scope,
+{
+    fn compact_snapshots(
+        &self,
+        state_store_cache: Rc<RefCell<StateStoreCache>>,
+    ) -> Stream<S, PathBuf>;
+}
+
+impl<S> CompactorOp<S> for Stream<S, SerializedSnapshot>
+where
+    S: Scope<Timestamp = u64>,
+{
+    fn compact_snapshots(
+        &self,
+        state_store_cache: Rc<RefCell<StateStoreCache>>,
+    ) -> Stream<S, PathBuf> {
+        let mut op_builder = OperatorBuilder::new("compactor".to_string(), self.scope());
+        let mut input = op_builder.new_input(self, Pipeline);
+
+        let (mut immediate_segments_output, immediate_segments) = op_builder.new_output();
+        let (mut batch_segments_output, batch_segments) = op_builder.new_output();
+        let segments = immediate_segments.concatenate(vec![batch_segments]);
+
+        let immediate_snapshot = state_store_cache.borrow().immediate_snapshot();
+
+        op_builder.build(move |init_caps| {
+            // TODO: EagerNotificator is probably not the right tool here
+            //       since the logic is the same, only the eager one is optional
+            //       depending on a condition, so a slightly different notificator
+            //       might avoid some code duplication and the Rc<RefCell<_>>
+            let inbuffer = Rc::new(RefCell::new(InBuffer::new()));
+            let mut ncater = EagerNotificator::new(init_caps, ());
+
+            move |input_frontiers| {
+                input.buffer_notify(&mut inbuffer.borrow_mut(), &mut ncater);
+
+                ncater.for_each(
+                    input_frontiers,
+                    |caps, ()| {
+                        if immediate_snapshot {
+                            let cap = &caps[0];
+                            let mut handle = immediate_segments_output.activate();
+                            let mut session = handle.session(cap);
+
+                            let epochs = inbuffer.borrow().epochs().collect::<Vec<_>>();
+                            for epoch in epochs {
+                                let (mut conn, file_name) =
+                                    state_store_cache.borrow_mut().open_segment(epoch);
+                                let txn = conn.transaction().unwrap();
+                                for snap in inbuffer.borrow_mut().remove(&epoch).unwrap() {
+                                    let SerializedSnapshot(
+                                        step_id,
+                                        state_key,
+                                        snap_epoch,
+                                        ser_change,
+                                    ) = snap;
+                                    txn.execute(
+                                        "INSERT INTO snaps (step_id, state_key, epoch, ser_change)
+                                     VALUES (?1, ?2, ?3, ?4)
+                                     ON CONFLICT (step_id, state_key, epoch) DO UPDATE
+                                     SET ser_change = EXCLUDED.ser_change",
+                                        (step_id.0, state_key.0, snap_epoch.0, ser_change),
+                                    )
+                                    .unwrap();
+                                }
+                                txn.commit().unwrap();
+                                session.give(file_name);
+                            }
+                        }
+                    },
+                    |caps, ()| {
+                        let cap = &caps[1];
+
+                        let mut handle = batch_segments_output.activate();
+                        let mut session = handle.session(cap);
+
+                        let epochs = inbuffer.borrow().epochs().collect::<Vec<_>>();
+                        for epoch in epochs {
+                            let (mut conn, file_name) =
+                                state_store_cache.borrow_mut().open_segment(epoch);
+                            let txn = conn.transaction().unwrap();
+                            for snap in inbuffer.borrow_mut().remove(&epoch).unwrap() {
+                                let SerializedSnapshot(step_id, state_key, snap_epoch, ser_change) =
+                                    snap;
+                                txn.execute(
+                                    "INSERT INTO snaps (step_id, state_key, epoch, ser_change)
+                                     VALUES (?1, ?2, ?3, ?4)
+                                     ON CONFLICT (step_id, state_key, epoch) DO UPDATE
+                                     SET ser_change = EXCLUDED.ser_change",
+                                    (step_id.0, state_key.0, snap_epoch.0, ser_change),
+                                )
+                                .unwrap();
+                            }
+                            txn.commit().unwrap();
+                            session.give(file_name);
+                        }
+                    },
+                )
+            }
+        });
+        segments
+    }
+}
+
+pub(crate) fn register(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<RecoveryConfig>()?;
-    m.add(
-        "InconsistentPartitionsError",
-        py.get_type_bound::<InconsistentPartitionsError>(),
-    )?;
-    m.add(
-        "MissingPartitionsError",
-        py.get_type_bound::<MissingPartitionsError>(),
-    )?;
-    m.add(
-        "NoPartitionsError",
-        py.get_type_bound::<NoPartitionsError>(),
-    )?;
     Ok(())
 }

--- a/src/timely.rs
+++ b/src/timely.rs
@@ -305,6 +305,12 @@ where
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub(crate) struct WorkerIndex(pub(crate) usize);
 
+impl Display for WorkerIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
 /// Integer representing the number of workers in a cluster.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct WorkerCount(pub(crate) usize);
@@ -533,7 +539,8 @@ where
                             let epoch = cap.time();
 
                             if let Some(items) = items_inbuf.remove(epoch) {
-                                assert!(!known.is_empty(), "Known partitions in {name} is empty; did you forget to broadcast initial partitions in the 0th epoch?");
+                                assert!(!known.is_empty(), "Known partitions in {name} is empty; \
+                                    did you forget to broadcast initial partitions in the 0th epoch?");
 
                                 let mut handle = partd_output.activate();
                                 let mut session = handle.session(cap);
@@ -541,7 +548,8 @@ where
                                 for (key, value) in items {
                                     let idx = pf.assign(&key);
                                     let wrapped_idx = idx % len;
-                                    tracing::trace!("Assigner gave value {idx} % {len}; wrapped to {wrapped_idx}");
+                                    tracing::trace!("Assigner gave value {idx} % {len}; \
+                                        wrapped to {wrapped_idx}");
                                     let part = known
                                         .iter()
                                         .nth(wrapped_idx)
@@ -682,7 +690,10 @@ where
 
                             let new_primaries = calc_primaries(known);
                             if new_primaries.is_empty() {
-                                panic!("No partitions found on any worker; did you forget to init them?");
+                                panic!(
+                                    "No partitions found on any worker; \
+                                    did you forget to init them?"
+                                );
                             }
 
                             let mut handle = routing_output.activate();
@@ -762,40 +773,48 @@ where
 
             move |input_frontiers| {
                 tracing::debug_span!("operator", operator = name).in_scope(|| {
-                items_input.buffer_notify(&mut items_inbuf, &mut ncater);
-                routing_input.buffer_notify(&mut routing_inbuf, &mut ncater);
+                    items_input.buffer_notify(&mut items_inbuf, &mut ncater);
+                    routing_input.buffer_notify(&mut routing_inbuf, &mut ncater);
 
-                ncater.for_each(
-                    input_frontiers,
-                    |caps, routing_map| {
-                        let cap = &caps[0];
-                        let epoch = cap.time();
+                    ncater.for_each(
+                        input_frontiers,
+                        |caps, routing_map| {
+                            let cap = &caps[0];
+                            let epoch = cap.time();
 
-                        if let Some(items) = items_inbuf.remove(epoch) {
-                            assert!(!routing_map.is_empty(), "Routing map is empty; did you forget to broadcast initial routes in the 0th epoch?");
+                            if let Some(items) = items_inbuf.remove(epoch) {
+                                assert!(
+                                    !routing_map.is_empty(),
+                                    "Routing map is empty; did you forget to \
+                                    broadcast initial routes in the 0th epoch?"
+                                );
 
-                            let mut handle = routed_output.activate();
-                            let mut session = handle.session(cap);
-                            for key_value in items {
-                                let (key, _value) = &key_value;
-                                let worker = *routing_map.get(key).unwrap_or_else(|| {
-                                    panic!("Key {key:?} is not in this worker's routing map; known keys are {:?}", routing_map.keys());
-                                });
-                                session.give((worker, key_value));
+                                let mut handle = routed_output.activate();
+                                let mut session = handle.session(cap);
+                                for key_value in items {
+                                    let (key, _value) = &key_value;
+                                    let worker = *routing_map.get(key).unwrap_or_else(|| {
+                                        panic!(
+                                            "Key {key:?} is not in this worker's routing map; \
+                                            known keys are {:?}",
+                                            routing_map.keys()
+                                        );
+                                    });
+                                    session.give((worker, key_value));
+                                }
                             }
-                        }
-                    },
-                    |caps, routing_map| {
-                        let cap = &caps[0];
-                        let epoch = cap.time();
+                        },
+                        |caps, routing_map| {
+                            let cap = &caps[0];
+                            let epoch = cap.time();
 
-                        if let Some(routes) = routing_inbuf.remove(epoch) {
-                            for (part, worker) in routes {
-                                routing_map.insert(part, worker);
+                            if let Some(routes) = routing_inbuf.remove(epoch) {
+                                for (part, worker) in routes {
+                                    routing_map.insert(part, worker);
+                                }
                             }
-                        }
-                    },
-                );
+                        },
+                    );
                 });
             }
         });
@@ -925,69 +944,71 @@ where
 
             move |input_frontiers| {
                 tracing::debug_span!("operator", operator = op_name).in_scope(|| {
-                routed_input.for_each(|cap, incoming| {
-                    let epoch = cap.time();
-                    assert!(routed_tmp.is_empty());
-                    incoming.swap(&mut routed_tmp);
-                    for (_worker, (part, (_key, value))) in routed_tmp.drain(..) {
-                        items_inbuf.entry(epoch.clone())
-                            .or_insert_with(BTreeMap::new)
-                            .entry(part)
-                            .or_insert_with(Vec::new)
-                            .push(value);
-                    }
-
-                    ncater.notify_at(epoch.clone());
-                });
-                primaries_input.buffer_notify(&mut primaries_inbuf, &mut ncater);
-
-                ncater.for_each(
-                    input_frontiers,
-                    |caps, parts| {
-                        let cap = &caps[0];
+                    routed_input.for_each(|cap, incoming| {
                         let epoch = cap.time();
+                        assert!(routed_tmp.is_empty());
+                        incoming.swap(&mut routed_tmp);
+                        for (_worker, (part, (_key, value))) in routed_tmp.drain(..) {
+                            items_inbuf
+                                .entry(epoch.clone())
+                                .or_insert_with(BTreeMap::new)
+                                .entry(part)
+                                .or_insert_with(Vec::new)
+                                .push(value);
+                        }
 
-                        // Writing happens eagerly in each epoch. We
-                        // still use a notificator at all because we
-                        // need to ensure that writes happen in epoch
-                        // order.
-                        if let Some(part_to_items) = items_inbuf.remove(epoch) {
-                            let known_parts: Vec<_> = parts.keys().cloned().collect();
-                            for (part_key, items) in part_to_items {
-                                let part = parts
-                                    .get_mut(&part_key)
-                                    .unwrap_or_else(|| {
-                                        panic!("Items routed to partition {part_key} but this worker only has {known_parts:?}");
+                        ncater.notify_at(epoch.clone());
+                    });
+                    primaries_input.buffer_notify(&mut primaries_inbuf, &mut ncater);
+
+                    ncater.for_each(
+                        input_frontiers,
+                        |caps, parts| {
+                            let cap = &caps[0];
+                            let epoch = cap.time();
+
+                            // Writing happens eagerly in each epoch. We
+                            // still use a notificator at all because we
+                            // need to ensure that writes happen in epoch
+                            // order.
+                            if let Some(part_to_items) = items_inbuf.remove(epoch) {
+                                let known_parts: Vec<_> = parts.keys().cloned().collect();
+                                for (part_key, items) in part_to_items {
+                                    let part = parts.get_mut(&part_key).unwrap_or_else(|| {
+                                        panic!(
+                                            "Items routed to partition {part_key} \
+                                            but this worker only has {known_parts:?}"
+                                        );
                                     });
 
-                                let labels = part_label_map
-                                    .get(&part_key)
-                                    .expect("No metric labels found for part key {part_key}");
-                                with_timer!(histogram, labels, part.write_batch(items));
-                            }
-                        }
-                    },
-                    |caps, parts| {
-                        let cap = &caps[0];
-                        let epoch = cap.time();
-
-                        if let Some(primaries) = primaries_inbuf.remove(epoch) {
-                            // If this worker was assigned to be
-                            // primary for a partition, build it.
-                            for (part_key, worker) in primaries {
-                                if worker == this_worker && !parts.contains_key(&part_key) {
-                                    let part = builder(&part_key);
-                                    parts.insert(part_key, part);
-                                } else {
-                                    parts.remove(&part_key);
+                                    let labels = part_label_map
+                                        .get(&part_key)
+                                        .expect("No metric labels found for part key {part_key}");
+                                    with_timer!(histogram, labels, part.write_batch(items));
                                 }
                             }
-                        }
+                        },
+                        |caps, parts| {
+                            let cap = &caps[0];
+                            let epoch = cap.time();
 
-                        // Emit our progress clock.
-                        clock_output.activate().session(cap).give(());
-                    },
-                );
+                            if let Some(primaries) = primaries_inbuf.remove(epoch) {
+                                // If this worker was assigned to be
+                                // primary for a partition, build it.
+                                for (part_key, worker) in primaries {
+                                    if worker == this_worker && !parts.contains_key(&part_key) {
+                                        let part = builder(&part_key);
+                                        parts.insert(part_key, part);
+                                    } else {
+                                        parts.remove(&part_key);
+                                    }
+                                }
+                            }
+
+                            // Emit our progress clock.
+                            clock_output.activate().session(cap).give(());
+                        },
+                    );
                 });
             }
         });

--- a/src/timely.rs
+++ b/src/timely.rs
@@ -528,47 +528,51 @@ where
             let mut ncater = EagerNotificator::new(init_caps, known);
 
             move |input_frontiers| {
-                tracing::debug_span!("operator", operator = name).in_scope(|| {
-                    items_input.buffer_notify(&mut items_inbuf, &mut ncater);
-                    known_input.buffer_notify(&mut known_inbuf, &mut ncater);
+                let _guard = tracing::debug_span!("operator", operator = name).entered();
+                items_input.buffer_notify(&mut items_inbuf, &mut ncater);
+                known_input.buffer_notify(&mut known_inbuf, &mut ncater);
 
-                    ncater.for_each(
-                        input_frontiers,
-                        |caps, known| {
-                            let cap = &caps[0];
-                            let epoch = cap.time();
+                ncater.for_each(
+                    input_frontiers,
+                    |caps, known| {
+                        let cap = &caps[0];
+                        let epoch = cap.time();
 
-                            if let Some(items) = items_inbuf.remove(epoch) {
-                                assert!(!known.is_empty(), "Known partitions in {name} is empty; \
-                                    did you forget to broadcast initial partitions in the 0th epoch?");
+                        if let Some(items) = items_inbuf.remove(epoch) {
+                            assert!(
+                                !known.is_empty(),
+                                "Known partitions in {name} is empty; \
+                                did you forget to broadcast initial partitions in the 0th epoch?"
+                            );
 
-                                let mut handle = partd_output.activate();
-                                let mut session = handle.session(cap);
-                                let len = known.len();
-                                for (key, value) in items {
-                                    let idx = pf.assign(&key);
-                                    let wrapped_idx = idx % len;
-                                    tracing::trace!("Assigner gave value {idx} % {len}; \
-                                        wrapped to {wrapped_idx}");
-                                    let part = known
-                                        .iter()
-                                        .nth(wrapped_idx)
-                                        .expect("hash idx was not in len of known parts")
-                                        .clone();
-                                    session.give((part, (key, value)));
-                                }
+                            let mut handle = partd_output.activate();
+                            let mut session = handle.session(cap);
+                            let len = known.len();
+                            for (key, value) in items {
+                                let idx = pf.assign(&key);
+                                let wrapped_idx = idx % len;
+                                tracing::trace!(
+                                    "Assigner gave value {idx} % {len}; \
+                                        wrapped to {wrapped_idx}"
+                                );
+                                let part = known
+                                    .iter()
+                                    .nth(wrapped_idx)
+                                    .expect("hash idx was not in len of known parts")
+                                    .clone();
+                                session.give((part, (key, value)));
                             }
-                        },
-                        |caps, known| {
-                            let cap = &caps[0];
-                            let epoch = cap.time();
+                        }
+                    },
+                    |caps, known| {
+                        let cap = &caps[0];
+                        let epoch = cap.time();
 
-                            if let Some(parts) = known_inbuf.remove(epoch) {
-                                known.extend(parts);
-                            }
-                        },
-                    );
-                });
+                        if let Some(parts) = known_inbuf.remove(epoch) {
+                            known.extend(parts);
+                        }
+                    },
+                );
             }
         });
 
@@ -1324,49 +1328,49 @@ where
             let mut ncater = EagerNotificator::new(init_caps, parts);
 
             move |input_frontiers| {
-                tracing::debug_span!("operator", operator = op_name).in_scope(|| {
-                    clock_input.buffer_notify(&mut clock_inbuf, &mut ncater);
-                    primaries_input.buffer_notify(&mut primaries_inbuf, &mut ncater);
+                let _guard = tracing::debug_span!("operator", operator = op_name).entered();
+                clock_input.buffer_notify(&mut clock_inbuf, &mut ncater);
+                primaries_input.buffer_notify(&mut primaries_inbuf, &mut ncater);
 
-                    ncater.for_each(
-                        input_frontiers,
-                        |_caps, _parts| {},
-                        |caps, parts| {
-                            let cap = &caps[0];
-                            let epoch = cap.time();
+                ncater.for_each(
+                    input_frontiers,
+                    |_caps, _parts| {},
+                    |caps, parts| {
+                        let cap = &caps[0];
+                        let epoch = cap.time();
 
-                            // We don't use the incoming ticks.
-                            clock_inbuf.remove(epoch);
-                            // Call commit before updating the partitions
-                            // in order to mirror the semantics of the
-                            // write operator.
-                            if let Some(delayed) = epoch.checked_sub(&delay) {
-                                for (part_key, part) in parts.iter_mut() {
-                                    tracing::trace_span!("partition", part_key = ?part_key)
-                                        .in_scope(|| {
-                                            part.commit(&delayed);
-                                        });
+                        // We don't use the incoming ticks.
+                        clock_inbuf.remove(epoch);
+                        // Call commit before updating the partitions
+                        // in order to mirror the semantics of the
+                        // write operator.
+                        if let Some(delayed) = epoch.checked_sub(&delay) {
+                            for (part_key, part) in parts.iter_mut() {
+                                tracing::trace_span!("partition", part_key = ?part_key).in_scope(
+                                    || {
+                                        part.commit(&delayed);
+                                    },
+                                );
+                            }
+                        }
+
+                        if let Some(primaries) = primaries_inbuf.remove(epoch) {
+                            // If this worker was assigned to be
+                            // primary for a partition, build it.
+                            for (part_key, worker) in primaries {
+                                if worker == this_worker && !parts.contains_key(&part_key) {
+                                    let part = builder(&part_key);
+                                    parts.insert(part_key, part);
+                                } else {
+                                    parts.remove(&part_key);
                                 }
                             }
+                        }
 
-                            if let Some(primaries) = primaries_inbuf.remove(epoch) {
-                                // If this worker was assigned to be
-                                // primary for a partition, build it.
-                                for (part_key, worker) in primaries {
-                                    if worker == this_worker && !parts.contains_key(&part_key) {
-                                        let part = builder(&part_key);
-                                        parts.insert(part_key, part);
-                                    } else {
-                                        parts.remove(&part_key);
-                                    }
-                                }
-                            }
-
-                            // Emit our progress clock.
-                            clock_output.activate().session(&cap).give(());
-                        },
-                    );
-                });
+                        // Emit our progress clock.
+                        clock_output.activate().session(&cap).give(());
+                    },
+                );
             }
         });
 


### PR DESCRIPTION
First PR for the advanced recovery proposal.
I'm using a `feature/advanced_recovery` branch as base so we can review this first part and then work on the rest on a separate PR, as this is already quite big on its own.

Introduces the `StateStore` as the way stateful operators interact with their own state.

All the state is now stored in the worker global store that keeps the state in memory, and saves the snapshots to a local db.

Snapshots from all the operators are then passed to the revoery section of the dataflow that uses the `Backup` class to save state segments of each epoch to a durable storage.

This PR doesn't include:
- Unloading of the in memory state to the local db to handle larger than memory state
- Full resume (on rescale, or on problems with local db for fast resume)
- Compaction
- Garbage collection