### PR TITLE
Adds a `TestingSource.PAUSE` special item

### DIFF
--- a/pysrc/bytewax/testing.py
+++ b/pysrc/bytewax/testing.py
@@ -78,7 +78,14 @@ def ffwd_iter(it: Iterator[Any], n: int) -> None:
 class _IterSourcePartition(StatefulSourcePartition[X, int]):
     def __init__(
         self,
-        ib: Iterable[Union[X, "TestingSource.EOF", "TestingSource.ABORT"]],
+        ib: Iterable[
+            Union[
+                X,
+                "TestingSource.EOF",
+                "TestingSource.ABORT",
+                "TestingSource.PAUSE",
+            ]
+        ],
         batch_size: int,
         resume_state: Optional[int],
     ):
@@ -192,7 +199,7 @@ class TestingSource(FixedPartitionedSource[X, int]):
 
         for_duration: timedelta
 
-    def __init__(self, ib: Iterable[Union[X, EOF, ABORT]], batch_size: int = 1):
+    def __init__(self, ib: Iterable[Union[X, EOF, ABORT, PAUSE]], batch_size: int = 1):
         """Init.
 
         :arg ib: Iterable for input.


### PR DESCRIPTION
This is useful for testing stuff that interacts with the notification
system in stateful operators in "integration" style, run an actual
dataflow tests.

This should be used sparingly. First, if there is a way to phrase your problem using event time, do that instead of system time. Then have a system "now getter" mock point in
your stateful operator logic so you can unit test your `notify_at`
return value. But at some point you should do an actual test in a
dataflow that uses the awakening machinery that goes through Timely,
and there's no good way to mock that out.
