### PR TITLE
Change 'Missing Values' example email

### DIFF
--- a/docs/guide/concepts/joins.md
+++ b/docs/guide/concepts/joins.md
@@ -301,7 +301,7 @@ the Bee, there's no name state. So nothing is emitted!
 
 | Key | Name Value | Email Value |
 | --- | ---------- | ----------- |
-| 123 | | `"bee@bytewax.io"` |
+| 123 | | `"queen@bytewax.io"` |
 
 Hopefully this helps clarify how basic streaming joins work. Realizing
 that the {py:obj}`~bytewax.operators.join` operator only keeps the


### PR DESCRIPTION
In the missing values section, within the example provided, the final email is identical to the first event, i.e., it is currently "bee@bytewax.io," but I believe it should be "queen@bytewax.io."