### PR TITLE
Adding missing python version 3.12 on CD

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11','3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v2
     - name: Set up QEMU

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11','3.12']
     steps:
     - uses: actions/checkout@v2
     - name: Set up QEMU


### PR DESCRIPTION
This PR adds the missing Python version 3.12 on the CD.