### PR TITLE
Fix Kafka source hanging when oauth_cb is configured

### DIFF
--- a/pysrc/bytewax/connectors/kafka/__init__.py
+++ b/pysrc/bytewax/connectors/kafka/__init__.py
@@ -383,6 +383,9 @@ class KafkaSource(
         }
         config.update(self._add_config)
         client = AdminClient(config)
+        # Workaround for https://github.com/confluentinc/librdkafka/issues/3753#issuecomment-1058272987
+        # to start any configured auth callbacks.
+        client.poll(0)
 
         return list(_list_parts(client, self._topics))
 


### PR DESCRIPTION
There is a known issue in confluent-kafka-python that the admin client does not automatically start calling any configured oauth_cb callbacks. The workaround is to call `poll()` once before calling `list_topics()`.

See https://github.com/nasa-gcn/gcn-kafka-python/blob/v0.3.3/gcn_kafka/core.py#L149-L151.