### PR TITLE
[CHORE] Tweak docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for investing your time in contributing to our project! Any
 contribution you make will be included in future Bytewax releases ✨.
 
 To get an overview of the project, read the
-[README](https://github.com/bytewax/bytewax/README.md)
+[README](https://github.com/bytewax/bytewax/blob/main/README.md)
 
 Read our [Code of
 Conduct](https://github.com/bytewax/bytewax/blob/main/CODE_OF_CONDUCT.md) to

--- a/docs/guide/contributing/local-development.md
+++ b/docs/guide/contributing/local-development.md
@@ -58,6 +58,15 @@ but I recommend installing it through either
 [`brew`](https://brew.sh/) on macOS or
 [`pipx`](https://pipx.pypa.io/stable/).
 
+### Install `cbfmt`
+
+We use [`cbfmt`](https://github.com/lukas-reineke/cbfmt) as a formatter for codeblocks
+within markdown files. If you have installed the Rust toolchain it can be installed by running
+
+```console
+cargo install cbfmt
+```
+
 (xref-dev-venv)=
 ## Setup the Reproducible Development Virtual Environment
 

--- a/docs/guide/getting-started/execution.md
+++ b/docs/guide/getting-started/execution.md
@@ -126,7 +126,7 @@ $ python -m bytewax.run -w3 simple
 ### Adding workers with waxctl
 
 ```console
-$ waxctl run simple.py --workers=4
+$ waxctl run simple.py --workers=3
 ```
 
 (xref-cluster)=

--- a/docs/guide/getting-started/join-example.md
+++ b/docs/guide/getting-started/join-example.md
@@ -78,7 +78,6 @@ In our example data, we'll use the `user_id` field.
 ```{testcode}
 from bytewax import operators as op
 
-from bytewax.connectors.stdio import StdOutSink
 from bytewax.dataflow import Dataflow
 from bytewax.testing import TestingSource
 

--- a/docs/guide/getting-started/join-example.md
+++ b/docs/guide/getting-started/join-example.md
@@ -129,7 +129,7 @@ join.debug: ('123', ({'user_id': '123', 'name': 'Bumble'}, {'user_id': '123', 'e
 ```
 
 Notice that we don't see any output for `user_id` 456. Since we didn't
-receive any input for that key from `inp2`, we won't see any output
+receive any input for that key from `inp1`, we won't see any output
 for that user until we do.
 
 For more details about the behavior of the join operator, see the


### PR DESCRIPTION
## Summary
Was going through the getting_started examples and got a confused by a typo in the `join_example`. This PR fixes that typo and some other things I came across when setting up the development set-up. Feel free to decline if this is too small to warrant a PR 

### Tweaks

- Fix broken README link in `CONTRIBUTING.md`
- Add `cbfmt` install instructions so pre-commit works
- Change `execution.md` to avoid potential confusion about whether `-w3` argument for `bytewax.run` means additional or total workers
- Fix `join-example.md` to refer to the right input stream

I also had an issue running `just get-started` which raised

```
× Failed to build `bytewax @ file:///Users/graaf015/dev/github/bytewax`
  ├─▶ Failed to parse: `pyproject.toml`
  ╰─▶ TOML parse error at line 1, column 1
        |
      1 | [project]
        | ^^^^^^^^^
      `pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list
```

Fixed it locally by adding a `version` to the pyproject.toml but opted not to add it to the PR in case it messes with packaging/releases. Mentioning it here in case its worth fixing or mentioning in the docs as well.