### PR TITLE
Join mode default now typechecks

### DIFF
--- a/pysrc/bytewax/operators/__init__.py
+++ b/pysrc/bytewax/operators/__init__.py
@@ -1653,7 +1653,7 @@ def join(
     side2: KeyedStream[V],
     /,
     *,
-    mode: Literal["complete"],
+    mode: Literal["complete"] = ...,
 ) -> KeyedStream[Tuple[U, V]]: ...
 
 
@@ -1665,7 +1665,7 @@ def join(
     side3: KeyedStream[W],
     /,
     *,
-    mode: Literal["complete"],
+    mode: Literal["complete"] = ...,
 ) -> KeyedStream[Tuple[U, V, W]]: ...
 
 
@@ -1678,7 +1678,7 @@ def join(
     side4: KeyedStream[X],
     /,
     *,
-    mode: Literal["complete"],
+    mode: Literal["complete"] = ...,
 ) -> KeyedStream[Tuple[U, V, W, X]]: ...
 
 
@@ -1732,7 +1732,7 @@ def join(
 def join(
     step_id: str,
     *sides: KeyedStream[V],
-    mode: Literal["complete"],
+    mode: Literal["complete"] = ...,
 ) -> KeyedStream[Tuple[V, ...]]: ...
 
 
@@ -1748,7 +1748,7 @@ def join(
 def join(
     step_id: str,
     *sides: KeyedStream[Any],
-    mode: JoinMode,
+    mode: JoinMode = ...,
 ) -> KeyedStream[Tuple]: ...
 
 

--- a/pysrc/bytewax/operators/windowing.py
+++ b/pysrc/bytewax/operators/windowing.py
@@ -1776,7 +1776,7 @@ def join_window(
     side1: KeyedStream[V],
     /,
     *,
-    mode: JoinMode,
+    mode: JoinMode = ...,
 ) -> WindowOut[V, Tuple[Optional[V]]]: ...
 
 
@@ -1789,7 +1789,7 @@ def join_window(
     side2: KeyedStream[V],
     /,
     *,
-    mode: JoinMode,
+    mode: JoinMode = ...,
 ) -> WindowOut[Union[U, V], Tuple[Optional[U], Optional[V]]]: ...
 
 
@@ -1803,7 +1803,7 @@ def join_window(
     side3: KeyedStream[W],
     /,
     *,
-    mode: JoinMode,
+    mode: JoinMode = ...,
 ) -> WindowOut[Union[U, V, W], Tuple[Optional[U], Optional[V], Optional[W]]]: ...
 
 
@@ -1818,7 +1818,7 @@ def join_window(
     side4: KeyedStream[X],
     /,
     *,
-    mode: JoinMode,
+    mode: JoinMode = ...,
 ) -> WindowOut[
     Union[U, V, W, X], Tuple[Optional[U], Optional[V], Optional[W], Optional[X]]
 ]: ...
@@ -1830,7 +1830,7 @@ def join_window(
     clock: Clock[V, Any],
     windower: Windower[Any],
     *sides: KeyedStream[V],
-    mode: JoinMode,
+    mode: JoinMode = ...,
 ) -> WindowOut[V, Tuple[Optional[V], ...]]: ...
 
 
@@ -1840,7 +1840,7 @@ def join_window(
     clock: Clock[Any, SC],
     windower: Windower[Any],
     *sides: KeyedStream[Any],
-    mode: JoinMode,
+    mode: JoinMode = ...,
 ) -> WindowOut[Any, Tuple]: ...
 
 

--- a/pytests/operators/test_join.py
+++ b/pytests/operators/test_join.py
@@ -25,14 +25,17 @@ def _build_join_dataflow(
     inp_l: List[int],
     inp_r: List[int],
     out: List[Tuple[Optional[int], Optional[int]]],
-    mode: JoinMode,
+    mode: Optional[JoinMode] = None,
 ) -> Dataflow:
     flow = Dataflow("test_df")
     lefts = op.input("inp_l", flow, TestingSource(inp_l))
     keyed_lefts = op.key_on("key_l", lefts, lambda _: "ALL")
     rights = op.input("inp_r", flow, TestingSource(inp_r))
     keyed_rights = op.key_on("key_r", rights, lambda _: "ALL")
-    joined = op.join("join", keyed_lefts, keyed_rights, mode=mode)
+    if mode is not None:
+        joined = op.join("join", keyed_lefts, keyed_rights, mode=mode)
+    else:
+        joined = op.join("join", keyed_lefts, keyed_rights)
     unkeyed = op.key_rm("unkey", joined)
     op.output("out", unkeyed, TestingSink(out))
     return flow
@@ -44,6 +47,19 @@ def test_join_complete() -> None:
     out: List[Tuple[Optional[int], Optional[int]]] = []
 
     flow = _build_join_dataflow(inp_l, inp_r, out, "complete")
+
+    run_main(flow)
+    assert out == [
+        (1, 2),
+    ]
+
+
+def test_join_default_is_complete() -> None:
+    inp_l = [1]
+    inp_r = [2]
+    out: List[Tuple[Optional[int], Optional[int]]] = []
+
+    flow = _build_join_dataflow(inp_l, inp_r, out)
 
     run_main(flow)
     assert out == [


### PR DESCRIPTION
I forgot to have an overload which says that `mode` is an argument
with a default value, so mypy thinks it's required. Adds `mode = ...`
to the overload that applies for the default value to make this work.

For `join` it's on the "complete" overloads since that is the default
value. For `join_window` it's on the other overloads since the default
is "final".
