### PR TITLE
Adding kafka dependencies to bytewax installation in docker images

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -9,7 +9,7 @@ RUN apt-get update && \
     python3 -m venv /venv && \
     /venv/bin/pip install --upgrade pip setuptools wheel
 
-RUN /venv/bin/pip3 install bytewax==$BYTEWAX_VERSION
+RUN /venv/bin/pip3 install bytewax[kafka]==$BYTEWAX_VERSION
 
 FROM python:$PYTHON_VERSION-slim-bullseye AS runner
 COPY --from=build /venv /venv


### PR DESCRIPTION
This PR adds `[kafka]` dependencies to the `pip install` command within the Bytewax Docker images to ensure Kafka functionality is readily available.
