### PR TITLE
join_window: properly shim `EventClock`

### DIFF
--- a/pysrc/bytewax/operators/windowing.py
+++ b/pysrc/bytewax/operators/windowing.py
@@ -1854,6 +1854,8 @@ def join_window(
         clock = EventClock(
             ts_getter=shim_getter,
             wait_for_system_duration=clock.wait_for_system_duration,
+            now_getter=clock.now_getter,
+            to_system_utc=clock.to_system_utc,
         )
 
     def shim_builder(


### PR DESCRIPTION
When using the `join_window` operator with an `EventClock`, the clock's `now_getter` argument is ignored. This is because the passed `EventClock` gets replaced by the following logic in `bytewax.operators.windowing.py` line 1816 and onwards:

```python
    # TODO: Egregious hack. Remove when we refactor to have timestamps
    # in stream.
    if isinstance(clock, EventClock):
        value_ts_getter = clock.ts_getter

        def shim_getter(i_v: Tuple[str, Any]) -> datetime:
            _, v = i_v
            return value_ts_getter(v)

        clock = EventClock(
            ts_getter=shim_getter,
            wait_for_system_duration=clock.wait_for_system_duration,
        )
```

To fix this, we need to pass `now_getter=clock.now_getter` to the new `EventClock` instance.