### PR TITLE
Introducing Bytewax Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Actions Status](https://github.com/bytewax/bytewax/workflows/CI/badge.svg)](https://github.com/bytewax/bytewax/actions)
 [![PyPI](https://img.shields.io/pypi/v/bytewax.svg?style=flat-square)](https://pypi.org/project/bytewax/)
 [![Bytewax User Guide](https://img.shields.io/badge/user-guide-brightgreen?style=flat-square)](https://docs.bytewax.io/stable/guide/index.html)
+[![](https://img.shields.io/badge/Gurubase-Ask%20Bytewax%20Guru-006BFF)](https://gurubase.io/g/bytewax)
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/bytewax/bytewax/assets/53014647/cd47293b-72c9-423c-b010-2c4990206c60" width="350">


### PR DESCRIPTION
Hello Bytewax team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Bytewax Guru](https://gurubase.io/g/bytewax) to Gurubase. Bytewax Guru uses the data from this repo and data from the [docs](https://docs.bytewax.io/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Bytewax Guru" badge, which highlights that Bytewax now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Bytewax Guru in Gurubase, just let me know that's totally fine.
