### PR TITLE
Use raise ... from ... in reraise error handlers

### DIFF
--- a/pysrc/bytewax/errors.py
+++ b/pysrc/bytewax/errors.py
@@ -1,0 +1,12 @@
+"""Utilities for error handling.
+
+When exceptions are thrown in Python from user code, errors
+are wrapped with a {py:obj}`bytewax.errors.BytewaxRuntimeError`. and
+annotated with additional context from the Rust runtime.
+"""
+
+
+class BytewaxRuntimeError(RuntimeError):
+    """A RuntimeError thrown by the Bytewax Runtime."""
+
+    pass

--- a/pysrc/bytewax/errors.py
+++ b/pysrc/bytewax/errors.py
@@ -1,12 +1,12 @@
-"""Utilities for error handling.
-
-When exceptions are thrown in Python from user code, errors
-are wrapped with a {py:obj}`bytewax.errors.BytewaxRuntimeError`. and
-annotated with additional context from the Rust runtime.
-"""
+"""Utilities for error handling."""
 
 
 class BytewaxRuntimeError(RuntimeError):
-    """A RuntimeError thrown by the Bytewax Runtime."""
+    """A RuntimeError thrown by the Bytewax Runtime.
+
+    When exceptions are thrown in Python from user code, errors
+    can be chained from this error to provide additional context
+    from the Rust runtime.
+    """
 
     pass

--- a/pytests/connectors/test_kafka.py
+++ b/pytests/connectors/test_kafka.py
@@ -12,6 +12,7 @@ from bytewax.connectors.kafka import (
     KafkaSourceMessage,
 )
 from bytewax.dataflow import Dataflow
+from bytewax.errors import BytewaxRuntimeError
 from bytewax.testing import TestingSink, TestingSource, poll_next_batch, run_main
 from confluent_kafka import (
     OFFSET_BEGINNING,
@@ -134,8 +135,7 @@ def test_input_raises_on_topic_not_exist():
     )
     op.output("out", s, TestingSink(out))
 
-    expect = "Broker: Unknown topic or partition"
-    with raises(Exception, match=re.escape(expect)):
+    with raises(BytewaxRuntimeError):
         run_main(flow)
 
 

--- a/pytests/operators/test_branch.py
+++ b/pytests/operators/test_branch.py
@@ -69,8 +69,9 @@ def test_branch_raises_on_non_bool_key():
     op.output("out_evens", evens, TestingSink(out_evens))
 
     expect = "must be a `bool`"
-    with raises(TypeError, match=re.escape(expect)):
-        run_main(flow)
+    with raises(RuntimeError):
+        with raises(TypeError, match=re.escape(expect)):
+            run_main(flow)
 
 
 def build_branch_dataflow(

--- a/pytests/operators/test_flatten.py
+++ b/pytests/operators/test_flatten.py
@@ -29,5 +29,6 @@ def test_flatten_raises():
     op.output("out", s, TestingSink(out))
 
     expect = "to be iterables"
-    with raises(TypeError, match=re.escape(expect)):
-        run_main(flow)
+    with raises(RuntimeError):
+        with raises(TypeError, match=re.escape(expect)):
+            run_main(flow)

--- a/pytests/operators/test_key_on.py
+++ b/pytests/operators/test_key_on.py
@@ -30,5 +30,6 @@ def test_key_on_raises_on_non_str_key():
     op.output("out", s, TestingSink(out))
 
     expect = "must be a `str`"
-    with raises(TypeError, match=re.escape(expect)):
-        run_main(flow)
+    with raises(RuntimeError):
+        with raises(TypeError, match=re.escape(expect)):
+            run_main(flow)

--- a/pytests/operators/test_stateful_map.py
+++ b/pytests/operators/test_stateful_map.py
@@ -49,5 +49,6 @@ def test_stateful_map_raises_on_non_tuple():
     op.output("out", s, TestingSink(out))
 
     expect = "must be a 2-tuple"
-    with raises(TypeError, match=re.escape(expect)):
-        run_main(flow)
+    with raises(RuntimeError):
+        with raises(TypeError, match=re.escape(expect)):
+            run_main(flow)

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -25,30 +25,7 @@ def test_run(entry_point):
     assert sorted(out) == sorted([1, 2, 3])
 
 
-def test_reraises_exception(entry_point):
-    flow = Dataflow("test_df")
-    inp = range(3)
-    stream = op.input("inp", flow, TestingSource(inp))
-
-    def boom(item):
-        if item == 0:
-            msg = "BOOM"
-            raise RuntimeError(msg)
-        else:
-            return item
-
-    stream = op.map("explode", stream, boom)
-    out = []
-    op.output("out", stream, TestingSink(out))
-
-    with raises(RuntimeError):
-        entry_point(flow)
-
-    assert len(out) < 3
-
-
-@mark.parametrize("entry_point_name", ["run_main"])
-def test_reraises_custom_exception_run_main(entry_point):
+def test_reraises_custom_exception(entry_point):
     class CustomException(Exception):
         """A custom exception with more than one argument"""
 

--- a/pytests/test_execution.py
+++ b/pytests/test_execution.py
@@ -7,6 +7,7 @@ from typing import BinaryIO
 
 import bytewax.operators as op
 from bytewax.dataflow import Dataflow
+from bytewax.errors import BytewaxRuntimeError
 from bytewax.testing import TestingSink, TestingSource
 from pytest import mark, raises
 
@@ -46,7 +47,8 @@ def test_reraises_exception(entry_point):
     assert len(out) < 3
 
 
-def test_reraises_custom_exception(entry_point):
+@mark.parametrize("entry_point_name", ["run_main"])
+def test_reraises_custom_exception_run_main(entry_point):
     class CustomException(Exception):
         """A custom exception with more than one argument"""
 
@@ -69,7 +71,7 @@ def test_reraises_custom_exception(entry_point):
     out = []
     op.output("out", stream, TestingSink(out))
 
-    with raises(RuntimeError):
+    with raises(BytewaxRuntimeError):
         with raises(CustomException):
             entry_point(flow)
 

--- a/pytests/test_inputs.py
+++ b/pytests/test_inputs.py
@@ -31,8 +31,9 @@ def test_flow_requires_input():
     flow = Dataflow("test_df")
 
     expect = "at least one input"
-    with raises(ValueError, match=re.escape(expect)):
-        run_main(flow)
+    with raises(RuntimeError):
+        with raises(ValueError, match=re.escape(expect)):
+            run_main(flow)
 
 
 def test_dynamic_source_next_batch_iterator():

--- a/pytests/test_outputs.py
+++ b/pytests/test_outputs.py
@@ -13,5 +13,6 @@ def test_flow_requires_output():
     op.input("inp", flow, TestingSource(inp))
 
     expect = "at least one output"
-    with raises(ValueError, match=re.escape(expect)):
-        run_main(flow)
+    with raises(RuntimeError):
+        with raises(ValueError, match=re.escape(expect)):
+            run_main(flow)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,7 +3,6 @@ use std::panic::Location;
 
 use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyRuntimeError;
-use pyo3::types::PyAnyMethods;
 use pyo3::types::PyTracebackMethods;
 use pyo3::PyDowncastError;
 use pyo3::PyErr;
@@ -56,89 +55,47 @@ pub(crate) trait PythonException<T> {
         })
     }
 
-    /// Make the existing error part of the traceback and raise a new
-    /// exception with the same type and an additional message.
+    /// Create a new RuntimeError with a custom message, setting
+    /// the current exception as it's cause.
     ///
     /// Example:
     ///
     /// ```ignore
-    /// func().reraise("Reraise same exception adding this message")?;
+    /// func().reraise("Reraise a new RuntimeError with this message")?;
     /// ```
     #[track_caller]
     fn reraise(self, msg: &'static str) -> PyResult<T>
     where
         Self: Sized,
     {
-        let caller = Location::caller();
         self.into_pyresult().map_err(|err| {
             Python::with_gil(|py| {
-                // Python treats KeyError differently then others:
-                // the message is always quoted, so that in case the key
-                // is an empty string, you see:
-                //
-                //   KeyError: ''
-                //
-                // instead of:
-                //
-                //   KeyError:
-                //
-                // This means that our message will be quoted if we reraise
-                // it as it is. So in this case we raise a RuntimeError instead.
-                if err.get_type_bound(py).is(&pyo3::types::PyType::new_bound::<
-                    pyo3::exceptions::PyKeyError,
-                >(py))
-                {
-                    PyRuntimeError::new_err(build_message(py, caller, &err, msg))
-                } else {
-                    PyErr::from_type_bound(
-                        err.get_type_bound(py),
-                        build_message(py, caller, &err, msg),
-                    )
-                }
+                let new_err = PyRuntimeError::new_err(msg);
+                new_err.set_cause(py, Some(err));
+                new_err
             })
         })
     }
 
-    /// Make the existing error part of the traceback and raise a new
-    /// exception with the same type and an additional message.
+    /// Create a new RuntimeError with a custom message, setting
+    /// the current exception as it's cause.
     ///
     /// Example:
     ///
     /// ```ignore
-    /// func().reraise_with(|| format("Reraise same exception adding this message"))?;
+    /// func().reraise_with(|| format("Reraise a RuntimeError with this message"))?;
     /// ```
     #[track_caller]
     fn reraise_with(self, f: impl FnOnce() -> String) -> PyResult<T>
     where
         Self: Sized,
     {
-        let caller = Location::caller();
         self.into_pyresult().map_err(|err| {
             let msg = f();
             Python::with_gil(|py| {
-                // Python treats KeyError differently then others:
-                // the message is always quoted, so that in case the key
-                // is an empty string, you see:
-                //
-                //   KeyError: ''
-                //
-                // instead of:
-                //
-                //   KeyError:
-                //
-                // This means that our message will be quoted if we reraise
-                // it as it is. So in this case we raise a RuntimeError instead.
-                if err.get_type_bound(py).is(&pyo3::types::PyType::new_bound::<
-                    pyo3::exceptions::PyKeyError,
-                >(py))
-                {
-                    PyRuntimeError::new_err(build_message(py, caller, &err, &msg))
-                } else {
-                    PyErr::from_type_bound(
-                        err.get_type_bound(py),
-                        build_message(py, caller, &err, &msg),
-                    )
-                }
+                let new_err = PyRuntimeError::new_err(msg);
+                new_err.set_cause(py, Some(err));
+                new_err
             })
         })
     }


### PR DESCRIPTION
Custom exceptions with more than one parameter could not be instantiated in our `reraise` handlers that re-create the original exception with a custom message. 

This commit uses PyO3's [`set_cause`](https://docs.rs/pyo3/latest/pyo3/prelude/struct.PyErr.html#method.set_cause) to set the original exception as the chained exception to a newly created `RuntimeError`.

This PR fixes the issue that was originally encountered when custom errors
from [urllib3](https://github.com/urllib3/urllib3/blob/951ea12ba18103e5434e751246c0895e54fef211/urllib3/exceptions.py#L26) were thrown from the `confluent-kafka` library.