### PR TITLE
feat: enable dynamic max_size for collect operator

### DIFF
--- a/pysrc/bytewax/operators/__init__.py
+++ b/pysrc/bytewax/operators/__init__.py
@@ -1114,7 +1114,7 @@ class _CollectLogic(StatefulLogic[V, List[V], _CollectState[V]]):
     step_id: str
     now_getter: Callable[[], datetime]
     timeout: timedelta
-    max_size: int | Callable
+    max_size: int | Callable[[V], int]
     state: _CollectState[V]
 
     @override


### PR DESCRIPTION
`op.collect` currently supports constant `max_size`, would be good to have an option to set `max_size` as dynamic, where the `max_size` could be determined by item that the stream receives

our company is using bytewax for stateful stream processing, and found a use case that requires dynamic `max_size`: i.e. we key our event stream by `zone`, and events from different `zone` would have different `max_size` at `op.collect`, it helps the events collected at a zone to be immediately emitted when it collects enough of events

My PR serves as an illustration of my prelim idea, open to discuss a better way to implement this feature!

btw Great product!