### PR TITLE
Use vermin 1.7.0

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1562,9 +1562,9 @@ uvicorn==0.29.0 \
     --hash=sha256:2c2aac7ff4f4365c206fd773a39bf4ebd1047c238f8b8268ad996829323473de \
     --hash=sha256:6a69214c0b6a087462412670b3ef21224fa48cae0e452b5883e8e8bdfdd11dd0
     # via sphinx-autobuild
-vermin==1.6.0 \
-    --hash=sha256:6266ca02f55d1c2aa189a610017c132eb2d1934f09e72a955b1eb3820ee6d4ef \
-    --hash=sha256:f1fa9ee40f59983dc40e0477eb2b1fa8061a3df4c3b2bcf349add462a5610efb
+vermin==1.7.0 \
+    --hash=sha256:5accad5f3599e428663af9f872debe27383edb85f737406f2d20855356e6ac2f \
+    --hash=sha256:e9e3c2c901dc2ceec746d9b9e807d6639ec4233a749ad62f51bc0334fbb38707
     # via -r requirements/dev.in
 virtualenv==20.25.3 \
     --hash=sha256:7bb554bbdfeaacc3349fa614ea5bff6ac300fc7c335e9facf3a3bcfc703f45be \


### PR DESCRIPTION
After having released version [1.7.0](https://github.com/netromdk/vermin/releases/tag/v1.7.0) of Vermin ([PyPi](https://pypi.org/project/vermin/1.7.0/)) it would make sense to also use it for the Bytewax CI pipelines.