### PR TITLE
refresh pyo3 to upgrade for python 3.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -253,7 +253,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "bytewax"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "axum 0.5.17",
  "chrono",
@@ -440,7 +440,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -544,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -941,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opentelemetry"
@@ -1153,7 +1153,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1188,9 +1188,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -1241,16 +1241,15 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "pyo3"
-version = "0.21.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a8b1990bd018761768d5e608a13df8bd1ac5f678456e0f301bb93e5f3ea16b"
+checksum = "37a6df7eab65fc7bee654a421404947e10a0f7085b6951bf2ea395f4659fb0cf"
 dependencies = [
- "cfg-if",
  "chrono",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -1260,19 +1259,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650dca34d463b6cdbdb02b1d71bfd6eb6b6816afc708faebb3bac1380ff4aef7"
+checksum = "f77d387774f6f6eec64a004eac0ed525aab7fa1966d94b42f743797b3e395afb"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a7da8fc04a8a2084909b59f29e1b8474decac98b951d77b80b26dc45f046ad"
+checksum = "2dd13844a4242793e02df3e2ec093f540d948299a6a77ea9ce7afd8623f542be"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1280,27 +1278,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8a199fce11ebb28e3569387228836ea98110e43a804a530a9fd83ade36d513"
+checksum = "eaf8f9f1108270b90d3676b8679586385430e5c0bb78bb5f043f95499c821a71"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fbbfd7eb553d10036513cb122b888dcd362a945a00b06c165f2ab480d4cc3b"
+checksum = "70a3b2274450ba5288bc9b8c1b69ff569d1d61189d4bff38f8d22e03d17f932b"
 dependencies = [
  "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1502,7 +1500,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1593,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1643,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.14"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "thiserror"
@@ -1664,7 +1662,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1804,7 +1802,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1931,7 +1929,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2114,7 +2112,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -2148,7 +2146,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.111",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2359,5 +2357,5 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.111",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bytewax"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 
 [lib]
@@ -18,7 +18,8 @@ opentelemetry-jaeger = { version = "0.19", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.13", features = ["trace", "reqwest-client", "grpc-tonic"] }
 opentelemetry-prometheus = "0.13.0"
 prometheus = { version = "0.13.3" }
-pyo3 = { version = "0.21.1", features = [ "macros", "chrono"] }
+pyo3 = { version = "0.27.1", features = ["macros", "chrono", "extension-module", "py-clone"] }
+
 rusqlite = { version = "0.30.0", features = ["bundled", "series"] }
 rusqlite_migration = { version = "1.1.0" }
 seahash = { version = "4.1.0" }
@@ -32,7 +33,8 @@ tracing-opentelemetry = { version = "0.20" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-pyo3 = { version = "0.21.1", features = ["macros", "chrono"] }
+pyo3 = { version = "0.27.1", features = ["macros", "chrono", "extension-module", "py-clone"] }
+
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,30 @@
-# Builder to get maturin
-FROM konstin2/maturin:v0.12.6 as maturin-builder
+# ----- Build stage: compile bytewax for linux/amd64 -----
+FROM --platform=linux/amd64 python:3.14-slim AS build
 
-# Builder to get the package
-FROM rust:1.68-slim-bullseye AS build
+ARG BYTEWAX_VERSION=0.22.0
 
-COPY --from=maturin-builder /usr/bin/maturin /usr/bin/maturin
+# build deps
+RUN apt-get update && apt-get install -y \
+    build-essential curl pkg-config libssl-dev libsqlite3-dev \
+ && rm -rf /var/lib/apt/lists/*
 
-ARG BYTEWAX_VERSION
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN apt-get update && \
-    apt-get install --no-install-suggests --no-install-recommends --yes \
-        build-essential \
-        cmake \
-        gcc \
-        libpython3-dev \
-        libsasl2-dev \
-        libssl-dev \
-        make \
-        openssl \
-        patchelf \
-        pkg-config \
-        protobuf-compiler \
-        python3-venv && \
-    python3 -m venv /venv && \
-    /venv/bin/pip install --upgrade pip setuptools wheel
+# maturin for building the wheel
+RUN pip install --no-cache-dir maturin
 
-COPY . /bytewax
-WORKDIR /bytewax
+WORKDIR /opt/bytewax
+COPY . .
 
-RUN maturin build --interpreter python3.9
-RUN /venv/bin/pip3 install /bytewax/target/wheels/bytewax-$BYTEWAX_VERSION-cp39-cp39-manylinux_2_31_x86_64.whl
+# build wheel for cp314 / linux x86_64
+RUN maturin build --release --interpreter python3.14
 
-# Final image
-FROM gcr.io/distroless/python3-debian11:debug
-COPY --from=build /venv /venv
-WORKDIR /bytewax
-COPY ./entrypoint.sh .
-COPY ./entrypoint-recovery.sh .
+# collect wheel in a clean place
+RUN mkdir -p /dist && cp target/wheels/bytewax-${BYTEWAX_VERSION}-cp314-*.whl /dist/
 
-ENV BYTEWAX_WORKDIR=/bytewax
+# ----- Artifact stage: ONLY the wheel -----
+FROM scratch AS artifact
+COPY --from=build /dist /dist
 
-# Ports that needs to be exposed
-EXPOSE 9999 3030
-
-ENTRYPOINT ["/bin/sh", "-c", "./entrypoint.sh"]

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -1,6 +1,8 @@
 use pyo3::exceptions::PyTypeError;
+use pyo3::IntoPyObject;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::prelude::PyAnyMethods;
+use pyo3::types::{PyDict, PyDictMethods};
 
 use crate::errors::PythonException;
 use crate::recovery::StepId;
@@ -8,23 +10,28 @@ use crate::recovery::StepId;
 pub(crate) struct Dataflow(PyObject);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for Dataflow {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Dataflow {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let abc = py.import_bound("bytewax.dataflow")?.getattr("Dataflow")?;
+        let abc = py.import("bytewax.dataflow")?.getattr("Dataflow")?;
         if !ob.is_instance(&abc)? {
             Err(PyTypeError::new_err(
                 "dataflow must subclass `bytewax.dataflow.Dataflow`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }
 
-impl IntoPy<Py<PyAny>> for Dataflow {
-    fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
-        self.0
+impl<'py> IntoPyObject<'py> for Dataflow {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> PyResult<Self::Output> {
+        Ok(self.0.into_bound(py))
     }
 }
 
@@ -41,16 +48,17 @@ impl Dataflow {
 pub(crate) struct Operator(PyObject);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for Operator {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Operator {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let abc = py.import_bound("bytewax.dataflow")?.getattr("Operator")?;
+        let abc = py.import("bytewax.dataflow")?.getattr("Operator")?;
         if !ob.is_instance(&abc)? {
             Err(PyTypeError::new_err(
                 "operator must subclass `bytewax.dataflow.Operator`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }
@@ -58,8 +66,9 @@ impl<'py> FromPyObject<'py> for Operator {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct StreamId(String);
 
-impl<'py> FromPyObject<'py> for StreamId {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for StreamId {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         Ok(Self(ob.extract()?))
     }
 }
@@ -83,7 +92,7 @@ impl Operator {
 
     pub(crate) fn is_core(&self, py: Python) -> PyResult<bool> {
         let core_cls = py
-            .import_bound("bytewax.dataflow")?
+            .import("bytewax.dataflow")?
             .getattr("_CoreOperator")?;
         self.0.bind(py).is_instance(&core_cls)
     }
@@ -102,13 +111,13 @@ impl Operator {
         py: Python,
         port_name: &str,
     ) -> PyResult<Vec<StreamId>> {
-        let stream_ids = self
+        let stream_ids: Bound<'_, PyDict> = self
             .0
             .bind(py)
             .getattr(port_name)
             .reraise_with(|| format!("operator did not have MultiPort {port_name:?}"))?
             .getattr("stream_ids")?
-            .extract::<&PyDict>()?;
+            .extract()?;
         stream_ids.values().extract()
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,10 @@
 use std::panic::Location;
 
+use pyo3::DowncastError;
 use pyo3::exceptions::PyException;
 use pyo3::import_exception;
 use pyo3::prelude::*;
 use pyo3::types::PyTracebackMethods;
-use pyo3::PyDowncastError;
 use pyo3::PyErr;
 use pyo3::PyResult;
 use pyo3::PyTypeInfo;
@@ -143,7 +143,7 @@ impl<T> PythonException<T> for Result<T, Box<dyn std::error::Error>> {
     }
 }
 
-impl<T> PythonException<T> for Result<T, PyDowncastError<'_>> {
+impl<T> PythonException<T> for Result<T, DowncastError<'_, '_>> {
     fn into_pyresult(self) -> PyResult<T> {
         self.map_err(|err| PyErr::new::<PyException, _>(format!("{err}")))
     }
@@ -167,7 +167,7 @@ fn build_message(py: Python, caller: &Location, err: &PyErr, msg: &str) -> Strin
 }
 
 fn get_traceback(py: Python, err: &PyErr) -> Option<String> {
-    err.traceback_bound(py).map(|tb| {
+    err.traceback(py).map(|tb| {
         tb.format()
             .unwrap_or_else(|_| "Unable to print traceback".to_string())
     })

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -18,7 +18,9 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::exceptions::PyStopIteration;
 use pyo3::exceptions::PyTypeError;
 use pyo3::intern;
+use pyo3::IntoPyObject;
 use pyo3::prelude::*;
+use pyo3::prelude::PyAnyMethods;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::Capability;
@@ -49,8 +51,9 @@ const DEFAULT_COOLDOWN: TimeDelta = TimeDelta::microseconds(1000);
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct EpochInterval(TimeDelta);
 
-impl<'py> FromPyObject<'py> for EpochInterval {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for EpochInterval {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         if let Ok(duration) = ob.extract::<TimeDelta>() {
             Ok(Self(duration))
         } else {
@@ -108,38 +111,37 @@ create_exception!(
 pub(crate) struct Source(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for Source {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Source {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let abc = py.import_bound("bytewax.inputs")?.getattr("Source")?;
+        let abc = py.import("bytewax.inputs")?.getattr("Source")?;
         if !ob.is_instance(&abc)? {
             Err(PyTypeError::new_err(
                 "source must subclass `bytewax.inputs.Source`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }
 
-impl IntoPy<Py<PyAny>> for Source {
-    fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
-        self.0
-    }
-}
+impl<'py> IntoPyObject<'py> for Source {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
 
-impl ToPyObject for Source {
-    fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.0.to_object(py)
+    fn into_pyobject(self, py: Python<'py>) -> PyResult<Self::Output> {
+        Ok(self.0.into_bound(py))
     }
 }
 
 impl Source {
     pub(crate) fn extract<'p, D>(&'p self, py: Python<'p>) -> PyResult<D>
     where
-        D: FromPyObject<'p>,
+        D: for<'a> FromPyObject<'a, 'p>,
     {
-        self.0.extract(py)
+        self.0.extract(py).map_err(Into::into)
     }
 }
 
@@ -148,18 +150,19 @@ impl Source {
 pub(crate) struct FixedPartitionedSource(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for FixedPartitionedSource {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for FixedPartitionedSource {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.inputs")?
+            .import("bytewax.inputs")?
             .getattr("FixedPartitionedSource")?;
         if !ob.is_instance(&abc)? {
             Err(PyTypeError::new_err(
                 "fixed partitioned source must subclass `bytewax.inputs.FixedPartitionedSource`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }
@@ -560,18 +563,19 @@ impl FixedPartitionedSource {
 struct StatefulPartition(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for StatefulPartition {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for StatefulPartition {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.inputs")?
+            .import("bytewax.inputs")?
             .getattr("StatefulSourcePartition")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
                 "stateful source partition must subclass `bytewax.inputs.StatefulSourcePartition`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }
@@ -589,14 +593,14 @@ impl StatefulPartition {
             Err(err) if err.is_instance_of::<AbortExecution>(py) => Ok(BatchResult::Abort),
             Err(err) => Err(err),
             Ok(obj) => {
-                let iter = obj.iter().reraise_with(|| {
+                let iter = obj.try_iter().reraise_with(|| {
                     format!(
                         "`next_batch` must return an iterable; got a `{}` instead",
                         unwrap_any!(obj.get_type().name()),
                     )
                 })?;
                 let batch = iter
-                    .map(|res| res.map(PyObject::from))
+                    .map(|res| res.map(|item| PyObject::from(item.unbind())))
                     .collect::<PyResult<Vec<_>>>()
                     .reraise("error while iterating through batch")?;
                 Ok(BatchResult::Batch(batch))
@@ -633,18 +637,19 @@ impl Drop for StatefulPartition {
 pub(crate) struct DynamicSource(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for DynamicSource {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for DynamicSource {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.inputs")?
+            .import("bytewax.inputs")?
             .getattr("DynamicSource")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
                 "dynamic source must subclass `bytewax.inputs.DynamicSource`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }
@@ -845,18 +850,19 @@ impl DynamicSource {
 struct StatelessPartition(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for StatelessPartition {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for StatelessPartition {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.inputs")?
+            .import("bytewax.inputs")?
             .getattr("StatelessSourcePartition")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
                 "stateless source partition must subclass `bytewax.inputs.StatelessSourcePartition`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }
@@ -868,14 +874,14 @@ impl StatelessPartition {
             Err(err) if err.is_instance_of::<AbortExecution>(py) => Ok(BatchResult::Abort),
             Err(err) => Err(err),
             Ok(obj) => {
-                let iter = obj.iter().reraise_with(|| {
+                let iter = obj.try_iter().reraise_with(|| {
                     format!(
                         "`next_batch` must return an iterable; got a `{}` instead",
                         unwrap_any!(obj.get_type().name()),
                     )
                 })?;
                 let batch = iter
-                    .map(|res| res.map(PyObject::from))
+                    .map(|res| res.map(|item| PyObject::from(item.unbind())))
                     .collect::<PyResult<Vec<_>>>()
                     .reraise("error while iterating through batch")?;
                 Ok(BatchResult::Batch(batch))
@@ -904,6 +910,6 @@ impl Drop for StatelessPartition {
 }
 
 pub(crate) fn register(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add("AbortExecution", py.get_type_bound::<AbortExecution>())?;
+    m.add("AbortExecution", py.get_type::<AbortExecution>())?;
     Ok(())
 }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -10,7 +10,9 @@ use chrono::Utc;
 use opentelemetry::KeyValue;
 use pyo3::exceptions::PyTypeError;
 use pyo3::intern;
+use pyo3::IntoPyObject;
 use pyo3::prelude::*;
+use pyo3::prelude::PyAnyMethods;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::Concatenate;
@@ -105,7 +107,7 @@ fn next_batch(
     in_batch: Vec<PyObject>,
 ) -> PyResult<()> {
     let res = mapper.call1((in_batch,)).reraise("error calling mapper")?;
-    let iter = res.iter().reraise_with(|| {
+    let iter = res.try_iter().reraise_with(|| {
         format!(
             "mapper must return an iterable; got a `{}` instead",
             unwrap_any!(res.get_type().name()),
@@ -242,7 +244,7 @@ where
 impl<S> InspectDebugOp<S> for Stream<S, TdPyAny>
 where
     S: Scope,
-    S::Timestamp: IntoPy<PyObject> + TotalOrder,
+    S::Timestamp: for<'py> IntoPyObject<'py> + TotalOrder,
 {
     fn inspect_debug(
         &self,
@@ -390,19 +392,13 @@ where
                         unwrap_any!(|| -> PyResult<()> {
                             for item in inbuf.drain(..) {
                                 let item = PyObject::from(item);
-                                let (key, value) = item
-                                    .extract::<(&PyAny, PyObject)>(py)
+                                let (key, value): (StateKey, PyObject) = item
+                                    .extract::<(StateKey, PyObject)>(py)
                                     .raise_with::<PyTypeError>(|| {
                                         format!("step {for_step_id} requires `(key, value)` 2-tuple from upstream for routing; got a `{}` instead",
                                             unwrap_any!(item.bind(py).get_type().name()),
                                         )
                                     })?;
-
-                                let key = key.extract::<StateKey>().raise_with::<PyTypeError>(|| {
-                                    format!("step {for_step_id} requires `str` keys in `(key, value)` from upstream; got a `{}` instead",
-                                        unwrap_any!(key.get_type().name()),
-                                    )
-                                })?;
                                 downstream_session.give((key, TdPyAny::from(value)));
                             }
                             Ok(())
@@ -430,7 +426,12 @@ where
         self.map(move |(key, value)| {
             let value = PyObject::from(value);
 
-            let item = Python::with_gil(|py| IntoPy::<PyObject>::into_py((key, value), py));
+            let item = Python::with_gil(|py| {
+                (key, value)
+                    .into_pyobject(py)
+                    .map(|obj| obj.unbind().into_any())
+                    .expect("tuple conversion to Python should not fail")
+            });
 
             TdPyAny::from(item)
         })
@@ -454,18 +455,19 @@ where
 struct StatefulBatchLogic(PyObject);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for StatefulBatchLogic {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for StatefulBatchLogic {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.operators")?
+            .import("bytewax.operators")?
             .getattr("StatefulBatchLogic")?;
         if !ob.is_instance(&abc)? {
             Err(PyTypeError::new_err(
                 "logic must subclass `bytewax.operators.StatefulBatchLogic`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }
@@ -475,8 +477,9 @@ enum IsComplete {
     Discard,
 }
 
-impl<'py> FromPyObject<'py> for IsComplete {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for IsComplete {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         if ob.extract::<bool>().reraise_with(|| {
             format!(
                 "`is_complete` was not a `bool`; got a `{}` instead",
@@ -492,17 +495,11 @@ impl<'py> FromPyObject<'py> for IsComplete {
 
 impl StatefulBatchLogic {
     fn extract_ret(res: Bound<'_, PyAny>) -> PyResult<(Vec<PyObject>, IsComplete)> {
-        let (iter, is_complete) = res.extract::<(&PyAny, &PyAny)>().reraise_with(|| {
+        let (emit, is_complete): (Vec<PyObject>, IsComplete) =
+            res.extract::<(Vec<PyObject>, IsComplete)>().reraise_with(|| {
             format!(
                 "did not return a 2-tuple of `(emit, is_complete)`; got a `{}` instead",
                 unwrap_any!(res.get_type().name())
-            )
-        })?;
-        let is_complete = is_complete.extract::<IsComplete>()?;
-        let emit = iter.extract::<Vec<_>>().reraise_with(|| {
-            format!(
-                "`emit` was not a `list`; got a `{}` instead",
-                unwrap_any!(iter.get_type().name())
             )
         })?;
 
@@ -533,7 +530,7 @@ impl StatefulBatchLogic {
 
     fn notify_at(&self, py: Python) -> PyResult<Option<DateTime<Utc>>> {
         let res = self.0.bind(py).call_method0(intern!(py, "notify_at"))?;
-        res.extract().reraise_with(|| {
+        res.extract::<Option<DateTime<Utc>>>().reraise_with(|| {
             format!(
                 "did not return a `datetime`; got a `{}` instead",
                 unwrap_any!(res.get_type().name())

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -7,9 +7,11 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
 use opentelemetry::KeyValue;
+use pyo3::IntoPyObject;
 use pyo3::exceptions::PyTypeError;
 use pyo3::intern;
 use pyo3::prelude::*;
+use pyo3::prelude::PyAnyMethods;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::Map;
@@ -33,38 +35,37 @@ use crate::with_timer;
 pub(crate) struct Sink(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for Sink {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Sink {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let abc = py.import_bound("bytewax.outputs")?.getattr("Sink")?;
+        let abc = py.import("bytewax.outputs")?.getattr("Sink")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
                 "sink must subclass `bytewax.outputs.Sink`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }
 
-impl IntoPy<Py<PyAny>> for Sink {
-    fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
-        self.0
-    }
-}
+impl<'py> IntoPyObject<'py> for Sink {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
 
-impl ToPyObject for Sink {
-    fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.0.to_object(py)
+    fn into_pyobject(self, py: Python<'py>) -> PyResult<Self::Output> {
+        Ok(self.0.into_bound(py))
     }
 }
 
 impl Sink {
     pub(crate) fn extract<'p, D>(&'p self, py: Python<'p>) -> PyResult<D>
     where
-        D: FromPyObject<'p>,
+        D: for<'a> FromPyObject<'a, 'p>,
     {
-        self.0.extract(py)
+        self.0.extract(py).map_err(Into::into)
     }
 }
 
@@ -73,18 +74,19 @@ impl Sink {
 pub(crate) struct FixedPartitionedSink(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for FixedPartitionedSink {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for FixedPartitionedSink {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.outputs")?
+            .import("bytewax.outputs")?
             .getattr("FixedPartitionedSink")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
                 "fixed partitioned sink must subclass `bytewax.outputs.FixedPartitionedSink`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }
@@ -121,18 +123,19 @@ impl FixedPartitionedSink {
 struct StatefulPartition(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for StatefulPartition {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for StatefulPartition {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.outputs")?
+            .import("bytewax.outputs")?
             .getattr("StatefulSinkPartition")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
                 "stateful sink partition must subclass `bytewax.outputs.StatefulSinkPartition`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }
@@ -415,16 +418,17 @@ where
 pub(crate) struct DynamicSink(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for DynamicSink {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for DynamicSink {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let abc = py.import_bound("bytewax.outputs")?.getattr("DynamicSink")?;
+        let abc = py.import("bytewax.outputs")?.getattr("DynamicSink")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
                 "dynamic sink must subclass `bytewax.outputs.DynamicSink`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }
@@ -447,18 +451,19 @@ impl DynamicSink {
 struct StatelessPartition(Py<PyAny>);
 
 /// Do some eager type checking.
-impl<'py> FromPyObject<'py> for StatelessPartition {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for StatelessPartition {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let abc = py
-            .import_bound("bytewax.outputs")?
+            .import("bytewax.outputs")?
             .getattr("StatelessSinkPartition")?;
         if !ob.is_instance(&abc)? {
             Err(tracked_err::<PyTypeError>(
                 "stateless sink partition must subclass `bytewax.outputs.StatelessSinkPartition`",
             ))
         } else {
-            Ok(Self(ob.to_object(py)))
+            Ok(Self(ob.to_owned().unbind()))
         }
     }
 }

--- a/src/pyo3_extensions.rs
+++ b/src/pyo3_extensions.rs
@@ -8,6 +8,7 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::sync::GILOnceCell;
 use pyo3::types::PyBytes;
+use pyo3::prelude::PyAnyMethods;
 use serde::ser::Error;
 use std::fmt;
 
@@ -90,7 +91,7 @@ impl serde::Serialize for TdPyAny {
             let x = self.bind(py);
             let pickle = PICKLE_MODULE
                 .get_or_try_init(py, || -> PyResult<Py<PyModule>> {
-                    Ok(py.import_bound("pickle")?.unbind())
+                    Ok(py.import("pickle")?.unbind())
                 })
                 .map_err(S::Error::custom)?;
             let binding = pickle
@@ -119,7 +120,7 @@ impl<'de> serde::de::Visitor<'de> for PickleVisitor {
         E: serde::de::Error,
     {
         let x: Result<TdPyAny, PyErr> = Python::with_gil(|py| {
-            let pickle = py.import_bound("pickle")?;
+            let pickle = py.import("pickle")?;
             let x = pickle
                 .call_method1(intern!(py, "loads"), (bytes,))?
                 .unbind()
@@ -146,10 +147,7 @@ impl PartialEq for TdPyAny {
             // pointer identity.
             let self_ = self.bind(py);
             let other = other.bind(py);
-            try_unwrap!(self_
-                .rich_compare(other, CompareOp::Eq)?
-                .as_gil_ref()
-                .is_truthy())
+            try_unwrap!(self_.rich_compare(other, CompareOp::Eq)?.is_truthy())
         })
     }
 }
@@ -162,8 +160,9 @@ pub(crate) struct TdPyCallable(PyObject);
 
 /// Have PyO3 do type checking to ensure we only make from callable
 /// objects.
-impl<'py> FromPyObject<'py> for TdPyCallable {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for TdPyCallable {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         if ob.is_callable() {
             let py = ob.py();
             Ok(Self(ob.as_unbound().clone_ref(py)))

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -23,9 +23,10 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::exceptions::PyTypeError;
 use pyo3::exceptions::PyValueError;
 use pyo3::intern;
+use pyo3::IntoPyObject;
 use pyo3::prelude::*;
 use pyo3::sync::GILOnceCell;
-use pyo3::types::PyBytes;
+use pyo3::types::{PyBytes, PyDelta, PyString};
 use rusqlite::Connection;
 use rusqlite::OpenFlags;
 use rusqlite_migration::Migrations;
@@ -161,14 +162,19 @@ impl Default for BackupInterval {
     }
 }
 
-impl IntoPy<Py<PyAny>> for BackupInterval {
-    fn into_py(self, py: Python<'_>) -> Py<PyAny> {
-        self.0.into_py(py)
+impl<'py> IntoPyObject<'py> for BackupInterval {
+    type Target = PyDelta;
+    type Output = Bound<'py, PyDelta>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> PyResult<Self::Output> {
+        Ok(self.0.into_pyobject(py)?)
     }
 }
 
-impl<'py> FromPyObject<'py> for BackupInterval {
-    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for BackupInterval {
+    type Error = PyErr;
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         if let Ok(duration) = obj.extract::<TimeDelta>() {
             Ok(Self(duration))
         } else {
@@ -205,15 +211,13 @@ impl Default for ResumeFrom {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, FromPyObject)]
 pub(crate) struct StepId(pub(crate) String);
 
-impl IntoPy<Py<PyAny>> for StepId {
-    fn into_py(self, py: Python<'_>) -> Py<PyAny> {
-        self.0.into_py(py)
-    }
-}
+impl<'py> IntoPyObject<'py> for StepId {
+    type Target = PyString;
+    type Output = Bound<'py, PyString>;
+    type Error = PyErr;
 
-impl ToPyObject for StepId {
-    fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.0.to_object(py)
+    fn into_pyobject(self, py: Python<'py>) -> PyResult<Self::Output> {
+        Ok(self.0.into_pyobject(py)?)
     }
 }
 
@@ -241,9 +245,13 @@ impl std::fmt::Display for StepId {
 )]
 pub(crate) struct StateKey(pub(crate) String);
 
-impl IntoPy<Py<PyAny>> for StateKey {
-    fn into_py(self, py: Python<'_>) -> Py<PyAny> {
-        self.0.into_py(py)
+impl<'py> IntoPyObject<'py> for StateKey {
+    type Target = PyString;
+    type Output = Bound<'py, PyString>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> PyResult<Self::Output> {
+        Ok(self.0.into_pyobject(py)?)
     }
 }
 
@@ -1525,7 +1533,7 @@ where
         // Effectively map-with-epoch.
         self.unary(Pipeline, "ser_snap", move |_init_cap, _info| {
             let mut inbuf = Vec::new();
-            let pickle = Python::with_gil(|py| unwrap_any!(py.import_bound("pickle")).unbind());
+            let pickle = Python::with_gil(|py| unwrap_any!(py.import("pickle")).unbind());
 
             move |snaps_input, ser_snaps_output| {
                 snaps_input.for_each(|cap, incoming| {
@@ -1594,11 +1602,11 @@ where
                 let snap_change = match ser_change {
                     Some(ser_snap) => {
                         let snap = unwrap_any!(Python::with_gil(|py| -> PyResult<PyObject> {
-                            let pickle = py.import_bound("pickle")?;
+                            let pickle = py.import("pickle")?;
                             Ok(pickle
                                 .call_method1(
                                     intern!(py, "loads"),
-                                    (PyBytes::new_bound(py, &ser_snap),),
+                                    (PyBytes::new(py, &ser_snap),),
                                 )?
                                 .unbind())
                         }));
@@ -1937,15 +1945,15 @@ pub(crate) fn register(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<RecoveryConfig>()?;
     m.add(
         "InconsistentPartitionsError",
-        py.get_type_bound::<InconsistentPartitionsError>(),
+        py.get_type::<InconsistentPartitionsError>(),
     )?;
     m.add(
         "MissingPartitionsError",
-        py.get_type_bound::<MissingPartitionsError>(),
+        py.get_type::<MissingPartitionsError>(),
     )?;
     m.add(
         "NoPartitionsError",
-        py.get_type_bound::<NoPartitionsError>(),
+        py.get_type::<NoPartitionsError>(),
     )?;
     Ok(())
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -41,7 +41,7 @@ fn start_server_runtime(df: Dataflow) -> PyResult<Runtime> {
     // Since the dataflow can't change at runtime, we encode it as a
     // string of JSON once, when the webserver starts.
     let dataflow_json: String = Python::with_gil(|py| -> PyResult<String> {
-        let vis_mod = PyModule::import_bound(py, "bytewax.visualize")?;
+        let vis_mod = PyModule::import(py, "bytewax.visualize")?;
         let to_json = vis_mod.getattr("to_json")?;
 
         let dataflow_json = to_json
@@ -152,8 +152,8 @@ pub(crate) fn run_main(
         if let Some(err) = panic_err.downcast_ref::<PyErr>() {
             // Special case for keyboard interrupt.
             if err
-                .get_type_bound(py)
-                .is(&PyType::new_bound::<PyKeyboardInterrupt>(py))
+                .get_type(py)
+                .is(&PyType::new::<PyKeyboardInterrupt>(py))
             {
                 tracked_err::<PyKeyboardInterrupt>(
                     "interrupt signal received, all processes have been shut down",

--- a/src/webserver/mod.rs
+++ b/src/webserver/mod.rs
@@ -53,7 +53,7 @@ async fn get_dataflow(Extension(state): Extension<Arc<State>>) -> impl IntoRespo
 
 async fn get_metrics() -> impl IntoResponse {
     let py_metrics: String = Python::with_gil(|py| -> PyResult<String> {
-        let metrics_mod = PyModule::import_bound(py, "bytewax._metrics")?;
+        let metrics_mod = PyModule::import(py, "bytewax._metrics")?;
         let metrics = metrics_mod
             .getattr("generate_python_metrics")?
             .call0()?


### PR DESCRIPTION
- Bump bytewax version to 0.22.0 and update pyo3 to 0.27.1 in dependencies
- Refresh locked transitive crates including syn, proc macro2, heck, once_cell and target lexicon
- Rework Docker build to use Python 3.14, install Rust via rustup, and emit only the wheel artefact
- Update Rust bindings for the new pyo3 API with Borrowed extraction and IntoPyObject conversions
- Adjust Python interop helpers and imports to the current pyo3 methods and types