### PR TITLE
[docs] [1-line] Fix missing markdown fencing in Deployment Overview

### DIFF
--- a/docs/guide/deployment/overview.md
+++ b/docs/guide/deployment/overview.md
@@ -19,6 +19,7 @@ Test it out locally after installing:
 
 ```console
 $ waxctl run mydataflow.py -p 2
+```
 
 You can find more information in <project:#ref-waxctl>.
 


### PR DESCRIPTION
(Unverified) this change will presumably fix the bad formatting in https://docs.bytewax.io/stable/guide/deployment/overview.html

![image](https://github.com/user-attachments/assets/816e30c8-43dd-436d-bfb0-20d028c76099)
