### PR TITLE
Bump PyO3 to 0.23.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -440,7 +440,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -544,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1153,7 +1153,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1188,9 +1188,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1241,16 +1241,16 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "pyo3"
-version = "0.21.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a8b1990bd018761768d5e608a13df8bd1ac5f678456e0f301bb93e5f3ea16b"
+checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
 dependencies = [
  "cfg-if",
  "chrono",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650dca34d463b6cdbdb02b1d71bfd6eb6b6816afc708faebb3bac1380ff4aef7"
+checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1270,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a7da8fc04a8a2084909b59f29e1b8474decac98b951d77b80b26dc45f046ad"
+checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1280,27 +1280,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8a199fce11ebb28e3569387228836ea98110e43a804a530a9fd83ade36d513"
+checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fbbfd7eb553d10036513cb122b888dcd362a945a00b06c165f2ab480d4cc3b"
+checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
 dependencies = [
  "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1502,7 +1502,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1593,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1664,7 +1664,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1804,7 +1804,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1931,7 +1931,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2114,7 +2114,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
@@ -2148,7 +2148,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2359,5 +2359,5 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.96",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ opentelemetry-jaeger = { version = "0.19", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.13", features = ["trace", "reqwest-client", "grpc-tonic"] }
 opentelemetry-prometheus = "0.13.0"
 prometheus = { version = "0.13.3" }
-pyo3 = { version = "0.21.1", features = [ "macros", "chrono"] }
+pyo3 = { version = "0.23", features = [ "macros", "chrono"] }
 rusqlite = { version = "0.30.0", features = ["bundled", "series"] }
 rusqlite_migration = { version = "1.1.0" }
 seahash = { version = "4.1.0" }
@@ -32,7 +32,7 @@ tracing-opentelemetry = { version = "0.20" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-pyo3 = { version = "0.21.1", features = ["macros", "chrono"] }
+pyo3 = { version = "0.23", features = ["macros", "chrono"] }
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -5,6 +5,7 @@ use pyo3::types::PyDict;
 use crate::errors::PythonException;
 use crate::recovery::StepId;
 
+#[derive(IntoPyObject)]
 pub(crate) struct Dataflow(PyObject);
 
 /// Do some eager type checking.
@@ -19,12 +20,6 @@ impl<'py> FromPyObject<'py> for Dataflow {
         } else {
             Ok(Self(ob.to_object(py)))
         }
-    }
-}
-
-impl IntoPy<Py<PyAny>> for Dataflow {
-    fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
-        self.0
     }
 }
 

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -11,7 +11,7 @@ pub(crate) struct Dataflow(PyObject);
 impl<'py> FromPyObject<'py> for Dataflow {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let abc = py.import_bound("bytewax.dataflow")?.getattr("Dataflow")?;
+        let abc = py.import("bytewax.dataflow")?.getattr("Dataflow")?;
         if !ob.is_instance(&abc)? {
             Err(PyTypeError::new_err(
                 "dataflow must subclass `bytewax.dataflow.Dataflow`",
@@ -44,7 +44,7 @@ pub(crate) struct Operator(PyObject);
 impl<'py> FromPyObject<'py> for Operator {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let abc = py.import_bound("bytewax.dataflow")?.getattr("Operator")?;
+        let abc = py.import("bytewax.dataflow")?.getattr("Operator")?;
         if !ob.is_instance(&abc)? {
             Err(PyTypeError::new_err(
                 "operator must subclass `bytewax.dataflow.Operator`",
@@ -82,9 +82,7 @@ impl Operator {
     }
 
     pub(crate) fn is_core(&self, py: Python) -> PyResult<bool> {
-        let core_cls = py
-            .import_bound("bytewax.dataflow")?
-            .getattr("_CoreOperator")?;
+        let core_cls = py.import("bytewax.dataflow")?.getattr("_CoreOperator")?;
         self.0.bind(py).is_instance(&core_cls)
     }
 

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -18,7 +18,7 @@ impl<'py> FromPyObject<'py> for Dataflow {
                 "dataflow must subclass `bytewax.dataflow.Dataflow`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }
@@ -45,7 +45,7 @@ impl<'py> FromPyObject<'py> for Operator {
                 "operator must subclass `bytewax.dataflow.Operator`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -101,7 +101,7 @@ impl Operator {
             .getattr(port_name)
             .reraise_with(|| format!("operator did not have MultiPort {port_name:?}"))?
             .getattr("stream_ids")?
-            .extract::<&PyDict>()?;
+            .extract::<Bound<'_, PyDict>>()?;
         stream_ids.values().extract()
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -167,7 +167,7 @@ fn build_message(py: Python, caller: &Location, err: &PyErr, msg: &str) -> Strin
 }
 
 fn get_traceback(py: Python, err: &PyErr) -> Option<String> {
-    err.traceback_bound(py).map(|tb| {
+    err.traceback(py).map(|tb| {
         tb.format()
             .unwrap_or_else(|_| "Unable to print traceback".to_string())
     })

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,9 +2,8 @@ use std::panic::Location;
 
 use pyo3::exceptions::PyException;
 use pyo3::import_exception;
-use pyo3::prelude::*;
 use pyo3::types::PyTracebackMethods;
-use pyo3::PyDowncastError;
+use pyo3::DowncastError;
 use pyo3::PyErr;
 use pyo3::PyResult;
 use pyo3::PyTypeInfo;
@@ -143,7 +142,7 @@ impl<T> PythonException<T> for Result<T, Box<dyn std::error::Error>> {
     }
 }
 
-impl<T> PythonException<T> for Result<T, PyDowncastError<'_>> {
+impl<T> PythonException<T> for Result<T, DowncastError<'_, '_>> {
     fn into_pyresult(self) -> PyResult<T> {
         self.map_err(|err| PyErr::new::<PyException, _>(format!("{err}")))
     }

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -111,7 +111,7 @@ pub(crate) struct Source(Py<PyAny>);
 impl<'py> FromPyObject<'py> for Source {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let abc = py.import_bound("bytewax.inputs")?.getattr("Source")?;
+        let abc = py.import("bytewax.inputs")?.getattr("Source")?;
         if !ob.is_instance(&abc)? {
             Err(PyTypeError::new_err(
                 "source must subclass `bytewax.inputs.Source`",
@@ -152,7 +152,7 @@ impl<'py> FromPyObject<'py> for FixedPartitionedSource {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.inputs")?
+            .import("bytewax.inputs")?
             .getattr("FixedPartitionedSource")?;
         if !ob.is_instance(&abc)? {
             Err(PyTypeError::new_err(
@@ -564,7 +564,7 @@ impl<'py> FromPyObject<'py> for StatefulPartition {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.inputs")?
+            .import("bytewax.inputs")?
             .getattr("StatefulSourcePartition")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
@@ -636,9 +636,7 @@ pub(crate) struct DynamicSource(Py<PyAny>);
 impl<'py> FromPyObject<'py> for DynamicSource {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let abc = py
-            .import_bound("bytewax.inputs")?
-            .getattr("DynamicSource")?;
+        let abc = py.import("bytewax.inputs")?.getattr("DynamicSource")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
                 "dynamic source must subclass `bytewax.inputs.DynamicSource`",
@@ -849,7 +847,7 @@ impl<'py> FromPyObject<'py> for StatelessPartition {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.inputs")?
+            .import("bytewax.inputs")?
             .getattr("StatelessSourcePartition")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
@@ -904,6 +902,6 @@ impl Drop for StatelessPartition {
 }
 
 pub(crate) fn register(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add("AbortExecution", py.get_type_bound::<AbortExecution>())?;
+    m.add("AbortExecution", py.get_type::<AbortExecution>())?;
     Ok(())
 }

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -104,7 +104,6 @@ create_exception!(
 );
 
 /// Represents a `bytewax.inputs.Source` from Python.
-#[derive(Clone)]
 pub(crate) struct Source(Py<PyAny>);
 
 /// Do some eager type checking.
@@ -144,7 +143,6 @@ impl Source {
 }
 
 /// Represents a `bytewax.inputs.FixedPartitionedSource` from Python.
-#[derive(Clone)]
 pub(crate) struct FixedPartitionedSource(Py<PyAny>);
 
 /// Do some eager type checking.
@@ -338,7 +336,7 @@ impl FixedPartitionedSource {
                                         py,
                                         &step_id,
                                         &part_key,
-                                        Some(state.into())
+                                        Some(state.into_py(py))
                                     ).reraise_with(|| format!("error calling `FixedPartitionSource.build_part` in step {step_id} for partition {part_key}"))?;
                                     let next_awake = part.next_awake(py)
                                         .reraise_with(|| format!("error calling `StatefulSourcePartition.next_awake` in step {step_id} for partition {part_key}"))?;
@@ -629,7 +627,6 @@ impl Drop for StatefulPartition {
 }
 
 /// Represents a `bytewax.inputs.DynamicInput` from Python.
-#[derive(Clone)]
 pub(crate) struct DynamicSource(Py<PyAny>);
 
 /// Do some eager type checking.

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -589,7 +589,7 @@ impl StatefulPartition {
             Err(err) if err.is_instance_of::<AbortExecution>(py) => Ok(BatchResult::Abort),
             Err(err) => Err(err),
             Ok(obj) => {
-                let iter = obj.iter().reraise_with(|| {
+                let iter = obj.try_iter().reraise_with(|| {
                     format!(
                         "`next_batch` must return an iterable; got a `{}` instead",
                         unwrap_any!(obj.get_type().name()),
@@ -866,7 +866,7 @@ impl StatelessPartition {
             Err(err) if err.is_instance_of::<AbortExecution>(py) => Ok(BatchResult::Abort),
             Err(err) => Err(err),
             Ok(obj) => {
-                let iter = obj.iter().reraise_with(|| {
+                let iter = obj.try_iter().reraise_with(|| {
                     format!(
                         "`next_batch` must return an iterable; got a `{}` instead",
                         unwrap_any!(obj.get_type().name()),

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -104,6 +104,7 @@ create_exception!(
 );
 
 /// Represents a `bytewax.inputs.Source` from Python.
+#[derive(IntoPyObject)]
 pub(crate) struct Source(Py<PyAny>);
 
 /// Do some eager type checking.
@@ -118,18 +119,6 @@ impl<'py> FromPyObject<'py> for Source {
         } else {
             Ok(Self(ob.to_object(py)))
         }
-    }
-}
-
-impl IntoPy<Py<PyAny>> for Source {
-    fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
-        self.0
-    }
-}
-
-impl ToPyObject for Source {
-    fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.0.to_object(py)
     }
 }
 

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -117,7 +117,7 @@ impl<'py> FromPyObject<'py> for Source {
                 "source must subclass `bytewax.inputs.Source`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }
@@ -146,7 +146,7 @@ impl<'py> FromPyObject<'py> for FixedPartitionedSource {
                 "fixed partitioned source must subclass `bytewax.inputs.FixedPartitionedSource`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }
@@ -558,7 +558,7 @@ impl<'py> FromPyObject<'py> for StatefulPartition {
                 "stateful source partition must subclass `bytewax.inputs.StatefulSourcePartition`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }
@@ -628,7 +628,7 @@ impl<'py> FromPyObject<'py> for DynamicSource {
                 "dynamic source must subclass `bytewax.inputs.DynamicSource`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }
@@ -840,7 +840,7 @@ impl<'py> FromPyObject<'py> for StatelessPartition {
                 "stateless source partition must subclass `bytewax.inputs.StatelessSourcePartition`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -468,7 +468,7 @@ impl<'py> FromPyObject<'py> for StatefulBatchLogic {
                 "logic must subclass `bytewax.operators.StatefulBatchLogic`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -242,7 +242,7 @@ where
 impl<S> InspectDebugOp<S> for Stream<S, TdPyAny>
 where
     S: Scope,
-    S::Timestamp: IntoPy<PyObject> + TotalOrder,
+    for<'py> S::Timestamp: IntoPyObject<'py> + TotalOrder,
 {
     fn inspect_debug(
         &self,
@@ -411,6 +411,7 @@ where
                 });
             }
         });
+
         downstream
     }
 }
@@ -428,13 +429,13 @@ where
 {
     fn wrap_key(&self) -> Stream<S, TdPyAny> {
         self.map(move |(key, value)| {
-            Python::with_gil(|py| {
+            unwrap_any!(Python::with_gil(|py| -> PyResult<TdPyAny> {
                 let value = value.into_py(py);
 
-                let item = IntoPy::<PyObject>::into_py((key, value), py);
+                let item = IntoPyObject::into_pyobject((key, value), py)?;
 
-                TdPyAny::from(item)
-            })
+                Ok(TdPyAny::from(item))
+            }))
         })
     }
 }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -458,7 +458,7 @@ impl<'py> FromPyObject<'py> for StatefulBatchLogic {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.operators")?
+            .import("bytewax.operators")?
             .getattr("StatefulBatchLogic")?;
         if !ob.is_instance(&abc)? {
             Err(PyTypeError::new_err(

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -105,7 +105,7 @@ fn next_batch(
     in_batch: Vec<PyObject>,
 ) -> PyResult<()> {
     let res = mapper.call1((in_batch,)).reraise("error calling mapper")?;
-    let iter = res.iter().reraise_with(|| {
+    let iter = res.try_iter().reraise_with(|| {
         format!(
             "mapper must return an iterable; got a `{}` instead",
             unwrap_any!(res.get_type().name()),

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -42,7 +42,7 @@ impl<'py> FromPyObject<'py> for Sink {
                 "sink must subclass `bytewax.outputs.Sink`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }
@@ -71,7 +71,7 @@ impl<'py> FromPyObject<'py> for FixedPartitionedSink {
                 "fixed partitioned sink must subclass `bytewax.outputs.FixedPartitionedSink`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }
@@ -119,7 +119,7 @@ impl<'py> FromPyObject<'py> for StatefulPartition {
                 "stateful sink partition must subclass `bytewax.outputs.StatefulSinkPartition`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }
@@ -415,7 +415,7 @@ impl<'py> FromPyObject<'py> for DynamicSink {
                 "dynamic sink must subclass `bytewax.outputs.DynamicSink`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }
@@ -449,7 +449,7 @@ impl<'py> FromPyObject<'py> for StatelessPartition {
                 "stateless sink partition must subclass `bytewax.outputs.StatelessSinkPartition`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.as_unbound().clone_ref(py)))
         }
     }
 }

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -36,7 +36,7 @@ pub(crate) struct Sink(Py<PyAny>);
 impl<'py> FromPyObject<'py> for Sink {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let abc = py.import_bound("bytewax.outputs")?.getattr("Sink")?;
+        let abc = py.import("bytewax.outputs")?.getattr("Sink")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
                 "sink must subclass `bytewax.outputs.Sink`",
@@ -77,7 +77,7 @@ impl<'py> FromPyObject<'py> for FixedPartitionedSink {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.outputs")?
+            .import("bytewax.outputs")?
             .getattr("FixedPartitionedSink")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
@@ -125,7 +125,7 @@ impl<'py> FromPyObject<'py> for StatefulPartition {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.outputs")?
+            .import("bytewax.outputs")?
             .getattr("StatefulSinkPartition")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
@@ -418,7 +418,7 @@ pub(crate) struct DynamicSink(Py<PyAny>);
 impl<'py> FromPyObject<'py> for DynamicSink {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let abc = py.import_bound("bytewax.outputs")?.getattr("DynamicSink")?;
+        let abc = py.import("bytewax.outputs")?.getattr("DynamicSink")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
                 "dynamic sink must subclass `bytewax.outputs.DynamicSink`",
@@ -451,7 +451,7 @@ impl<'py> FromPyObject<'py> for StatelessPartition {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.outputs")?
+            .import("bytewax.outputs")?
             .getattr("StatelessSinkPartition")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -29,6 +29,7 @@ use crate::unwrap_any;
 use crate::with_timer;
 
 /// Represents a `bytewax.outputs.Sink` from Python.
+#[derive(IntoPyObject)]
 pub(crate) struct Sink(Py<PyAny>);
 
 /// Do some eager type checking.
@@ -43,18 +44,6 @@ impl<'py> FromPyObject<'py> for Sink {
         } else {
             Ok(Self(ob.to_object(py)))
         }
-    }
-}
-
-impl IntoPy<Py<PyAny>> for Sink {
-    fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
-        self.0
-    }
-}
-
-impl ToPyObject for Sink {
-    fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.0.to_object(py)
     }
 }
 

--- a/src/pyo3_extensions.rs
+++ b/src/pyo3_extensions.rs
@@ -61,9 +61,9 @@ impl From<PyObject> for TdPyAny {
     }
 }
 
-impl From<Bound<'_, PyAny>> for TdPyAny {
-    fn from(x: Bound<'_, PyAny>) -> Self {
-        Self(Arc::new(x.unbind()))
+impl<'py, T> From<Bound<'py, T>> for TdPyAny {
+    fn from(x: Bound<'py, T>) -> Self {
+        Self(Arc::new(x.into_any().unbind()))
     }
 }
 

--- a/src/pyo3_extensions.rs
+++ b/src/pyo3_extensions.rs
@@ -90,7 +90,7 @@ impl serde::Serialize for TdPyAny {
             let x = self.bind(py);
             let pickle = PICKLE_MODULE
                 .get_or_try_init(py, || -> PyResult<Py<PyModule>> {
-                    Ok(py.import_bound("pickle")?.unbind())
+                    Ok(py.import("pickle")?.unbind())
                 })
                 .map_err(S::Error::custom)?;
             let binding = pickle
@@ -119,7 +119,7 @@ impl<'de> serde::de::Visitor<'de> for PickleVisitor {
         E: serde::de::Error,
     {
         let x: Result<TdPyAny, PyErr> = Python::with_gil(|py| {
-            let pickle = py.import_bound("pickle")?;
+            let pickle = py.import("pickle")?;
             let x = pickle
                 .call_method1(intern!(py, "loads"), (bytes,))?
                 .unbind()

--- a/src/pyo3_extensions.rs
+++ b/src/pyo3_extensions.rs
@@ -44,7 +44,7 @@ impl TdPyAny {
         self.0.bind(py)
     }
 
-    pub(crate) fn into_py<'py>(self, py: Python<'py>) -> PyObject {
+    pub(crate) fn into_py(self, py: Python<'_>) -> PyObject {
         match Arc::try_unwrap(self.0) {
             Ok(x) => x,
             Err(self_) => self_.clone_ref(py),
@@ -204,9 +204,6 @@ pub(crate) trait OptionPyExt {
 
 impl<T> OptionPyExt for Option<Py<T>> {
     fn cloned_ref(&self, py: Python) -> Self {
-        match self {
-            Some(x) => Some(x.clone_ref(py)),
-            None => None,
-        }
+        self.as_ref().map(|x| x.clone_ref(py))
     }
 }

--- a/src/pyo3_extensions.rs
+++ b/src/pyo3_extensions.rs
@@ -1,8 +1,5 @@
 //! Newtypes around PyO3 types which allow easier interfacing with
 //! Timely or other Rust libraries we use.
-use crate::try_unwrap;
-
-use pyo3::basic::CompareOp;
 use pyo3::exceptions::PyTypeError;
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -152,22 +149,6 @@ impl<'de> serde::de::Visitor<'de> for PickleVisitor {
 impl<'de> serde::Deserialize<'de> for TdPyAny {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         deserializer.deserialize_bytes(PickleVisitor)
-    }
-}
-
-/// Re-use Python's value semantics in Rust code.
-impl PartialEq for TdPyAny {
-    fn eq(&self, other: &Self) -> bool {
-        Python::with_gil(|py| {
-            // Don't use Py.eq or PyAny.eq since it only checks
-            // pointer identity.
-            let self_ = self.bind(py);
-            let other = other.bind(py);
-            try_unwrap!(self_
-                .rich_compare(other, CompareOp::Eq)?
-                .as_gil_ref()
-                .is_truthy())
-        })
     }
 }
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -1525,7 +1525,7 @@ where
         // Effectively map-with-epoch.
         self.unary(Pipeline, "ser_snap", move |_init_cap, _info| {
             let mut inbuf = Vec::new();
-            let pickle = Python::with_gil(|py| unwrap_any!(py.import_bound("pickle")).unbind());
+            let pickle = Python::with_gil(|py| unwrap_any!(py.import("pickle")).unbind());
 
             move |snaps_input, ser_snaps_output| {
                 snaps_input.for_each(|cap, incoming| {
@@ -1594,12 +1594,9 @@ where
                 let snap_change = match ser_change {
                     Some(ser_snap) => {
                         let snap = unwrap_any!(Python::with_gil(|py| -> PyResult<PyObject> {
-                            let pickle = py.import_bound("pickle")?;
+                            let pickle = py.import("pickle")?;
                             Ok(pickle
-                                .call_method1(
-                                    intern!(py, "loads"),
-                                    (PyBytes::new_bound(py, &ser_snap),),
-                                )?
+                                .call_method1(intern!(py, "loads"), (PyBytes::new(py, &ser_snap),))?
                                 .unbind())
                         }));
                         StateChange::Upsert(snap.into())
@@ -1937,15 +1934,12 @@ pub(crate) fn register(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<RecoveryConfig>()?;
     m.add(
         "InconsistentPartitionsError",
-        py.get_type_bound::<InconsistentPartitionsError>(),
+        py.get_type::<InconsistentPartitionsError>(),
     )?;
     m.add(
         "MissingPartitionsError",
-        py.get_type_bound::<MissingPartitionsError>(),
+        py.get_type::<MissingPartitionsError>(),
     )?;
-    m.add(
-        "NoPartitionsError",
-        py.get_type_bound::<NoPartitionsError>(),
-    )?;
+    m.add("NoPartitionsError", py.get_type::<NoPartitionsError>())?;
     Ok(())
 }

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -1538,7 +1538,7 @@ where
                                 .map(|Snapshot(step_id, state_key, snap_change)| {
                                     let ser_change = match snap_change {
                                         StateChange::Upsert(snap) => {
-                                            let snap = PyObject::from(snap);
+                                            let snap = snap.into_py(py);
                                             let bytes = unwrap_any!(|| -> PyResult<Vec<u8>> {
                                                 Ok(pickle
                                                     .bind(py)

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -15,6 +15,7 @@ use std::hash::Hash;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::OnceLock;
 
 use chrono::TimeDelta;
 use pyo3::create_exception;
@@ -24,7 +25,6 @@ use pyo3::exceptions::PyTypeError;
 use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::sync::GILOnceCell;
 use pyo3::types::PyBytes;
 use rusqlite::Connection;
 use rusqlite::OpenFlags;
@@ -327,7 +327,7 @@ impl RecoveryConfig {
     /// Build the Rust-side bundle from the Python-side recovery
     /// config.
     #[instrument(name = "build_recovery", skip_all)]
-    pub(crate) fn build(&self, py: Python) -> PyResult<(RecoveryBundle, BackupInterval)> {
+    pub(crate) fn build(&self) -> PyResult<(RecoveryBundle, BackupInterval)> {
         let mut part_paths = HashMap::new();
         let sqlite_ext = OsStr::new("sqlite3");
         if !self.db_dir.is_dir() {
@@ -339,8 +339,7 @@ impl RecoveryConfig {
         for entry in fs::read_dir(self.db_dir.clone()).reraise("Error listing recovery DB dir")? {
             let path = entry.reraise("Error accessing recovery DB file")?.path();
             if path.extension().map_or(false, |ext| *ext == *sqlite_ext) {
-                let part =
-                    RecoveryPart::open(py, &path).reraise("Error opening recovery DB file")?;
+                let part = RecoveryPart::open(&path).reraise("Error opening recovery DB file")?;
                 let mut part_loader = part.part_loader();
                 while let Some(batch) = part_loader.next_batch() {
                     for PartitionMeta(index, _count) in batch {
@@ -412,7 +411,9 @@ impl RecoveryBundle {
                             panic!("Trying to build RecoveryPartition for {part_key:?} but no path is known");
                         });
 
-                    let part = unwrap_any!(Python::with_gil(|py| RecoveryPart::open(py, path)));
+                    let part = RecoveryPart::open(path).unwrap_or_else(|err| {
+                        panic!("Trying to build RecoveryPartition for {part_key:?} but error opening: {err}");
+                    });
 
                     Rc::new(RefCell::new(part))
                 })
@@ -443,13 +444,10 @@ struct RecoveryPart {
 
 // The `'static` lifetime within [`Migrations`] is saying that the
 // [`str`]s composing the migrations are `'static`.
-//
-// Use [`GILOnceCell`] so we don't have to bring in a `lazy_static`
-// crate dep.
-static MIGRATIONS: GILOnceCell<Migrations<'static>> = GILOnceCell::new();
+static MIGRATIONS: OnceLock<Migrations<'static>> = OnceLock::new();
 
-fn get_migrations(py: Python) -> &Migrations<'static> {
-    MIGRATIONS.get_or_init(py, || {
+fn get_migrations() -> &'static Migrations<'static> {
+    MIGRATIONS.get_or_init(|| {
         Migrations::new(vec![
             M::up(
                 "CREATE TABLE parts (
@@ -511,11 +509,11 @@ fn get_migrations(py: Python) -> &Migrations<'static> {
 #[test]
 fn migrations_valid() -> rusqlite_migration::Result<()> {
     pyo3::prepare_freethreaded_python();
-    Python::with_gil(|py| get_migrations(py).validate())
+    get_migrations().validate()
 }
 
 /// Setup our connection-level pragmas. Run this on each connection.
-fn setup_conn(py: Python, conn: &Rc<RefCell<Connection>>) {
+fn setup_conn(conn: &Rc<RefCell<Connection>>) {
     let mut conn = conn.borrow_mut();
 
     rusqlite::vtab::series::load_module(&conn).unwrap();
@@ -523,7 +521,7 @@ fn setup_conn(py: Python, conn: &Rc<RefCell<Connection>>) {
     // These are recommended by Litestream.
     conn.pragma_update(None, "journal_mode", "WAL").unwrap();
     conn.pragma_update(None, "busy_timeout", "5000").unwrap();
-    get_migrations(py).to_latest(&mut conn).unwrap();
+    get_migrations().to_latest(&mut conn).unwrap();
 }
 
 struct PartitionMetaWriter {
@@ -987,7 +985,7 @@ impl Committer<u64> for RecoveryCommitter {
 #[test]
 fn gc_leaves_only_final_snap() {
     pyo3::prepare_freethreaded_python();
-    let conn = Python::with_gil(|py| RecoveryPart::init_open_mem(py));
+    let conn = RecoveryPart::init_open_mem();
     conn.snap_writer().write_batch(vec![
         SerializedSnapshot(
             StepId(String::from("step_1")),
@@ -1067,7 +1065,7 @@ create_exception!(
 );
 
 impl RecoveryPart {
-    fn init(py: Python, file: &Path, index: PartitionIndex, count: PartitionCount) -> PyResult<()> {
+    fn init(file: &Path, index: PartitionIndex, count: PartitionCount) -> PyResult<()> {
         tracing::debug!("Init recovery partition {index:?} / {count:?} at {file:?}");
         let conn = Rc::new(RefCell::new(
             Connection::open_with_flags(
@@ -1078,7 +1076,7 @@ impl RecoveryPart {
             )
             .reraise("can't open recovery DB")?,
         ));
-        setup_conn(py, &conn);
+        setup_conn(&conn);
 
         let _self = Self { conn };
         _self
@@ -1088,7 +1086,7 @@ impl RecoveryPart {
         Ok(())
     }
 
-    fn open(py: Python, file: &Path) -> PyResult<Self> {
+    fn open(file: &Path) -> PyResult<Self> {
         tracing::debug!("Opening recovery partition at {file:?}");
         let conn = Rc::new(RefCell::new(
             Connection::open_with_flags(
@@ -1097,14 +1095,14 @@ impl RecoveryPart {
             )
             .reraise("can't open recovery DB")?,
         ));
-        setup_conn(py, &conn);
+        setup_conn(&conn);
 
         Ok(Self { conn })
     }
 
-    fn init_open_mem(py: Python) -> Self {
+    fn init_open_mem() -> Self {
         let conn = Rc::new(RefCell::new(Connection::open_in_memory().unwrap()));
-        setup_conn(py, &conn);
+        setup_conn(&conn);
 
         Self { conn }
     }
@@ -1274,7 +1272,7 @@ impl RecoveryPart {
 #[test]
 fn resume_from_only_parts() {
     pyo3::prepare_freethreaded_python();
-    let conn = Python::with_gil(|py| RecoveryPart::init_open_mem(py));
+    let conn = RecoveryPart::init_open_mem();
     conn.part_writer()
         .write_batch(vec![PartitionMeta(PartitionIndex(0), PartitionCount(1))]);
 
@@ -1286,7 +1284,7 @@ fn resume_from_only_parts() {
 #[test]
 fn resume_from_all_explict_fronts() {
     pyo3::prepare_freethreaded_python();
-    let conn = Python::with_gil(|py| RecoveryPart::init_open_mem(py));
+    let conn = RecoveryPart::init_open_mem();
     conn.part_writer()
         .write_batch(vec![PartitionMeta(PartitionIndex(0), PartitionCount(1))]);
     conn.ex_writer().write_batch(vec![ExecutionMeta(
@@ -1310,7 +1308,7 @@ fn resume_from_all_explict_fronts() {
 #[test]
 fn resume_from_default_fronts() {
     pyo3::prepare_freethreaded_python();
-    let conn = Python::with_gil(|py| RecoveryPart::init_open_mem(py));
+    let conn = RecoveryPart::init_open_mem();
     conn.part_writer()
         .write_batch(vec![PartitionMeta(PartitionIndex(0), PartitionCount(1))]);
     conn.ex_writer().write_batch(vec![ExecutionMeta(
@@ -1334,7 +1332,7 @@ fn resume_from_default_fronts() {
 fn resume_from_inconsistent_error() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let conn = RecoveryPart::init_open_mem(py);
+        let conn = RecoveryPart::init_open_mem();
         conn.part_writer().write_batch(vec![
             PartitionMeta(PartitionIndex(0), PartitionCount(2)),
             PartitionMeta(PartitionIndex(1), PartitionCount(2)),
@@ -1368,7 +1366,7 @@ fn resume_from_inconsistent_error() {
 ///
 /// :type count: int
 #[pyfunction]
-fn init_db_dir(py: Python, db_dir: PathBuf, count: PartitionCount) -> PyResult<()> {
+fn init_db_dir(db_dir: PathBuf, count: PartitionCount) -> PyResult<()> {
     tracing::warn!("Creating {count:?} recovery partitions in {db_dir:?}");
     if !db_dir.is_dir() {
         return Err(PyFileNotFoundError::new_err(format!(
@@ -1378,7 +1376,7 @@ fn init_db_dir(py: Python, db_dir: PathBuf, count: PartitionCount) -> PyResult<(
     }
     for index in count.iter() {
         let part_file = db_dir.join(format!("part-{}.sqlite3", index.0));
-        RecoveryPart::init(py, &part_file, index, count)
+        RecoveryPart::init(&part_file, index, count)
             .reraise("error init-ing recovery partition")?;
     }
     Ok(())
@@ -1829,8 +1827,8 @@ impl ReadProgressOp for RecoveryBundle {
 pub(crate) struct ResumeCalc(RecoveryPart);
 
 impl ResumeCalc {
-    pub(crate) fn new(py: Python) -> Self {
-        Self(RecoveryPart::init_open_mem(py))
+    pub(crate) fn new() -> Self {
+        Self(RecoveryPart::init_open_mem())
     }
 
     pub(crate) fn resume_from(&self) -> PyResult<ResumeFrom> {

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -314,6 +314,7 @@ pub(crate) struct RecoveryConfig {
 #[pymethods]
 impl RecoveryConfig {
     #[new]
+    #[pyo3(signature = (db_dir, backup_interval=None))]
     fn new(db_dir: PathBuf, backup_interval: Option<BackupInterval>) -> Self {
         Self {
             db_dir,

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -152,18 +152,12 @@ pub(crate) struct CommitMeta(PartitionIndex, u64);
 /// can ensure that there's some resume epoch shared by all partitions
 /// we can use when resuming from a backup that might not be the most
 /// recent.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, IntoPyObject)]
 pub(crate) struct BackupInterval(TimeDelta);
 
 impl Default for BackupInterval {
     fn default() -> Self {
         Self(TimeDelta::zero())
-    }
-}
-
-impl IntoPy<Py<PyAny>> for BackupInterval {
-    fn into_py(self, py: Python<'_>) -> Py<PyAny> {
-        self.0.into_py(py)
     }
 }
 
@@ -202,20 +196,8 @@ impl Default for ResumeFrom {
 ///
 /// Recovery data is keyed off of this to ensure state is not mixed
 /// between operators.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, FromPyObject)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, IntoPyObject, FromPyObject)]
 pub(crate) struct StepId(pub(crate) String);
-
-impl IntoPy<Py<PyAny>> for StepId {
-    fn into_py(self, py: Python<'_>) -> Py<PyAny> {
-        self.0.into_py(py)
-    }
-}
-
-impl ToPyObject for StepId {
-    fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.0.to_object(py)
-    }
-}
 
 /// Displays the step ID in quotes.
 impl std::fmt::Display for StepId {
@@ -237,15 +219,19 @@ impl std::fmt::Display for StepId {
 /// we can't guarantee those things are correct on any arbitrary
 /// Python type.
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, FromPyObject,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    IntoPyObject,
+    FromPyObject,
 )]
 pub(crate) struct StateKey(pub(crate) String);
-
-impl IntoPy<Py<PyAny>> for StateKey {
-    fn into_py(self, py: Python<'_>) -> Py<PyAny> {
-        self.0.into_py(py)
-    }
-}
 
 impl std::fmt::Display for StateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/run.rs
+++ b/src/run.rs
@@ -26,6 +26,7 @@ use crate::errors::tracked_err;
 use crate::errors::PythonException;
 use crate::inputs::EpochInterval;
 use crate::metrics::initialize_metrics;
+use crate::pyo3_extensions::OptionPyExt;
 use crate::recovery::RecoveryConfig;
 use crate::unwrap_any;
 use crate::webserver::run_webserver;
@@ -308,8 +309,8 @@ pub(crate) fn cluster_main(
             other,
             timely::WorkerConfig::default(),
             move |worker| {
-                let flow = Python::with_gil(|py| flow.clone_ref(py));
-                let recovery_config = recovery_config.clone();
+                let (flow, recovery_config) =
+                    Python::with_gil(|py| (flow.clone_ref(py), recovery_config.cloned_ref(py)));
 
                 unwrap_any!(worker_main(
                     worker,

--- a/src/run.rs
+++ b/src/run.rs
@@ -41,7 +41,7 @@ fn start_server_runtime(df: Dataflow) -> PyResult<Runtime> {
     // Since the dataflow can't change at runtime, we encode it as a
     // string of JSON once, when the webserver starts.
     let dataflow_json: String = Python::with_gil(|py| -> PyResult<String> {
-        let vis_mod = PyModule::import_bound(py, "bytewax.visualize")?;
+        let vis_mod = PyModule::import(py, "bytewax.visualize")?;
         let to_json = vis_mod.getattr("to_json")?;
 
         let dataflow_json = to_json
@@ -151,10 +151,7 @@ pub(crate) fn run_main(
         eprintln!();
         if let Some(err) = panic_err.downcast_ref::<PyErr>() {
             // Special case for keyboard interrupt.
-            if err
-                .get_type_bound(py)
-                .is(&PyType::new_bound::<PyKeyboardInterrupt>(py))
-            {
+            if err.get_type(py).is(&PyType::new::<PyKeyboardInterrupt>(py)) {
                 tracked_err::<PyKeyboardInterrupt>(
                     "interrupt signal received, all processes have been shut down",
                 )

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -168,6 +168,7 @@ impl BytewaxTracer {
 ///
 /// :type log_level: str
 #[pyfunction]
+#[pyo3(signature = (tracing_config=None, log_level=None))]
 fn setup_tracing(
     py: Python,
     tracing_config: Option<Py<TracingConfig>>,

--- a/src/webserver/mod.rs
+++ b/src/webserver/mod.rs
@@ -53,7 +53,7 @@ async fn get_dataflow(Extension(state): Extension<Arc<State>>) -> impl IntoRespo
 
 async fn get_metrics() -> impl IntoResponse {
     let py_metrics: String = Python::with_gil(|py| -> PyResult<String> {
-        let metrics_mod = PyModule::import_bound(py, "bytewax._metrics")?;
+        let metrics_mod = PyModule::import(py, "bytewax._metrics")?;
         let metrics = metrics_mod
             .getattr("generate_python_metrics")?
             .call0()?

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -111,13 +111,13 @@ where
     tracing::info!("Worker start");
 
     let recovery = recovery_config
-        .map(|config| Python::with_gil(|py| config.borrow(py).build(py)))
+        .map(|config| Python::with_gil(|py| config.borrow(py).build()))
         .transpose()?;
 
     let resume_from = recovery
         .as_ref()
         .map(|(bundle, _backup_interval)| -> PyResult<ResumeFrom> {
-            let resume_calc = Python::with_gil(|py| Rc::new(RefCell::new(ResumeCalc::new(py))));
+            let resume_calc = Rc::new(RefCell::new(ResumeCalc::new()));
             let resume_calc_d = resume_calc.clone();
             let probe = Python::with_gil(|py| {
                 build_resume_calc_dataflow(py, worker.worker, bundle.clone_ref(py), resume_calc_d)


### PR DESCRIPTION
- **Bump PyO3**
- **Don't use deprecated `*_bound` calls**
- **Fixes some other rename deprecations**
- **Fixes deprecation on implicit trailing `None` default args**
- **Removes a use of `GilOnceCell` that doesn't need GIL**
- **`TdPyAny` is now `Clone` via `Arc`**
- **Migrates to new PyO3 conversion traits**
- **Uses easier conversion method**
- **Migrates some other old gilref uses to `Bound`**
- **`TdPyAny` is no longer `PartialEq`; not used**
- **Make `wrap_key` get GIL in batches**
- **Clippy fixes**

The most notable of the changes here is that `TdPyAny` is now `Arc<PyObject>` and removing `impl Clone` on all our other Python ABC shim types (which were `PyObject`). This is because of https://pyo3.rs/v0.23.4/migration.html#pyclone-is-now-gated-behind-the-py-clone-feature which basically says the only way to soundly increment the Python obj refcount is to be actually holding the GIL. This would introduce a ton of overhead in that you'd acq-rel the GIL on every `clone` and `drop` call. The best (and now default) course of action is to not `impl Clone` so you have to manually use `clone_ref` which takes a GIL token and you can performantly do this. The other option they provided during migration is a `py-clone` feature flag which `impl Clone`, but will panic if you are not holding the GIL; because most folks were using `clone` in a GIL block, this keeps the performance and behavior identical, but will panic instead of a soundness issue. Since we need `Clone` because Timely uses it to duplicate data if a `Stream` has two consumers, we have no control over how or when `clone` is called. Thus we can't guarantee the GIL will be held and we can't use the `py-clone` feature.

The other "hack" they recommend is to instead wrap your `Py` in `Arc`. This means there's two layers of reference counting: if a Python object is cloned on the Rust / Timely side, it increments the ARC refcount; on the Python side or when the GIL is held, it increments the Python object refcount. We provide a "destructor" which will "shim" changes to the ARC refcount into the Python refcount via a new function we wrote `TdPyAny::into_py` which we can call once we actually have the GIL.

This will have some not-obvious performance implications, but I think they'll be minimal and dependent on if there is a lot of branching in the dataflow.

FWIW, the discussion in https://pyo3.rs/v0.23.4/migration.html#pyclone-is-now-gated-behind-the-py-clone-feature implies that memory leaking is still a possibility: Any time `drop` is called on `Py` when the GIL isn't held, the implementation is to buffer the refcount decrement, but that could always hypothetically result in mem leaks. I don't see any way around that with the current architecture, although I have no idea how often this would happen. To me, this implies that `Py` should be a "must move" type which you always "bind" in order to ensure you have the GIL when dropping.

Funnily enough, all this goes away in a fully-nogil future because the Python refcount can be modified by multiple threads.