### PR TITLE
Changes due to RTD deprecations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,6 +95,9 @@ nitpick_ignore = [
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+print("READTHEDOCS_CANONICAL_URL", html_baseurl)
+
 html_show_copyright = False
 html_show_sourcelink = False
 html_static_path = ["_static"]


### PR DESCRIPTION
I got an email that Read the Docs is changing up their build environment in a way that requires explicit changes. https://about.readthedocs.com/blog/2024/07/addons-by-default/ has the details. It looks like the only thing that affects us is that we need to now manually read our custom domain from an env var, since now they are no longer injecting custom code into the Sphinx build.

I have gone an enabled the "addons" in our RtD project, which now injects the version switcher through JS, rather than the Sphinx build. They updated the design of it slightly and moved it to the right-hand side from the left, but the functionality is unchanged and works correctly. You can see an example in the CI doc build in this PR.