### PR TITLE
Fix issue with `SlidingWindower` assigning to too many windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ For help with updating to new Bytewax versions, please see the
 __Add any extra change notes here and we'll put them in the release
 notes on GitHub when we make a new release.__
 
+- Fixes a bug when using
+  {py:obj}`~bytewax.operators.windowing.SlidingWindower` where values
+  would be assigned to an extra window if their timestamps were near
+  the end of the correct window.
+
 - Upstream type hints on
   {py:obj}`bytewax.connectors.kafka.operators.serialize_key`,
   {py:obj}`~bytewax.connectors.kafka.operators.serialize_value`, and

--- a/pytests/operators/windowing/test_sliding_windower.py
+++ b/pytests/operators/windowing/test_sliding_windower.py
@@ -186,6 +186,30 @@ def test_intersect_overlap_offset_indivisible_by_length_bulk_positive():
     ]
 
 
+def test_intersect_overlap_offset_indivisible_by_length_bulk_positive_remainder():
+    logic = _SlidingWindowerLogic(
+        length=timedelta(seconds=10),
+        offset=timedelta(seconds=3),
+        align_to=datetime(2023, 3, 16, 9, 0, 0, tzinfo=timezone.utc),
+        state=_SlidingWindowerState(),
+    )
+
+    #            9:00:11.5
+    #            I
+    # [0--------)
+    #    [1--------)
+    #       [2--------)
+    #          [3--------)
+    #             [4--------)
+    assert logic.intersects(
+        datetime(2023, 3, 16, 9, 0, 11, 500000, tzinfo=timezone.utc)
+    ) == [
+        1,
+        2,
+        3,
+    ]
+
+
 def test_intersect_overlap_offset_indivisible_by_length_bulk_negative():
     logic = _SlidingWindowerLogic(
         length=timedelta(seconds=10),
@@ -202,6 +226,30 @@ def test_intersect_overlap_offset_indivisible_by_length_bulk_negative():
     #          [--------1)
     #             [0--------)
     assert logic.intersects(datetime(2023, 3, 16, 8, 59, 59, tzinfo=timezone.utc)) == [
+        -3,
+        -2,
+        -1,
+    ]
+
+
+def test_intersect_overlap_offset_indivisible_by_length_bulk_negative_remainder():
+    logic = _SlidingWindowerLogic(
+        length=timedelta(seconds=10),
+        offset=timedelta(seconds=3),
+        align_to=datetime(2023, 3, 16, 9, 0, 0, tzinfo=timezone.utc),
+        state=_SlidingWindowerState(),
+    )
+
+    #            8:59:58.5
+    #            I
+    # [--------4)
+    #    [--------3)
+    #       [--------2)
+    #          [--------1)
+    #             [0--------)
+    assert logic.intersects(
+        datetime(2023, 3, 16, 8, 59, 58, 500000, tzinfo=timezone.utc)
+    ) == [
         -3,
         -2,
         -1,


### PR DESCRIPTION
Should fix https://github.com/bytewax/bytewax/issues/485

I think what was happening was I was incorrectly using the distance from the end of the previous window as the time to the start of the next window to calculate if we needed to have the maximum overlap number of windows.

In any case, I did some more thinking and found a much simpler algorithm that gives us the same behavior. Adds tests for the missed cases.