### PR TITLE
Fix watermark assertion errors with `EventClock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ For help with updating to new Bytewax versions, please see the
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Fixes a bug when using
+  {py:obj}`~bytewax.operators.windowing.EventClock` where in-order but
+  "slow" data results in watermark assertion errors.
+
 ## v0.20.0
 
 - Adds a dataflow structure visualizer. Run `python -m

--- a/pytests/operators/windowing/test_event_clock.py
+++ b/pytests/operators/windowing/test_event_clock.py
@@ -104,6 +104,31 @@ def test_watermark_does_not_reverse_and_forwards_by_system_time_next_batch() -> 
     assert found_watermark == datetime(2024, 1, 1, 0, 0, 4, tzinfo=timezone.utc)
 
 
+def test_watermark_does_not_reverse_advancing_item_is_slower_than_system_time_gap() -> (
+    None
+):
+    source = TimeTestingGetter(datetime(2024, 1, 1, tzinfo=timezone.utc))
+
+    logic = _EventClockLogic(
+        source.get,
+        lambda x: x,
+        lambda x: x,
+        timedelta(seconds=5),
+    )
+    logic.before_batch()
+    # Watermark should be 7 - 5 = 2
+    logic.on_item(datetime(2024, 1, 1, 0, 0, 7, tzinfo=timezone.utc))
+    # Watermark should be 2 + 2 = 4
+    source.advance(timedelta(seconds=2))
+    logic.before_batch()
+    # Watermark from just this item would be 3.
+    _, found_watermark = logic.on_item(
+        datetime(2024, 1, 1, 0, 0, 8, tzinfo=timezone.utc)
+    )
+    # But must stay as 4.
+    assert found_watermark == datetime(2024, 1, 1, 0, 0, 4, tzinfo=timezone.utc)
+
+
 def test_watermark_is_end_of_time_on_eof() -> None:
     source = TimeTestingGetter(datetime(2024, 1, 1, tzinfo=timezone.utc))
 


### PR DESCRIPTION
I think in my quest to optimize the Python `EventClock`, I assumed that we could take a shortcut and just compare the timestamps of items seen to determine if the watermark would go forward. But no, we need to always calculate the current watermark from the duration since the previous max timestamp seen, then compare that with the watermark that would occur due to this new item, then ensure the watermark itself doesn't go backwards.

I don't think we had a test for this before, but I do think the Rust version of the logic was correct. Added a test which pretty clearly explains the situation.